### PR TITLE
Fix CLI analysis reporting wrong file names

### DIFF
--- a/CLI/Analyze.cpp
+++ b/CLI/Analyze.cpp
@@ -54,9 +54,7 @@ static bool analyzeFile(Luau::Frontend& frontend, const char* name, ReportFormat
     Luau::CheckResult cr;
 
     if (frontend.isDirty(name))
-    {
         cr = frontend.check(name);
-    }
 
     if (!frontend.getSourceModule(name))
     {

--- a/CLI/Analyze.cpp
+++ b/CLI/Analyze.cpp
@@ -51,7 +51,12 @@ static void reportWarning(ReportFormat format, const char* name, const Luau::Lin
 
 static bool analyzeFile(Luau::Frontend& frontend, const char* name, ReportFormat format, bool annotate)
 {
-    Luau::CheckResult cr = frontend.check(name);
+    Luau::CheckResult cr;
+
+    if (frontend.isDirty(name))
+    {
+        cr = frontend.check(name);
+    }
 
     if (!frontend.getSourceModule(name))
     {

--- a/CLI/Analyze.cpp
+++ b/CLI/Analyze.cpp
@@ -241,9 +241,9 @@ int main(int argc, char** argv)
         if (isDirectory(argv[i]))
         {
             traverseDirectory(argv[i], [&](const std::string& name) {
-                    if (name.length() > 4 && name.rfind(".lua") == name.length() - 4)
-                        failed += !analyzeFile(frontend, name.c_str(), format, annotate);
-                });
+                if (name.length() > 4 && name.rfind(".lua") == name.length() - 4)
+                    failed += !analyzeFile(frontend, name.c_str(), format, annotate);
+            });
         }
         else
         {

--- a/CLI/Analyze.cpp
+++ b/CLI/Analyze.cpp
@@ -34,8 +34,10 @@ static void report(ReportFormat format, const char* name, const Luau::Location& 
     }
 }
 
-static void reportError(ReportFormat format, const char* name, const Luau::TypeError& error)
+static void reportError(ReportFormat format, const Luau::TypeError& error)
 {
+    const char* name = error.moduleName.c_str();
+
     if (const Luau::SyntaxError* syntaxError = Luau::get_if<Luau::SyntaxError>(&error.data))
         report(format, name, error.location, "SyntaxError", syntaxError->message.c_str());
     else
@@ -58,7 +60,7 @@ static bool analyzeFile(Luau::Frontend& frontend, const char* name, ReportFormat
     }
 
     for (auto& error : cr.errors)
-        reportError(format, name, error);
+        reportError(format, error);
 
     Luau::LintResult lr = frontend.lint(name);
 
@@ -236,9 +238,9 @@ int main(int argc, char** argv)
         if (isDirectory(argv[i]))
         {
             traverseDirectory(argv[i], [&](const std::string& name) {
-                if (name.length() > 4 && name.rfind(".lua") == name.length() - 4)
-                    failed += !analyzeFile(frontend, name.c_str(), format, annotate);
-            });
+                    if (name.length() > 4 && name.rfind(".lua") == name.length() - 4)
+                        failed += !analyzeFile(frontend, name.c_str(), format, annotate);
+                });
         }
         else
         {


### PR DESCRIPTION
Fix #144

Regarding (https://github.com/Roblox/luau/issues/144#issuecomment-962295956):
> We should check frontend.isDirty(name) in analyzeFile before running type checking. This will automatically skip redundant checks for dependent modules when we encounter them again in recursive traversal

At about which point should this check happen? From my understanding `frontend.check(name)` does type checking, so should the function just exit early reporting no errors?

Additionally, `reportWarning` at a glance has the same undesirable behavior that `reportError` did, but I opted to wait and ask if this is intentional before changing it also.