### PR TITLE
Fix modulo operation and math.min/math.max bugs for edge cases

### DIFF
--- a/Compiler/src/Compiler.cpp
+++ b/Compiler/src/Compiler.cpp
@@ -2966,7 +2966,14 @@ struct Compiler
                 if (la.type == Constant::Type_Number && ra.type == Constant::Type_Number)
                 {
                     result.type = Constant::Type_Number;
-                    result.valueNumber = la.valueNumber - floor(la.valueNumber / ra.valueNumber) * ra.valueNumber;
+		    double r = fmod(la.valueNumber, ra.valueNumber);
+
+		    if (r == 0.0)
+		        r = ra.valueNumber < 0.0 ? -0.0 : 0.0;
+		    else if ((r < 0) != (ra.valueNumber < 0))
+			r += ra.valueNumber;
+
+		    result.valueNumber = r;
                 }
                 break;
 

--- a/VM/src/lbuiltins.cpp
+++ b/VM/src/lbuiltins.cpp
@@ -266,6 +266,9 @@ static int luauF_max(lua_State* L, StkId res, TValue* arg0, int nresults, StkId 
     {
         double r = nvalue(arg0);
 
+        if (r != r)
+            return -1;
+
         for (int i = 2; i <= nparams; ++i)
         {
             if (!ttisnumber(args + (i - 2)))
@@ -273,7 +276,13 @@ static int luauF_max(lua_State* L, StkId res, TValue* arg0, int nresults, StkId 
 
             double a = nvalue(args + (i - 2));
 
-            r = (a > r) ? a : r;
+	    if (a != a)
+                return -1;
+
+            if (a == 0.0 && r == 0.0)
+                r = 1.0 / a < 0 && 1.0 / r < 0.0 ? -0.0 : 0.0;
+            else
+                r = (a > r) ? a : r;
         }
 
         setnvalue(res, r);
@@ -289,6 +298,9 @@ static int luauF_min(lua_State* L, StkId res, TValue* arg0, int nresults, StkId 
     {
         double r = nvalue(arg0);
 
+        if (r != r)
+            return -1;
+
         for (int i = 2; i <= nparams; ++i)
         {
             if (!ttisnumber(args + (i - 2)))
@@ -296,7 +308,13 @@ static int luauF_min(lua_State* L, StkId res, TValue* arg0, int nresults, StkId 
 
             double a = nvalue(args + (i - 2));
 
-            r = (a < r) ? a : r;
+            if (a != a)
+                return -1;
+
+            if (a == 0.0 && r == 0.0)
+                r = 1.0 / a > 0.0 && 1.0 / r > 0.0 ? 0.0 : -0.0;
+            else
+                r = (a < r) ? a : r;
         }
 
         setnvalue(res, r);

--- a/VM/src/lmathlib.cpp
+++ b/VM/src/lmathlib.cpp
@@ -200,9 +200,7 @@ static int math_min(lua_State* L)
     int i;
     for (i = 2; i <= n; i++)
     {
-        double d = luaL_checknumber(L, i);
-        if (d < dmin)
-            dmin = d;
+        dmin = fmin(luaL_checknumber(L, i), dmin);
     }
     lua_pushnumber(L, dmin);
     return 1;
@@ -215,9 +213,7 @@ static int math_max(lua_State* L)
     int i;
     for (i = 2; i <= n; i++)
     {
-        double d = luaL_checknumber(L, i);
-        if (d > dmax)
-            dmax = d;
+        dmax = fmax(luaL_checknumber(L, i), dmax);
     }
     lua_pushnumber(L, dmax);
     return 1;

--- a/VM/src/lnumutils.h
+++ b/VM/src/lnumutils.h
@@ -29,7 +29,18 @@ inline bool luai_vecisnan(const float* a)
 LUAU_FASTMATH_BEGIN
 inline double luai_nummod(double a, double b)
 {
-    return a - floor(a / b) * b;
+    // The old definition "a - floor(a / b) * b" is flawed:
+    // * If 'b' is math.huge, the result should be 'a' but it results in NaN
+    // * If 'a / b' results in (+/-)Infinity, it results in (+/-)Infinity depending on the sign of 'a' when it shouldn't be
+    double r = fmod(a, b);
+
+    // Ensure the result is the same sign as the divisor
+    if (r == 0.0)
+        r = b < 0.0 ? -0.0 : 0.0;
+    else if ((r < 0.0) != (b < 0.0))
+        r += b;
+
+    return r;
 }
 LUAU_FASTMATH_END
 


### PR DESCRIPTION
This is a patch for `%` operator, `math.min`, and `math.max` bugs for edge cases:
- It patches the bug where the `%` operator returns NaN if the denominator is infinite when it should've returned the numerator.
- It patches the `math.min` and `math.max` bug where `0` and `-0` entered as its operands results in a non-commutative result.