### PR TITLE
Add RFC status fields

### DIFF
--- a/rfcs/README.md
+++ b/rfcs/README.md
@@ -52,4 +52,4 @@ When an RFC gets merged, the feature *can* be implemented; however, there's no s
 
 To avoid having permanently stale RFCs, in rare cases Luau team can *remove* a previously merged RFC when the landscape is believed to change enough for a feature like this to warrant further discussion.
 
-To track progress of implemented features, it's advised to follow documentation instead; while RFCs aren't meant to be user-facing documentation, recaps in particular can reference RFCs for additional context behind the changes.
+When an RFC is implemented and the implementation is enabled via feature flags, RFC should be updated to include "**Status**: Implemented" at the top level (before *Summary* section).

--- a/rfcs/behavior-eq-metamethod.md
+++ b/rfcs/behavior-eq-metamethod.md
@@ -2,6 +2,8 @@
 
 > Note: this RFC was adapted from an internal proposal that predates RFC process
 
+**Status**: Implemented
+
 ## Summary
 
 `__eq` metamethod will always be called during `==`/`~=` comparison, even for objects that are rawequal.

--- a/rfcs/change-global-version.md
+++ b/rfcs/change-global-version.md
@@ -2,6 +2,8 @@
 
 > Note: this RFC was adapted from an internal proposal that predates RFC process
 
+**Status**: Implemented
+
 ## Summary
 
 Change \_VERSION global to "Luau" to differentiate Luau from Lua

--- a/rfcs/function-debug-info.md
+++ b/rfcs/function-debug-info.md
@@ -2,6 +2,8 @@
 
 > Note: this RFC was adapted from an internal proposal that predates RFC process
 
+**Status**: Implemented
+
 ## Summary
 
 Add `debug.info` as programmatic debug info access API, similarly to Lua's `debug.getinfo`

--- a/rfcs/function-string-pack-unpack.md
+++ b/rfcs/function-string-pack-unpack.md
@@ -2,6 +2,8 @@
 
 > Note: this RFC was adapted from an internal proposal that predates RFC process
 
+**Status**: Implemented
+
 ## Summary
 
 Add string pack/unpack from Lua 5.3 for binary interop, with small tweaks to format specification to make format strings portable.

--- a/rfcs/function-table-clear.md
+++ b/rfcs/function-table-clear.md
@@ -2,6 +2,8 @@
 
 > Note: this RFC was adapted from an internal proposal that predates RFC process and as such doesn't follow the template precisely
 
+**Status**: Implemented
+
 ## Summary
 
 Add `table.clear` function that removes all elements from the table but keeps internal capacity allocated.

--- a/rfcs/function-table-create-find.md
+++ b/rfcs/function-table-create-find.md
@@ -2,6 +2,8 @@
 
 > Note: this RFC was adapted from an internal proposal that predates RFC process and as such doesn't follow the template precisely
 
+**Status**: Implemented
+
 ## Design
 
 This proposal suggests adding two new builtin table functions:

--- a/rfcs/syntax-array-like-table-types.md
+++ b/rfcs/syntax-array-like-table-types.md
@@ -2,6 +2,8 @@
 
 > Note: this RFC was adapted from an internal proposal that predates RFC process
 
+**Status**: Implemented
+
 ## Summary
 
 Add special syntax for array-like table types, `{ T }`

--- a/rfcs/syntax-compound-assignment.md
+++ b/rfcs/syntax-compound-assignment.md
@@ -2,6 +2,8 @@
 
 > Note: this RFC was adapted from an internal proposal that predates RFC process and as such doesn't follow the template precisely
 
+**Status**: Implemented
+
 ## Design
 
 A feature present in many many programming languages is assignment operators that perform operations on the left hand side, for example

--- a/rfcs/syntax-continue-statement.md
+++ b/rfcs/syntax-continue-statement.md
@@ -2,6 +2,8 @@
 
 > Note: this RFC was adapted from an internal proposal that predates RFC process
 
+**Status**: Implemented
+
 ## Summary
 
 Add `continue` statement to `for`, `while` and `repeat` loops using a context-sensitive keyword to preserve compatibility.

--- a/rfcs/syntax-number-literals.md
+++ b/rfcs/syntax-number-literals.md
@@ -2,6 +2,8 @@
 
 > Note: this RFC was adapted from an internal proposal that predates RFC process and as such doesn't follow the template precisely
 
+**Status**: Implemented
+
 ## Design
 
 This proposal suggests extending Lua number syntax with:

--- a/rfcs/syntax-type-ascription.md
+++ b/rfcs/syntax-type-ascription.md
@@ -2,6 +2,8 @@
 
 > Note: this RFC was adapted from an internal proposal that predates RFC process
 
+**Status**: Implemented
+
 ## Summary
 
 Implement syntax for type ascriptions using `::`

--- a/rfcs/syntax-typed-variadics.md
+++ b/rfcs/syntax-typed-variadics.md
@@ -2,7 +2,7 @@
 
 > Note: this RFC was adapted from an internal proposal that predates RFC process
 
-Status: **Implemented**
+**Status**: Implemented
 
 ## Summary
 

--- a/rfcs/syntax-typed-variadics.md
+++ b/rfcs/syntax-typed-variadics.md
@@ -2,6 +2,8 @@
 
 > Note: this RFC was adapted from an internal proposal that predates RFC process
 
+Status: **Implemented**
+
 ## Summary
 
 Add syntax for ascribing a type to variadic pack (`...`).


### PR DESCRIPTION
It seems more consistent and unambiguous if we mark RFCs as being
implemented when the implementation lands instead of expecting to
cross-reference documentation. That also makes it easier for us to flag
stale RFCs.