### PR TITLE
move static_assert from ltable.h to ltable.cpp

### DIFF
--- a/VM/src/ltable.cpp
+++ b/VM/src/ltable.cpp
@@ -30,6 +30,7 @@ LUAU_FASTFLAGVARIABLE(LuauArrayBoundary, false)
 #define MAXBITS 26
 #define MAXSIZE (1 << MAXBITS)
 
+static_assert(offsetof(LuaNode, val) == 0, "Unexpected Node memory layout, pointer cast in gval2slot is incorrect");
 // TKey is bitpacked for memory efficiency so we need to validate bit counts for worst case
 static_assert(TKey{{NULL}, 0, LUA_TDEADKEY, 0}.tt == LUA_TDEADKEY, "not enough bits for tt");
 static_assert(TKey{{NULL}, 0, LUA_TNIL, MAXSIZE - 1}.next == MAXSIZE - 1, "not enough bits for next");

--- a/VM/src/ltable.h
+++ b/VM/src/ltable.h
@@ -9,7 +9,6 @@
 #define gval(n) (&(n)->val)
 #define gnext(n) ((n)->key.next)
 
-static_assert(offsetof(LuaNode, val) == 0, "Unexpected Node memory layout, pointer cast below is incorrect");
 #define gval2slot(t, v) int(cast_to(LuaNode*, static_cast<const TValue*>(v)) - t->node)
 
 LUAI_FUNC const TValue* luaH_getnum(Table* t, int key);


### PR DESCRIPTION
Fixes #178

Sorry, I couldn't add a fast flag for this one. :P

It's a bit separated from the code it concerns now, but bindgen accepts it and there are no other tradeoffs to doing this.