### PR TITLE
fix unable to find library -lpthread

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,7 +87,10 @@ if(LUAU_BUILD_CLI)
     target_link_libraries(Luau.Repl.CLI PRIVATE Luau.Compiler Luau.VM)
 
     if(UNIX)
-        target_link_libraries(Luau.Repl.CLI PRIVATE pthread)
+        find_library(LIBPTHREAD pthread)
+        if (LIBPTHREAD)
+            target_link_libraries(Luau.Repl.CLI PRIVATE pthread)
+        endif()
     endif()
 
     if(NOT EMSCRIPTEN)


### PR DESCRIPTION
add check libpthread if can be found, once found it, link it, otherwise do not link it. Beacause on Android, unlike Linux, there are no separate libpthread libraries. That functionality is included directly in libc