### PR TITLE
Update compatibility.md

### DIFF
--- a/docs/_pages/compatibility.md
+++ b/docs/_pages/compatibility.md
@@ -26,7 +26,7 @@ Luau has certain limitations around the number of local variables, registers, up
 - Constants: 2^23 per function (up from 2^18 in Lua 5.1)
 - Instructions: 2^23 per function (up from 2^17 in Lua 5.1, although in both cases the limit only applies to control flow)
 - Nested functions: 2^15 per function (down from 2^18 in Lua 5.1)
-- Stack depth: 20000 Lua calls per Lua thread, 200 C calls per C thread (e.g. coroutine.resume nesting is limited to 200)
+- Stack depth: 20000 Lua calls per Lua thread, 200 C calls per C thread (e.g. `coroutine.resume`/`pcall` nesting is limited to 200)
 
 Note that Lua 5.3 has a larger upvalue limit (255) and a larger constant limit (2^26); existing Luau limits are likely sufficient for reasonable use cases.
 


### PR DESCRIPTION
Add a note about `pcall` - really the C limit is universal but it will most often be hit during either pcall or coroutine.resume.