### PR TITLE
Fix build on Clang 12 by removing unused variables

### DIFF
--- a/Analysis/src/Autocomplete.cpp
+++ b/Analysis/src/Autocomplete.cpp
@@ -496,7 +496,7 @@ static bool canSuggestInferredType(ScopePtr scope, TypeId ty)
         return false;
 
     // No syntax for unnamed tables with a metatable
-    if (const MetatableTypeVar* mtv = get<MetatableTypeVar>(ty))
+    if (get<MetatableTypeVar>(ty))
         return false;
 
     if (const TableTypeVar* ttv = get<TableTypeVar>(ty))
@@ -688,7 +688,7 @@ static std::optional<bool> functionIsExpectedAt(const Module& module, AstNode* n
 
     TypeId expectedType = follow(*it);
 
-    if (const FunctionTypeVar* ftv = get<FunctionTypeVar>(expectedType))
+    if (get<FunctionTypeVar>(expectedType))
         return true;
 
     if (const IntersectionTypeVar* itv = get<IntersectionTypeVar>(expectedType))

--- a/Analysis/src/TypeInfer.cpp
+++ b/Analysis/src/TypeInfer.cpp
@@ -2129,7 +2129,7 @@ TypeId TypeChecker::checkRelationalOperation(
         if (!isNonstrictMode() && !isOrOp)
             return ty;
 
-        if (auto i = get<UnionTypeVar>(ty))
+        if (get<UnionTypeVar>(ty))
         {
             std::optional<TypeId> cleaned = tryStripUnionFromNil(ty);
 

--- a/Analysis/src/TypePack.cpp
+++ b/Analysis/src/TypePack.cpp
@@ -216,7 +216,7 @@ bool finite(TypePackId tp)
     if (auto pack = get<TypePack>(tp))
         return pack->tail ? finite(*pack->tail) : true;
 
-    if (auto pack = get<VariadicTypePack>(tp))
+    if (get<VariadicTypePack>(tp))
         return false;
 
     return true;

--- a/Analysis/src/TypeVar.cpp
+++ b/Analysis/src/TypeVar.cpp
@@ -749,9 +749,9 @@ void StateDot::visitChild(TypeId ty, int parentIndex, const char* linkName)
 
     if (opts.duplicatePrimitives && canDuplicatePrimitive(ty))
     {
-        if (const PrimitiveTypeVar* ptv = get<PrimitiveTypeVar>(ty))
+        if (get<PrimitiveTypeVar>(ty))
             formatAppend(result, "n%d [label=\"%s\"];\n", index, toStringDetailed(ty, {}).name.c_str());
-        else if (const AnyTypeVar* atv = get<AnyTypeVar>(ty))
+        else if (get<AnyTypeVar>(ty))
             formatAppend(result, "n%d [label=\"any\"];\n", index);
     }
     else
@@ -902,19 +902,19 @@ void StateDot::visitChildren(TypeId ty, int index)
         finishNodeLabel(ty);
         finishNode();
     }
-    else if (const AnyTypeVar* atv = get<AnyTypeVar>(ty))
+    else if (get<AnyTypeVar>(ty))
     {
         formatAppend(result, "AnyTypeVar %d", index);
         finishNodeLabel(ty);
         finishNode();
     }
-    else if (const PrimitiveTypeVar* ptv = get<PrimitiveTypeVar>(ty))
+    else if (get<PrimitiveTypeVar>(ty))
     {
         formatAppend(result, "PrimitiveTypeVar %s", toStringDetailed(ty, {}).name.c_str());
         finishNodeLabel(ty);
         finishNode();
     }
-    else if (const ErrorTypeVar* etv = get<ErrorTypeVar>(ty))
+    else if (get<ErrorTypeVar>(ty))
     {
         formatAppend(result, "ErrorTypeVar %d", index);
         finishNodeLabel(ty);
@@ -994,7 +994,7 @@ void StateDot::visitChildren(TypePackId tp, int index)
         finishNodeLabel(tp);
         finishNode();
     }
-    else if (const Unifiable::Error* etp = get<Unifiable::Error>(tp))
+    else if (get<Unifiable::Error>(tp))
     {
         formatAppend(result, "ErrorTypePack %d", index);
         finishNodeLabel(tp);


### PR DESCRIPTION
Clang 12 has a warning for unused variables, and all warnings are errors.