### PR TITLE
Add gc callback

### DIFF
--- a/VM/include/lua.h
+++ b/VM/include/lua.h
@@ -358,6 +358,8 @@ struct lua_Callbacks
     void (*debugstep)(lua_State* L, lua_Debug* ar);      /* gets called after each instruction in single step mode */
     void (*debuginterrupt)(lua_State* L, lua_Debug* ar); /* gets called when thread execution is interrupted by break in another thread */
     void (*debugprotectederror)(lua_State* L);           /* gets called when protected call results in an error */
+
+    void (*gc)(lua_State* L); /* gets called when a garbage collection cycle starts */
 };
 
 LUA_API lua_Callbacks* lua_callbacks(lua_State* L);

--- a/VM/src/lgc.cpp
+++ b/VM/src/lgc.cpp
@@ -617,6 +617,8 @@ static void markroot(lua_State* L)
     markvalue(g, registry(L));
     markmt(g);
     g->gcstate = GCSpropagate;
+    if (g->cb.gc)
+        g->cb.gc(L);
 }
 
 static size_t remarkupvals(global_State* g)


### PR DESCRIPTION
This can be used by host code to instantly mark white any values that they are using, even if they are not present in the registry or any Lua code.

This can be used as an alternative to `lua_ref`.

Note that this usecase is almost entirely covered by `lua_ref`, especially if Luau code does not have access to the registry (which it does not). You can do more things with it than you can with `lua_ref`, but the question is whether or not anyone in their right mind would be doing that.