### PR TITLE
Fix lbuiltins.cpp comment

### DIFF
--- a/VM/src/lbuiltins.cpp
+++ b/VM/src/lbuiltins.cpp
@@ -20,7 +20,8 @@
 // If types of the arguments mismatch, luauF_* needs to return -1 and the execution will fall back to the usual call path
 // If luauF_* succeeds, it needs to return *all* requested arguments, filling results with nil as appropriate.
 // On input, nparams refers to the actual number of arguments (0+), whereas nresults contains LUA_MULTRET for arbitrary returns or 0+ for a
-// fixed-length return Because of this, and the fact that "extra" returned values will be ignored, implementations below typically check that nresults
+// fixed-length return
+// Because of this, and the fact that "extra" returned values will be ignored, implementations below typically check that nresults
 // is <= expected number, which covers the LUA_MULTRET case.
 
 static int luauF_assert(lua_State* L, StkId res, TValue* arg0, int nresults, StkId args, int nparams)

--- a/VM/src/lbuiltins.cpp
+++ b/VM/src/lbuiltins.cpp
@@ -21,8 +21,8 @@
 // If luauF_* succeeds, it needs to return *all* requested arguments, filling results with nil as appropriate.
 // On input, nparams refers to the actual number of arguments (0+), whereas nresults contains LUA_MULTRET for arbitrary returns or 0+ for a
 // fixed-length return
-// Because of this, and the fact that "extra" returned values will be ignored, implementations below typically check that nresults
-// is <= expected number, which covers the LUA_MULTRET case.
+// Because of this, and the fact that "extra" returned values will be ignored, implementations below typically check that nresults is <= expected
+// number, which covers the LUA_MULTRET case.
 
 static int luauF_assert(lua_State* L, StkId res, TValue* arg0, int nresults, StkId args, int nparams)
 {


### PR DESCRIPTION
My impression of the situation is that this comment was wrapped by automated formatting, so simply moving the wrapped content back to the end of the line will just cause it to get wrapped again. Instead, put a newline between the wrapped content and the next line.