### PR TITLE
Added syntax documentation for if expressions

### DIFF
--- a/docs/_pages/syntax.md
+++ b/docs/_pages/syntax.md
@@ -189,7 +189,7 @@ For more information please refer to [typechecking documentation](typecheck).
 
 ## If-then-else expressions
 
-In addition to supporting standard if *statements*, luau has added support for if *expressions*.  Syntactically, `if-then-else` expressions look very similar to if statements.  However instead of conditionally executing blocks of code, if expressions conditionally evaluate expressions and return the value produced as a result. Also, unlike if statements, if expressions do not terminate with the `end` keyword.
+In addition to supporting standard if *statements*, Luau adds support for if *expressions*.  Syntactically, `if-then-else` expressions look very similar to if statements.  However instead of conditionally executing blocks of code, if expressions conditionally evaluate expressions and return the value produced as a result. Also, unlike if statements, if expressions do not terminate with the `end` keyword.
 
 Here is a simple example of an `if-then-else` expression:
 ```lua


### PR DESCRIPTION
Added documentation to "syntax.md" to describe the new `if-then-else` expressions.  Mostly it covers the syntax, how they differ from if statements and why they are preferred to the previously used idiom in Lua.