### PR TITLE
Remove Roblox-specific mutable globals

### DIFF
--- a/Compiler/include/Luau/Compiler.h
+++ b/Compiler/include/Luau/Compiler.h
@@ -36,6 +36,10 @@ struct CompileOptions
     // global builtin to construct vectors; disabled by default
     const char* vectorLib = nullptr;
     const char* vectorCtor = nullptr;
+
+    // array of globals that are mutable; disables the import optimization for
+    // fields accessed through them. use NULL to end the array
+    const char** mutableGlobalNames;
 };
 
 class CompileError : public std::exception

--- a/Compiler/include/Luau/Compiler.h
+++ b/Compiler/include/Luau/Compiler.h
@@ -39,7 +39,7 @@ struct CompileOptions
 
     // array of globals that are mutable; disables the import optimization for fields accessed through them
     // use NULL to end the array
-    const char** mutableGlobalNames = nullptr;
+    const char** mutableGlobals = nullptr;
 };
 
 class CompileError : public std::exception

--- a/Compiler/include/Luau/Compiler.h
+++ b/Compiler/include/Luau/Compiler.h
@@ -37,8 +37,8 @@ struct CompileOptions
     const char* vectorLib = nullptr;
     const char* vectorCtor = nullptr;
 
-    // array of globals that are mutable; disables the import optimization for
-    // fields accessed through them. use NULL to end the array
+    // optional array of globals that are mutable; disables the import optimization for fields accessed through them
+    // use NULL to end the array
     const char** mutableGlobalNames;
 };
 

--- a/Compiler/include/Luau/Compiler.h
+++ b/Compiler/include/Luau/Compiler.h
@@ -37,9 +37,9 @@ struct CompileOptions
     const char* vectorLib = nullptr;
     const char* vectorCtor = nullptr;
 
-    // optional array of globals that are mutable; disables the import optimization for fields accessed through them
+    // array of globals that are mutable; disables the import optimization for fields accessed through them
     // use NULL to end the array
-    const char** mutableGlobalNames;
+    const char** mutableGlobalNames = nullptr;
 };
 
 class CompileError : public std::exception

--- a/Compiler/src/Compiler.cpp
+++ b/Compiler/src/Compiler.cpp
@@ -22,7 +22,7 @@ static const uint32_t kMaxRegisterCount = 255;
 static const uint32_t kMaxUpvalueCount = 200;
 static const uint32_t kMaxLocalCount = 200;
 
-static const char* kSpecialGlobals[] = {"Game", "Workspace", "_G", "game", "plugin", "script", "shared", "workspace"};
+static const char* kSpecialGlobals[] = {"_G"};
 
 CompileError::CompileError(const Location& location, const std::string& message)
     : location(location)

--- a/Compiler/src/Compiler.cpp
+++ b/Compiler/src/Compiler.cpp
@@ -3716,7 +3716,9 @@ void compileOrThrow(BytecodeBuilder& bytecode, AstStatBlock* root, const AstName
                 if (AstName name = names.get(*ptr); name.value)
                     compiler.globals[name].writable = true;
             }
-    } else {
+    }
+    else
+    {
         for (const char* global : kSpecialGlobals)
         {
             if (AstName name = names.get(global); name.value)

--- a/Compiler/src/Compiler.cpp
+++ b/Compiler/src/Compiler.cpp
@@ -22,8 +22,6 @@ static const uint32_t kMaxRegisterCount = 255;
 static const uint32_t kMaxUpvalueCount = 200;
 static const uint32_t kMaxLocalCount = 200;
 
-static const char* kSpecialGlobals[] = {"_G"};
-
 CompileError::CompileError(const Location& location, const std::string& message)
     : location(location)
     , message(message)
@@ -3704,9 +3702,8 @@ void compileOrThrow(BytecodeBuilder& bytecode, AstStatBlock* root, const AstName
     Compiler compiler(bytecode, options);
 
     // since access to some global objects may result in values that change over time, we block imports from non-readonly tables
-    for (const char* global : kSpecialGlobals)
     {
-        AstName name = names.get(global);
+        AstName name = names.get("_G");
 
         if (name.value)
             compiler.globals[name].writable = true;

--- a/Compiler/src/Compiler.cpp
+++ b/Compiler/src/Compiler.cpp
@@ -13,7 +13,7 @@
 LUAU_FASTFLAGVARIABLE(LuauPreloadClosures, false)
 LUAU_FASTFLAGVARIABLE(LuauPreloadClosuresFenv, false)
 LUAU_FASTFLAGVARIABLE(LuauPreloadClosuresUpval, false)
-LUAU_FASTFLAGVARIABLE(LuauGenericSpecialGlobals, true)
+LUAU_FASTFLAGVARIABLE(LuauGenericSpecialGlobals, false)
 LUAU_FASTFLAG(LuauIfElseExpressionBaseSupport)
 
 namespace Luau

--- a/Compiler/src/Compiler.cpp
+++ b/Compiler/src/Compiler.cpp
@@ -3703,7 +3703,7 @@ void compileOrThrow(BytecodeBuilder& bytecode, AstStatBlock* root, const AstName
 
     Compiler compiler(bytecode, options);
 
-    // since access to some global objects may result in values that change over time, we block table imports
+    // since access to some global objects may result in values that change over time, we block imports from non-readonly tables
     for (const char* global : kSpecialGlobals)
     {
         AstName name = names.get(global);
@@ -3711,6 +3711,15 @@ void compileOrThrow(BytecodeBuilder& bytecode, AstStatBlock* root, const AstName
         if (name.value)
             compiler.globals[name].special = true;
     }
+
+    if (options.mutableGlobalNames)
+        for (const char** ptr = options.mutableGlobalNames; ptr; ptr += sizeof(const char*))
+        {
+            AstName name = names.get(*ptr);
+
+            if (name.value)
+                compiler.globals[name].special = true;
+        }
 
     // this visitor traverses the AST to analyze mutability of locals/globals, filling Local::written and Global::written
     Compiler::AssignmentVisitor assignmentVisitor(&compiler);

--- a/Compiler/src/Compiler.cpp
+++ b/Compiler/src/Compiler.cpp
@@ -3710,8 +3710,8 @@ void compileOrThrow(BytecodeBuilder& bytecode, AstStatBlock* root, const AstName
         if (AstName name = names.get("_G"); name.value)
             compiler.globals[name].writable = true;
 
-        if (options.mutableGlobalNames)
-            for (const char** ptr = options.mutableGlobalNames; *ptr != NULL; ++ptr)
+        if (options.mutableGlobals)
+            for (const char** ptr = options.mutableGlobals; *ptr != NULL; ++ptr)
             {
                 if (AstName name = names.get(*ptr); name.value)
                     compiler.globals[name].writable = true;

--- a/Compiler/src/Compiler.cpp
+++ b/Compiler/src/Compiler.cpp
@@ -3707,25 +3707,19 @@ void compileOrThrow(BytecodeBuilder& bytecode, AstStatBlock* root, const AstName
     // since access to some global objects may result in values that change over time, we block imports from non-readonly tables
     if (FFlag::LuauGenericSpecialGlobals)
     {
-        AstName name = names.get("_G");
-
-        if (name.value)
+        if (AstName name = names.get("_G"); name.value)
             compiler.globals[name].writable = true;
 
         if (options.mutableGlobalNames)
             for (const char** ptr = options.mutableGlobalNames; *ptr != NULL; ++ptr)
             {
-                AstName name = names.get(*ptr);
-
-                if (name.value)
+                if (AstName name = names.get(*ptr); name.value)
                     compiler.globals[name].writable = true;
             }
     } else {
         for (const char* global : kSpecialGlobals)
         {
-            AstName name = names.get(global);
-
-            if (name.value)
+            if (AstName name = names.get(global); name.value)
                 compiler.globals[name].writable = true;
         }
     }

--- a/Compiler/src/Compiler.cpp
+++ b/Compiler/src/Compiler.cpp
@@ -3710,7 +3710,7 @@ void compileOrThrow(BytecodeBuilder& bytecode, AstStatBlock* root, const AstName
     }
 
     if (options.mutableGlobalNames)
-        for (const char** ptr = options.mutableGlobalNames; ptr; ptr += sizeof(const char*))
+        for (const char** ptr = options.mutableGlobalNames; *ptr != NULL; ptr += sizeof(const char*))
         {
             AstName name = names.get(*ptr);
 

--- a/Compiler/src/Compiler.cpp
+++ b/Compiler/src/Compiler.cpp
@@ -3710,7 +3710,7 @@ void compileOrThrow(BytecodeBuilder& bytecode, AstStatBlock* root, const AstName
     }
 
     if (options.mutableGlobalNames)
-        for (const char** ptr = options.mutableGlobalNames; *ptr != NULL; ptr += sizeof(const char*))
+        for (const char** ptr = options.mutableGlobalNames; *ptr != NULL; ++ptr)
         {
             AstName name = names.get(*ptr);
 

--- a/Compiler/src/Compiler.cpp
+++ b/Compiler/src/Compiler.cpp
@@ -1277,7 +1277,7 @@ struct Compiler
     {
         const Global* global = globals.find(expr->name);
 
-        return options.optimizationLevel >= 1 && (!global || (!global->written && !global->special));
+        return options.optimizationLevel >= 1 && (!global || (!global->written && !global->writable));
     }
 
     void compileExprIndexName(AstExprIndexName* expr, uint8_t target)
@@ -3447,7 +3447,7 @@ struct Compiler
 
     struct Global
     {
-        bool special = false;
+        bool writable = false;
         bool written = false;
     };
 
@@ -3505,7 +3505,7 @@ struct Compiler
             {
                 Global* g = globals.find(object->name);
 
-                return !g || (!g->special && !g->written) ? Builtin{object->name, expr->index} : Builtin();
+                return !g || (!g->writable && !g->written) ? Builtin{object->name, expr->index} : Builtin();
             }
             else
             {
@@ -3709,7 +3709,7 @@ void compileOrThrow(BytecodeBuilder& bytecode, AstStatBlock* root, const AstName
         AstName name = names.get(global);
 
         if (name.value)
-            compiler.globals[name].special = true;
+            compiler.globals[name].writable = true;
     }
 
     if (options.mutableGlobalNames)
@@ -3718,7 +3718,7 @@ void compileOrThrow(BytecodeBuilder& bytecode, AstStatBlock* root, const AstName
             AstName name = names.get(*ptr);
 
             if (name.value)
-                compiler.globals[name].special = true;
+                compiler.globals[name].writable = true;
         }
 
     // this visitor traverses the AST to analyze mutability of locals/globals, filling Local::written and Global::written

--- a/Compiler/src/Compiler.cpp
+++ b/Compiler/src/Compiler.cpp
@@ -13,7 +13,7 @@
 LUAU_FASTFLAGVARIABLE(LuauPreloadClosures, false)
 LUAU_FASTFLAGVARIABLE(LuauPreloadClosuresFenv, false)
 LUAU_FASTFLAGVARIABLE(LuauPreloadClosuresUpval, false)
-LUAU_FASTFLAGVARIABLE(LuauGenericSpecialGlobals, false)
+LUAU_FASTFLAGVARIABLE(LuauGenericSpecialGlobals, true)
 LUAU_FASTFLAG(LuauIfElseExpressionBaseSupport)
 
 namespace Luau

--- a/Compiler/src/Compiler.cpp
+++ b/Compiler/src/Compiler.cpp
@@ -13,8 +13,8 @@
 LUAU_FASTFLAGVARIABLE(LuauPreloadClosures, false)
 LUAU_FASTFLAGVARIABLE(LuauPreloadClosuresFenv, false)
 LUAU_FASTFLAGVARIABLE(LuauPreloadClosuresUpval, false)
+LUAU_FASTFLAGVARIABLE(LuauGenericSpecialGlobals, false)
 LUAU_FASTFLAG(LuauIfElseExpressionBaseSupport)
-LUAU_FASTFLAG(LuauGenericSpecialGlobals)
 
 namespace Luau
 {

--- a/tests/Compiler.test.cpp
+++ b/tests/Compiler.test.cpp
@@ -3749,7 +3749,7 @@ RETURN R0 0
     bcb.setDumpFlags(Luau::BytecodeBuilder::Dump_Code);
     Luau::CompileOptions options;
     const char* mutableGlobals[] = {"Game", "Workspace", "game", "plugin", "script", "shared", "workspace", NULL};
-    options.mutableGlobalNames = &mutableGlobals[0];
+    options.mutableGlobals = &mutableGlobals[0];
     Luau::compileOrThrow(bcb, source, options);
 
     CHECK_EQ("\n" + bcb.dumpFunction(0), R"(

--- a/tests/Compiler.test.cpp
+++ b/tests/Compiler.test.cpp
@@ -3673,8 +3673,6 @@ RETURN R0 0
 
 TEST_CASE("LuauGenericSpecialGlobals")
 {
-    FFlag::LuauGenericSpecialGlobals.value = false;
-
     const char* source = R"(
 print()
 Game.print()
@@ -3687,8 +3685,11 @@ shared.print()
 workspace.print()
 )";
 
-    // Check Roblox globals are here
-    CHECK_EQ("\n" + compileFunction0(source), R"(
+    {
+        ScopedFastFlag genericSpecialGlobals{"LuauGenericSpecialGlobals", false};
+
+        // Check Roblox globals are here
+        CHECK_EQ("\n" + compileFunction0(source), R"(
 GETIMPORT R0 1
 CALL R0 0 0
 GETIMPORT R1 3
@@ -3717,8 +3718,9 @@ GETTABLEKS R0 R1 K0
 CALL R0 0 0
 RETURN R0 0
 )");
+    }
 
-    FFlag::LuauGenericSpecialGlobals.value = true;
+    ScopedFastFlag genericSpecialGlobals{"LuauGenericSpecialGlobals", true};
 
     // Check Roblox globals are no longer here
     CHECK_EQ("\n" + compileFunction0(source), R"(

--- a/tests/Compiler.test.cpp
+++ b/tests/Compiler.test.cpp
@@ -13,6 +13,7 @@
 LUAU_FASTFLAG(LuauPreloadClosures)
 LUAU_FASTFLAG(LuauPreloadClosuresFenv)
 LUAU_FASTFLAG(LuauPreloadClosuresUpval)
+LUAU_FASTFLAG(LuauGenericSpecialGlobals)
 
 using namespace Luau;
 
@@ -3666,6 +3667,118 @@ NEWCLOSURE R5 P2
 CAPTURE VAL R3
 CALL R4 1 0
 FORNLOOP R0 -7
+RETURN R0 0
+)");
+}
+
+TEST_CASE("LuauGenericSpecialGlobals")
+{
+    FFlag::LuauGenericSpecialGlobals.value = false;
+
+    const char* source = R"(
+print()
+Game.print()
+Workspace.print()
+_G.print()
+game.print()
+plugin.print()
+script.print()
+shared.print()
+workspace.print()
+)";
+
+    // Check Roblox globals are here
+    CHECK_EQ("\n" + compileFunction0(source), R"(
+GETIMPORT R0 1
+CALL R0 0 0
+GETIMPORT R1 3
+GETTABLEKS R0 R1 K0
+CALL R0 0 0
+GETIMPORT R1 5
+GETTABLEKS R0 R1 K0
+CALL R0 0 0
+GETIMPORT R1 7
+GETTABLEKS R0 R1 K0
+CALL R0 0 0
+GETIMPORT R1 9
+GETTABLEKS R0 R1 K0
+CALL R0 0 0
+GETIMPORT R1 11
+GETTABLEKS R0 R1 K0
+CALL R0 0 0
+GETIMPORT R1 13
+GETTABLEKS R0 R1 K0
+CALL R0 0 0
+GETIMPORT R1 15
+GETTABLEKS R0 R1 K0
+CALL R0 0 0
+GETIMPORT R1 17
+GETTABLEKS R0 R1 K0
+CALL R0 0 0
+RETURN R0 0
+)");
+
+    FFlag::LuauGenericSpecialGlobals.value = true;
+
+    // Check Roblox globals are no longer here
+    CHECK_EQ("\n" + compileFunction0(source), R"(
+GETIMPORT R0 1
+CALL R0 0 0
+GETIMPORT R0 3
+CALL R0 0 0
+GETIMPORT R0 5
+CALL R0 0 0
+GETIMPORT R1 7
+GETTABLEKS R0 R1 K0
+CALL R0 0 0
+GETIMPORT R0 9
+CALL R0 0 0
+GETIMPORT R0 11
+CALL R0 0 0
+GETIMPORT R0 13
+CALL R0 0 0
+GETIMPORT R0 15
+CALL R0 0 0
+GETIMPORT R0 17
+CALL R0 0 0
+RETURN R0 0
+)");
+
+    // Check we can add them back
+    Luau::BytecodeBuilder bcb;
+    bcb.setDumpFlags(Luau::BytecodeBuilder::Dump_Code);
+    Luau::CompileOptions options;
+    const char* mutableGlobals[] = {"Game", "Workspace", "game", "plugin", "script", "shared", "workspace", NULL};
+    options.mutableGlobalNames = &mutableGlobals[0];
+    Luau::compileOrThrow(bcb, source, options);
+
+    CHECK_EQ("\n" + bcb.dumpFunction(0), R"(
+GETIMPORT R0 1
+CALL R0 0 0
+GETIMPORT R1 3
+GETTABLEKS R0 R1 K0
+CALL R0 0 0
+GETIMPORT R1 5
+GETTABLEKS R0 R1 K0
+CALL R0 0 0
+GETIMPORT R1 7
+GETTABLEKS R0 R1 K0
+CALL R0 0 0
+GETIMPORT R1 9
+GETTABLEKS R0 R1 K0
+CALL R0 0 0
+GETIMPORT R1 11
+GETTABLEKS R0 R1 K0
+CALL R0 0 0
+GETIMPORT R1 13
+GETTABLEKS R0 R1 K0
+CALL R0 0 0
+GETIMPORT R1 15
+GETTABLEKS R0 R1 K0
+CALL R0 0 0
+GETIMPORT R1 17
+GETTABLEKS R0 R1 K0
+CALL R0 0 0
 RETURN R0 0
 )");
 }


### PR DESCRIPTION
`kSpecialGlobals` is used by the compiler to disable the import optimization for values that are fetched from a mutable source (for example, `_G.xd`). Not only does this currently include Roblox-specific globals that might mean totally different things in other applications, but there's no way for embedding applications to specify if they have their own globals that act this way, which means that the import optimization may misbehave in those cases.

In vanilla Luau, only the `_G` global is mutable. Roblox can use the newly-implemented `mutableGlobalNames` compile option to specify its own globals - and crucially, third-party applications can as well. 