### PR TITLE
completely untested, speculative mockup of fatuserdata

### DIFF
--- a/VM/include/lua.h
+++ b/VM/include/lua.h
@@ -65,6 +65,7 @@ enum lua_Type
 
     
     LUA_TLIGHTUSERDATA,
+    LUA_TFATUSERDATA,
     LUA_TNUMBER,
     LUA_TVECTOR,
 
@@ -166,6 +167,7 @@ LUA_API void lua_pushcfunction(
     lua_State* L, lua_CFunction fn, const char* debugname = NULL, int nup = 0, lua_Continuation cont = NULL);
 LUA_API void lua_pushboolean(lua_State* L, int b);
 LUA_API void lua_pushlightuserdata(lua_State* L, void* p);
+LUA_API void lua_pushfatuserdata(lua_State* L);
 LUA_API int lua_pushthread(lua_State* L);
 
 /*

--- a/VM/include/luaconf.h
+++ b/VM/include/luaconf.h
@@ -102,6 +102,14 @@
 /* maximum number of captures supported by pattern matching */
 #define LUA_MAXCAPTURES 32
 
+/*
+@@ LUAU_FATUSERDATA_WORDS defines the amount of extra space embedded in
+@* fatuserdata values.
+** This inflates every value in the VM, so use it carefully.
+** At least 1 is required to store the `vector` value type.
+*/
+#define LUAU_FATUSERDATA_WORDS 1
+
 /* }================================================================== */
 
 /* Default number printing format and the string length limit */

--- a/VM/src/lapi.cpp
+++ b/VM/src/lapi.cpp
@@ -882,8 +882,8 @@ int lua_setmetatable(lua_State* L, int objindex)
     case LUA_TFATUSERDATA:
     {
         mpvalue(obj) = (void*)mt;
-        if (mt)
-            luaC_objbarrier(L, uvalue(obj), mt);
+        //if (mt)
+            // TODO find the right barrier
         break;
     }
     default:

--- a/VM/src/lgc.cpp
+++ b/VM/src/lgc.cpp
@@ -42,6 +42,8 @@ LUAU_FASTFLAG(LuauArrayBoundary)
         checkconsistency(o); \
         if (iscollectable(o) && iswhite(gcvalue(o))) \
             reallymarkobject(g, gcvalue(o)); \
+        else if (ttisfatuserdata(o) && mpvalue(o) && iswhite((GCObject*)mpvalue(o))) \
+            reallymarkobject(g, (GCObject*)mpvalue(o)); \
     }
 
 #define markobject(g, t) \

--- a/VM/src/lmem.cpp
+++ b/VM/src/lmem.cpp
@@ -33,11 +33,16 @@
 #define ABISWITCH(x64, ms32, gcc32) (sizeof(void*) == 8 ? x64 : ms32)
 #endif
 
+// Padding makes it difficult to verify these statically, we'd basically be mirroring the compiler's layout algorithm
+// So instead, only assert these when LUAU_FATUSERDATA_WORDS is 1, which is the go-to default/embedded configuration
+#if LUAU_FATUSERDATA_WORDS == 1
 static_assert(sizeof(TValue) == ABISWITCH(16, 16, 16), "size mismatch for value");
+static_assert(sizeof(LuaNode) == ABISWITCH(32, 32, 32), "size mismatch for table entry");
+#endif
+
 static_assert(offsetof(TString, data) == ABISWITCH(24, 20, 20), "size mismatch for string header");
 static_assert(offsetof(Udata, data) == ABISWITCH(24, 16, 16), "size mismatch for userdata header");
 static_assert(sizeof(Table) == ABISWITCH(56, 36, 36), "size mismatch for table header");
-static_assert(sizeof(LuaNode) == ABISWITCH(32, 32, 32), "size mismatch for table entry");
 
 const size_t kSizeClasses = LUA_SIZECLASSES;
 const size_t kMaxSmallSize = 512;

--- a/VM/src/lobject.cpp
+++ b/VM/src/lobject.cpp
@@ -15,7 +15,7 @@
 
 
 
-const TValue luaO_nilobject_ = {{NULL}, LUA_TNIL};
+const TValue luaO_nilobject_ = {{NULL}, {}, LUA_TNIL};
 
 int luaO_log2(unsigned int x)
 {

--- a/VM/src/ltable.cpp
+++ b/VM/src/ltable.cpp
@@ -32,17 +32,17 @@ LUAU_FASTFLAGVARIABLE(LuauArrayBoundary, false)
 
 static_assert(offsetof(LuaNode, val) == 0, "Unexpected Node memory layout, pointer cast in gval2slot is incorrect");
 // TKey is bitpacked for memory efficiency so we need to validate bit counts for worst case
-static_assert(TKey{{NULL}, 0, LUA_TDEADKEY, 0}.tt == LUA_TDEADKEY, "not enough bits for tt");
-static_assert(TKey{{NULL}, 0, LUA_TNIL, MAXSIZE - 1}.next == MAXSIZE - 1, "not enough bits for next");
-static_assert(TKey{{NULL}, 0, LUA_TNIL, -(MAXSIZE - 1)}.next == -(MAXSIZE - 1), "not enough bits for next");
+static_assert(TKey{{NULL}, {}, LUA_TDEADKEY, 0}.tt == LUA_TDEADKEY, "not enough bits for tt");
+static_assert(TKey{{NULL}, {}, LUA_TNIL, MAXSIZE - 1}.next == MAXSIZE - 1, "not enough bits for next");
+static_assert(TKey{{NULL}, {}, LUA_TNIL, -(MAXSIZE - 1)}.next == -(MAXSIZE - 1), "not enough bits for next");
 
 // reset cache of absent metamethods, cache is updated in luaT_gettm
 #define invalidateTMcache(t) t->flags = 0
 
 // empty hash data points to dummynode so that we can always dereference it
 const LuaNode luaH_dummynode = {
-    {{NULL}, 0, LUA_TNIL},   /* value */
-    {{NULL}, 0, LUA_TNIL, 0} /* key */
+    {{NULL}, {}, LUA_TNIL},   /* value */
+    {{NULL}, {}, LUA_TNIL, 0} /* key */
 };
 
 #define dummynode (&luaH_dummynode)

--- a/VM/src/ltm.cpp
+++ b/VM/src/ltm.cpp
@@ -17,6 +17,7 @@ const char* const luaT_typenames[] = {
 
     
     "userdata",
+    "userdata",
     "number",
     "vector",
 
@@ -107,6 +108,9 @@ const TValue* luaT_gettmbyobj(lua_State* L, const TValue* o, TMS event)
         break;
     case LUA_TUSERDATA:
         mt = uvalue(o)->metatable;
+        break;
+    case LUA_TFATUSERDATA:
+        mt = (Table*)(mpvalue(o));
         break;
     default:
         mt = L->global->mt[ttype(o)];


### PR DESCRIPTION
Based on this comment from @zeux:
https://github.com/Roblox/luau/issues/196#issuecomment-967785098

I had a go at _starting_ the possible implementation of a fatuserdata type, which is a userdata value type. Bad news is, supporting this type for anything except 32-bit integers requires expanding the TValue struct _for all values_, so it's a compile-time configuration option.

This only took me a couple hours to whip up. Things I'm unsure about:
- Execution. I haven't touched the interpreter because I don't know how it works and I definitely don't know how to make it work.
- Garbage collection. I try to have the metatable marked when the value is traversed but I couldn't find the right barrier to use when _setting_ the value's metatable.
- Tests. Right now, there's a high likelyhood the interpreter will blow up upon encountering a fatuserdata in the first place, so I haven't bothered with any tests yet. All existing tests still pass, thankfully.
- Everything else. I don't even know if my `memcpy`s are correct.

So I need help and feedback...