### PR TITLE
Removed incorrect info

### DIFF
--- a/docs/_pages/syntax.md
+++ b/docs/_pages/syntax.md
@@ -21,7 +21,7 @@ local function tree_insert(tree, x)
 end
 ```
 
-Note that future versions of Lua extend the Lua 5.1 syntax with the following features; these are **not** supported by Luau with the exception of the string literals:
+Note that future versions of Lua extend the Lua 5.1 syntax with the following features; Luau does support string literal extensions but does not support other features from this list:
 
 - hexadecimal (`\x`), Unicode (`\u`) and `\z` escapes for string literals
 - goto statements and labels

--- a/docs/_pages/syntax.md
+++ b/docs/_pages/syntax.md
@@ -21,7 +21,7 @@ local function tree_insert(tree, x)
 end
 ```
 
-Note that future versions of Lua extend the Lua 5.1 syntax with the following features; these are **not** supported by Luau with the exception of the string literals:
+Note that future versions of Lua extend the Lua 5.1 syntax with the following features; the following are **not** supported by Luau with the exception of the string literals:
 
 - hexadecimal (`\x`), Unicode (`\u`) and `\z` escapes for string literals
 - goto statements and labels

--- a/docs/_pages/syntax.md
+++ b/docs/_pages/syntax.md
@@ -21,8 +21,9 @@ local function tree_insert(tree, x)
 end
 ```
 
-Note that future versions of Lua extend the Lua 5.1 syntax with the following features; with the exception of the string literals, these are **not** supported by Luau:
+Note that future versions of Lua extend the Lua 5.1 syntax with the following features; these are **not** supported by Luau with the exception of the string literals:
 
+- hexadecimal (`\x`), Unicode (`\u`) and `\z` escapes for string literals
 - goto statements and labels
 - bitwise operators
 - floor division operator (`//`)

--- a/docs/_pages/syntax.md
+++ b/docs/_pages/syntax.md
@@ -21,7 +21,7 @@ local function tree_insert(tree, x)
 end
 ```
 
-Note that future versions of Lua extend the Lua 5.1 syntax with the following features; the following are **not** supported by Luau with the exception of the string literals:
+Note that future versions of Lua extend the Lua 5.1 syntax with the following features; these are **not** supported by Luau with the exception of the string literals:
 
 - hexadecimal (`\x`), Unicode (`\u`) and `\z` escapes for string literals
 - goto statements and labels

--- a/docs/_pages/syntax.md
+++ b/docs/_pages/syntax.md
@@ -23,7 +23,6 @@ end
 
 Note that future versions of Lua extend the Lua 5.1 syntax with the following features; with the exception of the string literals, these are **not** supported by Luau:
 
-- hexadecimal (`\x`), Unicode (`\u`) and `\z` escapes for string literals
 - goto statements and labels
 - bitwise operators
 - floor division operator (`//`)


### PR DESCRIPTION
The manual says Luau does not support hexadecimal \0x, Unicode \u and \z
when this clearly isn't the case.
This is also quite confusing as just a bit below it says it does support them.