### PR TITLE
Added note about encrypting bytecode to SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,7 +7,7 @@ Any source code can not result in memory safety errors or crashes during its com
 Note that Luau does not provide termination guarantees - some code may exhaust CPU or RAM resources on the system during compilation or execution.
 
 The runtime expects valid bytecode as an input. Feeding bytecode that was not produced by Luau compiler into the VM is not supported and
-doesn't come with any security guarantees; make sure to sign the bytecode when it crosses a network or file system boundary to avoid tampering.
+doesn't come with any security guarantees; make sure to sign and/or encrypt the bytecode when it crosses a network or file system boundary to avoid tampering.
 
 # Reporting a Vulnerability
 


### PR DESCRIPTION
In some use cases it is better to encrypt the bytecode, while on others you may want to do both.

The Luau Roblox version does this, this could be also advantageous for other usecases.