### PR TITLE
Don't allow registry to be set to readonly

### DIFF
--- a/VM/src/lapi.cpp
+++ b/VM/src/lapi.cpp
@@ -704,8 +704,7 @@ void lua_setreadonly(lua_State* L, int objindex, bool value)
     const TValue* o = index2adr(L, objindex);
     api_check(L, ttistable(o));
     Table* t = hvalue(o);
-    if (value && t == hvalue(registry(L)))
-        luaG_runerror(L, "Attempt to set the registry to readonly");
+    api_check(L, t != hvalue(registry(L)));
     t->readonly = value;
     return;
 }

--- a/VM/src/lapi.cpp
+++ b/VM/src/lapi.cpp
@@ -10,6 +10,7 @@
 #include "ldo.h"
 #include "lvm.h"
 #include "lnumutils.h"
+#include "ldebug.h"
 
 #include <string.h>
 
@@ -703,6 +704,8 @@ void lua_setreadonly(lua_State* L, int objindex, bool value)
     const TValue* o = index2adr(L, objindex);
     api_check(L, ttistable(o));
     Table* t = hvalue(o);
+    if (value && obj2gco(t) == gcvalue(registry(L)))
+        luaG_runerror(L, "Attempt to set the registry to readonly");
     t->readonly = value;
     return;
 }

--- a/VM/src/lapi.cpp
+++ b/VM/src/lapi.cpp
@@ -704,7 +704,7 @@ void lua_setreadonly(lua_State* L, int objindex, bool value)
     const TValue* o = index2adr(L, objindex);
     api_check(L, ttistable(o));
     Table* t = hvalue(o);
-    if (value && obj2gco(t) == gcvalue(registry(L)))
+    if (value && t == hvalue(registry(L)))
         luaG_runerror(L, "Attempt to set the registry to readonly");
     t->readonly = value;
     return;

--- a/VM/src/lapi.cpp
+++ b/VM/src/lapi.cpp
@@ -10,7 +10,6 @@
 #include "ldo.h"
 #include "lvm.h"
 #include "lnumutils.h"
-#include "ldebug.h"
 
 #include <string.h>
 


### PR DESCRIPTION
Roblox does not do this, but I know for a fact that doing this causes Luau to crash and burn almost instantly (it's fun to use it to crash Roblox even). It would be nice to have some protection against doing it by accident.