### PR TITLE
Fix unused variable treatment

### DIFF
--- a/Ast/src/Parser.cpp
+++ b/Ast/src/Parser.cpp
@@ -2379,15 +2379,12 @@ AstArray<AstTypeOrPack> Parser::parseTypeParams()
         Lexeme begin = lexer.current();
         nextLexeme();
 
-        bool seenPack = false;
         while (true)
         {
             if (FFlag::LuauParseTypePackTypeParameters)
             {
                 if (shouldParseTypePackAnnotation(lexer))
                 {
-                    seenPack = true;
-
                     auto typePack = parseTypePackAnnotation();
 
                     if (FFlag::LuauTypeAliasPacks) // Type packs are recorded only is we can handle them
@@ -2399,8 +2396,6 @@ AstArray<AstTypeOrPack> Parser::parseTypeParams()
 
                     if (typePack)
                     {
-                        seenPack = true;
-
                         if (FFlag::LuauTypeAliasPacks) // Type packs are recorded only is we can handle them
                             parameters.push_back({{}, typePack});
                     }

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,10 @@ OBJECTS=$(AST_OBJECTS) $(COMPILER_OBJECTS) $(ANALYSIS_OBJECTS) $(VM_OBJECTS) $(T
 CXXFLAGS=-g -Wall -Werror
 LDFLAGS=
 
-CXXFLAGS+=-Wno-unused # temporary, for older gcc versions
+# temporary, for older gcc versions as they treat var in `if (type var = val)` as unused
+ifeq ($(findstring g++,$(shell $(CXX) --version)),g++)
+CXXFLAGS+=-Wno-unused
+endif
 
 # configuration-specific flags
 ifeq ($(config),release)

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ LDFLAGS=
 
 # temporary, for older gcc versions as they treat var in `if (type var = val)` as unused
 ifeq ($(findstring g++,$(shell $(CXX) --version)),g++)
-CXXFLAGS+=-Wno-unused
+	CXXFLAGS+=-Wno-unused
 endif
 
 # configuration-specific flags


### PR DESCRIPTION
Right now our CMake infra specifies -Wno-unused only for GCC builds, but Makefile specifies it for all builds.
The intent has been to use it just for GCC, so we now do that by detecting the compiler version - this should
equalize the behavior across different types of builds.

Separately, latest version of clang appears to expose an unused variable that clang-10 was okay with, so fix that.

Fixes #136 