### PR TITLE
Fixes linux typo in README.md "Linus" to "Linux"

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ cmake --build . --target Luau.Repl.CLI --config RelWithDebInfo
 cmake --build . --target Luau.Analyze.CLI --config RelWithDebInfo
 ```
 
-Alternatively, on Linus/macOS you can use make:
+Alternatively, on Linux/macOS you can use make:
 
 ```sh
 make config=release luau luau-analyze


### PR DESCRIPTION
This PR fixes the typo of "Linus" instead of "Linux" in README.md.