### PR TITLE
Change _VERSION to display version of luau in use

### DIFF
--- a/VM/src/lbaselib.cpp
+++ b/VM/src/lbaselib.cpp
@@ -449,7 +449,8 @@ LUALIB_API int luaopen_base(lua_State* L)
 
     /* open lib into global table */
     luaL_register(L, "_G", base_funcs);
-    lua_pushliteral(L, "Luau");
+    lua_pushliteral(L, "Luau 0.503"); /* set _VERSION to display the version of Luau currently in use */
+
     lua_setglobal(L, "_VERSION"); /* set global _VERSION */
 
     /* `ipairs' and `pairs' need auxiliary functions as upvalues */


### PR DESCRIPTION
this is just the commit for the issue I made with the same name #175 

please keep in mind this is my first time using C++ so it may not work but from running make test it seems fine
<img width="297" alt="Screenshot 2021-11-08 at 10 47 40" src="https://user-images.githubusercontent.com/68239467/140728881-c0727c71-5698-44f0-8282-d6cba394d810.png">

I mean it works which I didn't expect but yup

in the future it may be beneficial / convenient to store the version in like a Version.txt file but I obviously have no idea how to do that

this is such a minor change I don't expect it to cause any issues as its backwards compatible with any code expecting it to return Luau

and even better it follows Lua's format for _VERSION
<img width="85" alt="Screenshot 2021-11-08 at 10 51 10" src="https://user-images.githubusercontent.com/68239467/140729362-09d75b86-c8c7-4d81-953c-2a37c09a9a05.png">
