### PR TITLE
Use uint8_t for lua_Type and TValue.tt

### DIFF
--- a/VM/include/lua.h
+++ b/VM/include/lua.h
@@ -58,7 +58,7 @@ typedef void* (*lua_Alloc)(lua_State* L, void* ud, void* ptr, size_t osize, size
  * grep "ORDER TYPE"
  */
 // clang-format off
-enum lua_Type
+enum lua_Type: uint8_t
 {
     LUA_TNIL = 0,     /* must be 0 due to lua_isnoneornil */
     LUA_TBOOLEAN = 1, /* must be 1 due to l_isfalse */

--- a/VM/src/lobject.h
+++ b/VM/src/lobject.h
@@ -48,7 +48,7 @@ typedef struct lua_TValue
 {
     Value value;
     int extra;
-    int tt;
+    uint8_t tt;
 } TValue;
 
 /* Macros to test type */


### PR DESCRIPTION
The type will probably still be 8-byte-aligned (due to `double`), so it'll probably still take up 16 bytes of space in arrays, but this will silence the compiler from yelling at me that `lua_Type` is unsigned and `TValue.tt` is signed.

Space before the `: uint8_t` or not? Maybe `TValue.tt` should be `lua_Value tt` as well? (I already have it working locally)