### PR TITLE
Less ambiguity to what 'SECRET TOOL' is?

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -53,7 +53,7 @@ feature_row3:
   - 
     title: Analysis
     excerpt: >
-        To make it easier to write correct code, Luau comes with a set of analysis tools that can surface common mistakes. These consist of a linter and a type checker, colloquially known as script analysis, and can be used from [Roblox Studio](https://developer.roblox.com/en-us/articles/The-Script-Analysis-Tool) or using SECRET TOOL. The linting passes are [described here](lint), and the type checking user guide can [be found here](typecheck).
+        To make it easier to write correct code, Luau comes with a set of analysis tools that can surface common mistakes. These consist of a linter and a type checker, colloquially known as script analysis, and can be used from [Roblox Studio](https://developer.roblox.com/en-us/articles/The-Script-Analysis-Tool) or from the (currently internal-only) CLI version of Roblox. The linting passes are [described here](lint), and the type checking user guide can [be found here](typecheck).
     url: /typecheck
     btn_label: Learn More
     btn_class: "btn--primary"

--- a/docs/index.md
+++ b/docs/index.md
@@ -53,7 +53,7 @@ feature_row3:
   - 
     title: Analysis
     excerpt: >
-        To make it easier to write correct code, Luau comes with a set of analysis tools that can surface common mistakes. These consist of a linter and a type checker, colloquially known as script analysis, and can be used from [Roblox Studio](https://developer.roblox.com/en-us/articles/The-Script-Analysis-Tool) or the (currently internal-only) command-line interface version of Roblox Studio. The linting passes are [described here](lint), and the type checking user guide can [be found here](typecheck).
+        To make it easier to write correct code, Luau comes with a set of analysis tools that can surface common mistakes. These consist of a linter and a type checker, colloquially known as script analysis, and can be used from [Roblox Studio](https://developer.roblox.com/en-us/articles/The-Script-Analysis-Tool). The linting passes are [described here](lint), and the type checking user guide can [be found here](typecheck).
     url: /typecheck
     btn_label: Learn More
     btn_class: "btn--primary"

--- a/docs/index.md
+++ b/docs/index.md
@@ -53,7 +53,7 @@ feature_row3:
   - 
     title: Analysis
     excerpt: >
-        To make it easier to write correct code, Luau comes with a set of analysis tools that can surface common mistakes. These consist of a linter and a type checker, colloquially known as script analysis, and can be used from [Roblox Studio](https://developer.roblox.com/en-us/articles/The-Script-Analysis-Tool) or from the (currently internal-only) CLI version of Roblox. The linting passes are [described here](lint), and the type checking user guide can [be found here](typecheck).
+        To make it easier to write correct code, Luau comes with a set of analysis tools that can surface common mistakes. These consist of a linter and a type checker, colloquially known as script analysis, and can be used from [Roblox Studio](https://developer.roblox.com/en-us/articles/The-Script-Analysis-Tool) or the (currently internal-only) command-line interface version of Roblox Studio. The linting passes are [described here](lint), and the type checking user guide can [be found here](typecheck).
     url: /typecheck
     btn_label: Learn More
     btn_class: "btn--primary"


### PR DESCRIPTION
It seems this substitution has been overlooked, but it's present on the index page. I think it would be helpful to disclose what this actually is. Alternatively, the mention of `SECRET TOOL` can be removed entirely?