### PR TITLE
Fix HATRA '21 README.md formatting

### DIFF
--- a/papers/hatra21/README.md
+++ b/papers/hatra21/README.md
@@ -27,10 +27,10 @@ sudo tlmgr install preprint
 sudo tlmgr install libertine
 sudo tlmgr install inconsolata
 sudo tlmgr install newtx
-sudo tlmgr install latexmk`
+sudo tlmgr install latexmk
 sudo tlmgr install montserrat
 sudo tlmgr install ly1
-``
+```
 
 ## Building the paper
 


### PR DESCRIPTION
A misplaced backtick was causing the last two codeblocks to display incorrectly.