### PR TITLE
Expand vectors to 4 components using compile time switch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,7 +87,10 @@ if(LUAU_BUILD_CLI)
     target_link_libraries(Luau.Repl.CLI PRIVATE Luau.Compiler Luau.VM)
 
     if(UNIX)
-        target_link_libraries(Luau.Repl.CLI PRIVATE pthread)
+        find_library(LIBPTHREAD pthread)
+        if (LIBPTHREAD)
+            target_link_libraries(Luau.Repl.CLI PRIVATE pthread)
+        endif()
     endif()
 
     if(NOT EMSCRIPTEN)

--- a/VM/include/lua.h
+++ b/VM/include/lua.h
@@ -157,7 +157,11 @@ LUA_API void lua_pushnil(lua_State* L);
 LUA_API void lua_pushnumber(lua_State* L, double n);
 LUA_API void lua_pushinteger(lua_State* L, int n);
 LUA_API void lua_pushunsigned(lua_State* L, unsigned n);
+#ifdef LUA_FLOAT4_VECTORS
+LUA_API void lua_pushvector(lua_State* L, float x, float y, float z, float w);
+#else
 LUA_API void lua_pushvector(lua_State* L, float x, float y, float z);
+#endif
 LUA_API void lua_pushlstring(lua_State* L, const char* s, size_t l);
 LUA_API void lua_pushstring(lua_State* L, const char* s);
 LUA_API const char* lua_pushvfstring(lua_State* L, const char* fmt, va_list argp);

--- a/VM/include/lua.h
+++ b/VM/include/lua.h
@@ -157,7 +157,7 @@ LUA_API void lua_pushnil(lua_State* L);
 LUA_API void lua_pushnumber(lua_State* L, double n);
 LUA_API void lua_pushinteger(lua_State* L, int n);
 LUA_API void lua_pushunsigned(lua_State* L, unsigned n);
-#ifdef LUA_FLOAT4_VECTORS
+#if LUA_VECTOR_SIZE == 4
 LUA_API void lua_pushvector(lua_State* L, float x, float y, float z, float w);
 #else
 LUA_API void lua_pushvector(lua_State* L, float x, float y, float z);

--- a/VM/include/luaconf.h
+++ b/VM/include/luaconf.h
@@ -123,12 +123,6 @@
         long l; \
     }
 
-#define LUA_FLOAT4_VECTORS
-
-#ifdef LUA_FLOAT4_VECTORS
-#define LUA_VECTOR_SIZE 4
-#else
-#define LUA_VECTOR_SIZE 3
-#endif
+#define LUA_VECTOR_SIZE 3	/* must be 3 or 4 */
 
 #define LUA_EXTRA_SIZE LUA_VECTOR_SIZE - 2

--- a/VM/include/luaconf.h
+++ b/VM/include/luaconf.h
@@ -124,3 +124,11 @@
     }
 
 #define LUA_FLOAT4_VECTORS
+
+#ifdef LUA_FLOAT4_VECTORS
+#define LUA_VECTOR_SIZE 4
+#else
+#define LUA_VECTOR_SIZE 3
+#endif
+
+#define LUA_EXTRA_VALUE_SIZE LUA_VECTOR_SIZE - 2	// note: this assumes vector size >= 2!

--- a/VM/include/luaconf.h
+++ b/VM/include/luaconf.h
@@ -122,3 +122,5 @@
         void* s; \
         long l; \
     }
+
+#define LUA_FLOAT4_VECTORS

--- a/VM/include/luaconf.h
+++ b/VM/include/luaconf.h
@@ -131,4 +131,4 @@
 #define LUA_VECTOR_SIZE 3
 #endif
 
-#define LUA_EXTRA_VALUE_SIZE LUA_VECTOR_SIZE - 2	// note: this assumes vector size >= 2!
+#define LUA_EXTRA_SIZE LUA_VECTOR_SIZE - 2

--- a/VM/src/lapi.cpp
+++ b/VM/src/lapi.cpp
@@ -550,12 +550,21 @@ void lua_pushunsigned(lua_State* L, unsigned u)
     return;
 }
 
+#ifdef LUA_FLOAT4_VECTORS
+void lua_pushvector(lua_State* L, float x, float y, float z, float w)
+{
+    setvvalue(L->top, x, y, z, w);
+    api_incr_top(L);
+    return;
+}
+#else
 void lua_pushvector(lua_State* L, float x, float y, float z)
 {
     setvvalue(L->top, x, y, z);
     api_incr_top(L);
     return;
 }
+#endif
 
 void lua_pushlstring(lua_State* L, const char* s, size_t len)
 {

--- a/VM/src/lapi.cpp
+++ b/VM/src/lapi.cpp
@@ -560,7 +560,7 @@ void lua_pushvector(lua_State* L, float x, float y, float z, float w)
 #else
 void lua_pushvector(lua_State* L, float x, float y, float z)
 {
-    setvvalue(L->top, x, y, z);
+    setvvalue(L->top, x, y, z, 0.0f);
     api_incr_top(L);
     return;
 }

--- a/VM/src/lapi.cpp
+++ b/VM/src/lapi.cpp
@@ -550,7 +550,7 @@ void lua_pushunsigned(lua_State* L, unsigned u)
     return;
 }
 
-#ifdef LUA_FLOAT4_VECTORS
+#if LUA_VECTOR_SIZE == 4
 void lua_pushvector(lua_State* L, float x, float y, float z, float w)
 {
     setvvalue(L->top, x, y, z, w);

--- a/VM/src/laux.cpp
+++ b/VM/src/laux.cpp
@@ -462,7 +462,7 @@ LUALIB_API const char* luaL_tolstring(lua_State* L, int idx, size_t* len)
     case LUA_TVECTOR:
     {
         const float* v = lua_tovector(L, idx);
-#ifdef LUA_FLOAT4_VECTORS
+#if LUA_VECTOR_SIZE == 4
         lua_pushfstring(L, LUA_NUMBER_FMT ", " LUA_NUMBER_FMT ", " LUA_NUMBER_FMT ", " LUA_NUMBER_FMT, v[0], v[1], v[2], v[3]);
 #else
         lua_pushfstring(L, LUA_NUMBER_FMT ", " LUA_NUMBER_FMT ", " LUA_NUMBER_FMT, v[0], v[1], v[2]);

--- a/VM/src/laux.cpp
+++ b/VM/src/laux.cpp
@@ -462,7 +462,11 @@ LUALIB_API const char* luaL_tolstring(lua_State* L, int idx, size_t* len)
     case LUA_TVECTOR:
     {
         const float* v = lua_tovector(L, idx);
+#ifdef LUA_FLOAT4_VECTORS
+        lua_pushfstring(L, LUA_NUMBER_FMT ", " LUA_NUMBER_FMT ", " LUA_NUMBER_FMT ", " LUA_NUMBER_FMT, v[0], v[1], v[2], v[3]);
+#else
         lua_pushfstring(L, LUA_NUMBER_FMT ", " LUA_NUMBER_FMT ", " LUA_NUMBER_FMT, v[0], v[1], v[2]);
+#endif
         break;
     }
     default:

--- a/VM/src/lbuiltins.cpp
+++ b/VM/src/lbuiltins.cpp
@@ -1016,6 +1016,23 @@ static int luauF_tunpack(lua_State* L, StkId res, TValue* arg0, int nresults, St
     return -1;
 }
 
+#ifdef LUA_FLOAT4_VECTORS
+static int luauF_vector(lua_State* L, StkId res, TValue* arg0, int nresults, StkId args, int nparams)
+{
+    if (nparams >= 3 && nresults <= 1 && ttisnumber(arg0) && ttisnumber(args) && ttisnumber(args + 1) && ttisnumber(args + 2))
+    {
+        double x = nvalue(arg0);
+        double y = nvalue(args);
+        double z = nvalue(args + 1);
+        double w = nvalue(args + 2);
+
+        setvvalue(res, float(x), float(y), float(z), float(w));
+        return 1;
+    }
+
+    return -1;
+}
+#else
 static int luauF_vector(lua_State* L, StkId res, TValue* arg0, int nresults, StkId args, int nparams)
 {
     if (nparams >= 3 && nresults <= 1 && ttisnumber(arg0) && ttisnumber(args) && ttisnumber(args + 1))
@@ -1030,6 +1047,7 @@ static int luauF_vector(lua_State* L, StkId res, TValue* arg0, int nresults, Stk
 
     return -1;
 }
+#endif
 
 static int luauF_countlz(lua_State* L, StkId res, TValue* arg0, int nresults, StkId args, int nparams)
 {

--- a/VM/src/lbuiltins.cpp
+++ b/VM/src/lbuiltins.cpp
@@ -1019,27 +1019,23 @@ static int luauF_tunpack(lua_State* L, StkId res, TValue* arg0, int nresults, St
 static int luauF_vector(lua_State* L, StkId res, TValue* arg0, int nresults, StkId args, int nparams)
 {
 #ifdef LUA_FLOAT4_VECTORS
-    if (nparams >= 3 && nresults <= 1 && ttisnumber(arg0) && ttisnumber(args) && ttisnumber(args + 1) && ttisnumber(args + 2))
+    if (nparams >= 4 && nresults <= 1 && ttisnumber(arg0) && ttisnumber(args) && ttisnumber(args + 1) && ttisnumber(args + 2))
+#else
+    if (nparams >= 3 && nresults <= 1 && ttisnumber(arg0) && ttisnumber(args) && ttisnumber(args + 1))
+#endif
     {
         double x = nvalue(arg0);
         double y = nvalue(args);
         double z = nvalue(args + 1);
-        double w = nvalue(args + 2);
+        double w = 0.0;
+
+#ifdef LUA_FLOAT4_VECTORS
+        w = nvalue(args + 2);
+#endif
 
         setvvalue(res, float(x), float(y), float(z), float(w));
         return 1;
     }
-#else
-    if (nparams >= 3 && nresults <= 1 && ttisnumber(arg0) && ttisnumber(args) && ttisnumber(args + 1))
-    {
-        double x = nvalue(arg0);
-        double y = nvalue(args);
-        double z = nvalue(args + 1);
-
-        setvvalue(res, float(x), float(y), float(z));
-        return 1;
-    }
-#endif
 
     return -1;
 }

--- a/VM/src/lbuiltins.cpp
+++ b/VM/src/lbuiltins.cpp
@@ -1027,13 +1027,14 @@ static int luauF_vector(lua_State* L, StkId res, TValue* arg0, int nresults, Stk
         double x = nvalue(arg0);
         double y = nvalue(args);
         double z = nvalue(args + 1);
-        double w = 0.0;
 
 #if LUA_VECTOR_SIZE == 4
-        w = nvalue(args + 2);
+        double w = nvalue(args + 2);
+        setvvalue(res, float(x), float(y), float(z), float(w));
+#else
+        setvvalue(res, float(x), float(y), float(z), 0.0f);
 #endif
 
-        setvvalue(res, float(x), float(y), float(z), float(w));
         return 1;
     }
 

--- a/VM/src/lbuiltins.cpp
+++ b/VM/src/lbuiltins.cpp
@@ -1016,9 +1016,9 @@ static int luauF_tunpack(lua_State* L, StkId res, TValue* arg0, int nresults, St
     return -1;
 }
 
-#ifdef LUA_FLOAT4_VECTORS
 static int luauF_vector(lua_State* L, StkId res, TValue* arg0, int nresults, StkId args, int nparams)
 {
+#ifdef LUA_FLOAT4_VECTORS
     if (nparams >= 3 && nresults <= 1 && ttisnumber(arg0) && ttisnumber(args) && ttisnumber(args + 1) && ttisnumber(args + 2))
     {
         double x = nvalue(arg0);
@@ -1029,12 +1029,7 @@ static int luauF_vector(lua_State* L, StkId res, TValue* arg0, int nresults, Stk
         setvvalue(res, float(x), float(y), float(z), float(w));
         return 1;
     }
-
-    return -1;
-}
 #else
-static int luauF_vector(lua_State* L, StkId res, TValue* arg0, int nresults, StkId args, int nparams)
-{
     if (nparams >= 3 && nresults <= 1 && ttisnumber(arg0) && ttisnumber(args) && ttisnumber(args + 1))
     {
         double x = nvalue(arg0);
@@ -1044,10 +1039,10 @@ static int luauF_vector(lua_State* L, StkId res, TValue* arg0, int nresults, Stk
         setvvalue(res, float(x), float(y), float(z));
         return 1;
     }
+#endif
 
     return -1;
 }
-#endif
 
 static int luauF_countlz(lua_State* L, StkId res, TValue* arg0, int nresults, StkId args, int nparams)
 {

--- a/VM/src/lbuiltins.cpp
+++ b/VM/src/lbuiltins.cpp
@@ -1018,7 +1018,7 @@ static int luauF_tunpack(lua_State* L, StkId res, TValue* arg0, int nresults, St
 
 static int luauF_vector(lua_State* L, StkId res, TValue* arg0, int nresults, StkId args, int nparams)
 {
-#ifdef LUA_FLOAT4_VECTORS
+#if LUA_VECTOR_SIZE == 4
     if (nparams >= 4 && nresults <= 1 && ttisnumber(arg0) && ttisnumber(args) && ttisnumber(args + 1) && ttisnumber(args + 2))
 #else
     if (nparams >= 3 && nresults <= 1 && ttisnumber(arg0) && ttisnumber(args) && ttisnumber(args + 1))
@@ -1029,7 +1029,7 @@ static int luauF_vector(lua_State* L, StkId res, TValue* arg0, int nresults, Stk
         double z = nvalue(args + 1);
         double w = 0.0;
 
-#ifdef LUA_FLOAT4_VECTORS
+#if LUA_VECTOR_SIZE == 4
         w = nvalue(args + 2);
 #endif
 

--- a/VM/src/lmem.cpp
+++ b/VM/src/lmem.cpp
@@ -33,7 +33,7 @@
 #define ABISWITCH(x64, ms32, gcc32) (sizeof(void*) == 8 ? x64 : ms32)
 #endif
 
-#ifdef LUA_FLOAT4_VECTORS
+#if LUA_VECTOR_SIZE == 4
 static_assert(sizeof(TValue) == ABISWITCH(24, 24, 24), "size mismatch for value");
 static_assert(sizeof(LuaNode) == ABISWITCH(48, 48, 48), "size mismatch for table entry");
 #else

--- a/VM/src/lmem.cpp
+++ b/VM/src/lmem.cpp
@@ -35,17 +35,15 @@
 
 #ifdef LUA_FLOAT4_VECTORS
 static_assert(sizeof(TValue) == ABISWITCH(24, 24, 24), "size mismatch for value");
-static_assert(offsetof(TString, data) == ABISWITCH(24, 20, 20), "size mismatch for string header");
-static_assert(offsetof(Udata, data) == ABISWITCH(24, 16, 16), "size mismatch for userdata header");
-static_assert(sizeof(Table) == ABISWITCH(56, 36, 36), "size mismatch for table header");
 static_assert(sizeof(LuaNode) == ABISWITCH(48, 48, 48), "size mismatch for table entry");
 #else
 static_assert(sizeof(TValue) == ABISWITCH(16, 16, 16), "size mismatch for value");
+static_assert(sizeof(LuaNode) == ABISWITCH(32, 32, 32), "size mismatch for table entry");
+#endif
+
 static_assert(offsetof(TString, data) == ABISWITCH(24, 20, 20), "size mismatch for string header");
 static_assert(offsetof(Udata, data) == ABISWITCH(24, 16, 16), "size mismatch for userdata header");
 static_assert(sizeof(Table) == ABISWITCH(56, 36, 36), "size mismatch for table header");
-static_assert(sizeof(LuaNode) == ABISWITCH(32, 32, 32), "size mismatch for table entry");
-#endif
 
 const size_t kSizeClasses = LUA_SIZECLASSES;
 const size_t kMaxSmallSize = 512;

--- a/VM/src/lmem.cpp
+++ b/VM/src/lmem.cpp
@@ -33,11 +33,19 @@
 #define ABISWITCH(x64, ms32, gcc32) (sizeof(void*) == 8 ? x64 : ms32)
 #endif
 
+#ifdef LUA_FLOAT4_VECTORS
+static_assert(sizeof(TValue) == ABISWITCH(24, 24, 24), "size mismatch for value");
+static_assert(offsetof(TString, data) == ABISWITCH(24, 20, 20), "size mismatch for string header");
+static_assert(offsetof(Udata, data) == ABISWITCH(24, 16, 16), "size mismatch for userdata header");
+static_assert(sizeof(Table) == ABISWITCH(56, 36, 36), "size mismatch for table header");
+static_assert(sizeof(LuaNode) == ABISWITCH(48, 48, 48), "size mismatch for table entry");
+#else
 static_assert(sizeof(TValue) == ABISWITCH(16, 16, 16), "size mismatch for value");
 static_assert(offsetof(TString, data) == ABISWITCH(24, 20, 20), "size mismatch for string header");
 static_assert(offsetof(Udata, data) == ABISWITCH(24, 16, 16), "size mismatch for userdata header");
 static_assert(sizeof(Table) == ABISWITCH(56, 36, 36), "size mismatch for table header");
 static_assert(sizeof(LuaNode) == ABISWITCH(32, 32, 32), "size mismatch for table entry");
+#endif
 
 const size_t kSizeClasses = LUA_SIZECLASSES;
 const size_t kMaxSmallSize = 512;

--- a/VM/src/lnumutils.h
+++ b/VM/src/lnumutils.h
@@ -18,7 +18,7 @@
 
 inline bool luai_veceq(const float* a, const float* b)
 {
-#ifdef LUA_FLOAT4_VECTORS
+#if LUA_VECTOR_SIZE == 4
     return a[0] == b[0] && a[1] == b[1] && a[2] == b[2] && a[3] == b[3];
 #else
     return a[0] == b[0] && a[1] == b[1] && a[2] == b[2];
@@ -27,7 +27,7 @@ inline bool luai_veceq(const float* a, const float* b)
 
 inline bool luai_vecisnan(const float* a)
 {
-#ifdef LUA_FLOAT4_VECTORS
+#if LUA_VECTOR_SIZE == 4
     return a[0] != a[0] || a[1] != a[1] || a[2] != a[2] || a[3] != a[3];
 #else
     return a[0] != a[0] || a[1] != a[1] || a[2] != a[2];

--- a/VM/src/lnumutils.h
+++ b/VM/src/lnumutils.h
@@ -18,12 +18,20 @@
 
 inline bool luai_veceq(const float* a, const float* b)
 {
+#ifdef LUA_FLOAT4_VECTORS
+    return a[0] == b[0] && a[1] == b[1] && a[2] == b[2] && a[3] == b[3];
+#else
     return a[0] == b[0] && a[1] == b[1] && a[2] == b[2];
+#endif
 }
 
 inline bool luai_vecisnan(const float* a)
 {
+#ifdef LUA_FLOAT4_VECTORS
+    return a[0] != a[0] || a[1] != a[1] || a[2] != a[2] || a[3] != a[3];
+#else
     return a[0] != a[0] || a[1] != a[1] || a[2] != a[2];
+#endif
 }
 
 LUAU_FASTMATH_BEGIN

--- a/VM/src/lobject.cpp
+++ b/VM/src/lobject.cpp
@@ -15,7 +15,7 @@
 
 
 
-const TValue luaO_nilobject_ = {{NULL}, LUA_TNIL};
+const TValue luaO_nilobject_ = {{NULL}, {0}, LUA_TNIL};
 
 int luaO_log2(unsigned int x)
 {

--- a/VM/src/lobject.h
+++ b/VM/src/lobject.h
@@ -105,7 +105,7 @@ typedef struct lua_TValue
         i_o->tt = LUA_TNUMBER; \
     }
 
-#ifdef LUA_FLOAT4_VECTORS
+#if LUA_VECTOR_SIZE == 4
 #define setvvalue(obj, x, y, z, w) \
     { \
         TValue* i_o = (obj); \

--- a/VM/src/lobject.h
+++ b/VM/src/lobject.h
@@ -394,8 +394,7 @@ typedef struct LuaNode
         LuaNode* n_ = (node); \
         const TValue* i_o = (obj); \
         n_->key.value = i_o->value; \
-        for (int i = 0; i < LUA_EXTRA_VALUE_SIZE; i++) \
-            n_->key.extra[i] = i_o->extra[i]; \
+        memcpy(n_->key.extra, i_o->extra, sizeof(n_->key.extra)); \
         n_->key.tt = i_o->tt; \
         checkliveness(L->global, i_o); \
     }
@@ -406,8 +405,7 @@ typedef struct LuaNode
         TValue* i_o = (obj); \
         const LuaNode* n_ = (node); \
         i_o->value = n_->key.value; \
-        for (int i = 0; i < LUA_EXTRA_VALUE_SIZE; i++) \
-            i_o->extra[i] = n_->key.extra[i]; \
+        memcpy(i_o->extra, n_->key.extra, sizeof(i_o->extra)); \
         i_o->tt = n_->key.tt; \
         checkliveness(L->global, i_o); \
     }

--- a/VM/src/lobject.h
+++ b/VM/src/lobject.h
@@ -117,7 +117,7 @@ typedef struct lua_TValue
         i_o->tt = LUA_TVECTOR; \
     }
 #else
-#define setvvalue(obj, x, y, z) \
+#define setvvalue(obj, x, y, z, w) \
     { \
         TValue* i_o = (obj); \
         float* i_v = i_o->value.v; \

--- a/VM/src/lobject.h
+++ b/VM/src/lobject.h
@@ -47,7 +47,7 @@ typedef union
 typedef struct lua_TValue
 {
     Value value;
-    int extra[LUA_EXTRA_VALUE_SIZE];
+    int extra[LUA_EXTRA_SIZE];
     int tt;
 } TValue;
 
@@ -377,7 +377,7 @@ typedef struct Closure
 typedef struct TKey
 {
     ::Value value;
-    int extra[LUA_EXTRA_VALUE_SIZE];
+    int extra[LUA_EXTRA_SIZE];
     unsigned tt : 4;
     int next : 28; /* for chaining */
 } TKey;

--- a/VM/src/ltable.cpp
+++ b/VM/src/ltable.cpp
@@ -42,8 +42,8 @@ static_assert(TKey{{NULL}, {0}, LUA_TNIL, -(MAXSIZE - 1)}.next == -(MAXSIZE - 1)
 
 // empty hash data points to dummynode so that we can always dereference it
 const LuaNode luaH_dummynode = {
-    {{NULL}, 0, LUA_TNIL},   /* value */
-    {{NULL}, 0, LUA_TNIL, 0} /* key */
+    {{NULL}, {0}, LUA_TNIL},   /* value */
+    {{NULL}, {0}, LUA_TNIL, 0} /* key */
 };
 
 #define dummynode (&luaH_dummynode)

--- a/VM/src/ltable.cpp
+++ b/VM/src/ltable.cpp
@@ -32,17 +32,10 @@ LUAU_FASTFLAGVARIABLE(LuauArrayBoundary, false)
 
 static_assert(offsetof(LuaNode, val) == 0, "Unexpected Node memory layout, pointer cast in gval2slot is incorrect");
 
-#ifdef LUA_FLOAT4_VECTORS
 // TKey is bitpacked for memory efficiency so we need to validate bit counts for worst case
-static_assert(TKey{{NULL}, {0, 0}, LUA_TDEADKEY, 0}.tt == LUA_TDEADKEY, "not enough bits for tt");
-static_assert(TKey{{NULL}, {0, 0}, LUA_TNIL, MAXSIZE - 1}.next == MAXSIZE - 1, "not enough bits for next");
-static_assert(TKey{{NULL}, {0, 0}, LUA_TNIL, -(MAXSIZE - 1)}.next == -(MAXSIZE - 1), "not enough bits for next");
-#else
-// TKey is bitpacked for memory efficiency so we need to validate bit counts for worst case
-static_assert(TKey{{NULL}, 0, LUA_TDEADKEY, 0}.tt == LUA_TDEADKEY, "not enough bits for tt");
-static_assert(TKey{{NULL}, 0, LUA_TNIL, MAXSIZE - 1}.next == MAXSIZE - 1, "not enough bits for next");
-static_assert(TKey{{NULL}, 0, LUA_TNIL, -(MAXSIZE - 1)}.next == -(MAXSIZE - 1), "not enough bits for next");
-#endif
+static_assert(TKey{{NULL}, {0}, LUA_TDEADKEY, 0}.tt == LUA_TDEADKEY, "not enough bits for tt");
+static_assert(TKey{{NULL}, {0}, LUA_TNIL, MAXSIZE - 1}.next == MAXSIZE - 1, "not enough bits for next");
+static_assert(TKey{{NULL}, {0}, LUA_TNIL, -(MAXSIZE - 1)}.next == -(MAXSIZE - 1), "not enough bits for next");
 
 // reset cache of absent metamethods, cache is updated in luaT_gettm
 #define invalidateTMcache(t) t->flags = 0
@@ -102,52 +95,30 @@ static LuaNode* hashnum(const Table* t, double n)
     return hashpow2(t, h2);
 }
 
+static LuaNode* hashvec(const Table* t, const float* v)
+{
+    unsigned int i[LUA_VECTOR_SIZE];
+    memcpy(i, v, sizeof(i));
+
+    for(int j = 0; j < LUA_VECTOR_SIZE; j++)
+    {
+        // convert -0 to 0 to make sure they hash to the same value
+        i[j] = (i[j] == 0x8000000) ? 0 : i[j];
+
+        // scramble bits to make sure that integer coordinates have entropy in lower bits
+        i[j] ^= i[j] >> 17;
+    }
+
+    // Optimized Spatial Hashing for Collision Detection of Deformable Objects
+    static_assert(LUA_VECTOR_SIZE >= 3, "vector size must be 3 or 4 currently");
+    unsigned int h = (i[0] * 73856093) ^ (i[1] * 19349663) ^ (i[2] * 83492791);
+
 #ifdef LUA_FLOAT4_VECTORS
-static LuaNode* hashvec(const Table* t, const float* v)
-{
-    unsigned int i[4];
-    memcpy(i, v, sizeof(i));
-
-    // convert -0 to 0 to make sure they hash to the same value
-    i[0] = (i[0] == 0x8000000) ? 0 : i[0];
-    i[1] = (i[1] == 0x8000000) ? 0 : i[1];
-    i[2] = (i[2] == 0x8000000) ? 0 : i[2];
-    i[3] = (i[3] == 0x8000000) ? 0 : i[3];
-
-    // scramble bits to make sure that integer coordinates have entropy in lower bits
-    i[0] ^= i[0] >> 17;
-    i[1] ^= i[1] >> 17;
-    i[2] ^= i[2] >> 17;
-    i[3] ^= i[3] >> 17;
-
-    // Optimized Spatial Hashing for Collision Detection of Deformable Objects
-    unsigned int h = (i[0] * 73856093) ^ (i[1] * 19349663) ^ (i[2] * 83492791);
     h ^= i[3];  // TODO: proper hashing function for 4D vectors
-    
-    return hashpow2(t, h);
-}
-#else
-static LuaNode* hashvec(const Table* t, const float* v)
-{
-    unsigned int i[3];
-    memcpy(i, v, sizeof(i));
-
-    // convert -0 to 0 to make sure they hash to the same value
-    i[0] = (i[0] == 0x8000000) ? 0 : i[0];
-    i[1] = (i[1] == 0x8000000) ? 0 : i[1];
-    i[2] = (i[2] == 0x8000000) ? 0 : i[2];
-
-    // scramble bits to make sure that integer coordinates have entropy in lower bits
-    i[0] ^= i[0] >> 17;
-    i[1] ^= i[1] >> 17;
-    i[2] ^= i[2] >> 17;
-
-    // Optimized Spatial Hashing for Collision Detection of Deformable Objects
-    unsigned int h = (i[0] * 73856093) ^ (i[1] * 19349663) ^ (i[2] * 83492791);
-
-    return hashpow2(t, h);
-}
 #endif
+
+    return hashpow2(t, h);
+}
 
 /*
 ** returns the `main' position of an element in a table (that is, the index

--- a/VM/src/ltable.cpp
+++ b/VM/src/ltable.cpp
@@ -113,7 +113,7 @@ static LuaNode* hashvec(const Table* t, const float* v)
     // Optimized Spatial Hashing for Collision Detection of Deformable Objects
     unsigned int h = (i[0] * 73856093) ^ (i[1] * 19349663) ^ (i[2] * 83492791);
 
-#ifdef LUA_FLOAT4_VECTORS
+#if LUA_VECTOR_SIZE == 4
     i[3] = (i[3] == 0x8000000) ? 0 : i[3];
     i[3] ^= i[3] >> 17;
     h ^= i[3] * 39916801;

--- a/VM/src/ltable.cpp
+++ b/VM/src/ltable.cpp
@@ -114,7 +114,7 @@ static LuaNode* hashvec(const Table* t, const float* v)
     unsigned int h = (i[0] * 73856093) ^ (i[1] * 19349663) ^ (i[2] * 83492791);
 
 #ifdef LUA_FLOAT4_VECTORS
-    h ^= i[3];  // TODO: proper hashing function for 4D vectors
+    h ^= i[3] * 39916801;
 #endif
 
     return hashpow2(t, h);

--- a/VM/src/ltable.cpp
+++ b/VM/src/ltable.cpp
@@ -97,23 +97,25 @@ static LuaNode* hashnum(const Table* t, double n)
 
 static LuaNode* hashvec(const Table* t, const float* v)
 {
-    unsigned int i[LUA_VECTOR_SIZE];
+    unsigned int i[4];
     memcpy(i, v, sizeof(i));
 
-    for(int j = 0; j < LUA_VECTOR_SIZE; j++)
-    {
-        // convert -0 to 0 to make sure they hash to the same value
-        i[j] = (i[j] == 0x8000000) ? 0 : i[j];
+    // convert -0 to 0 to make sure they hash to the same value
+    i[0] = (i[0] == 0x8000000) ? 0 : i[0];
+    i[1] = (i[1] == 0x8000000) ? 0 : i[1];
+    i[2] = (i[2] == 0x8000000) ? 0 : i[2];
 
-        // scramble bits to make sure that integer coordinates have entropy in lower bits
-        i[j] ^= i[j] >> 17;
-    }
+    // scramble bits to make sure that integer coordinates have entropy in lower bits
+    i[0] ^= i[0] >> 17;
+    i[1] ^= i[1] >> 17;
+    i[2] ^= i[2] >> 17;
 
     // Optimized Spatial Hashing for Collision Detection of Deformable Objects
-    static_assert(LUA_VECTOR_SIZE >= 3, "vector size must be 3 or 4 currently");
     unsigned int h = (i[0] * 73856093) ^ (i[1] * 19349663) ^ (i[2] * 83492791);
 
 #ifdef LUA_FLOAT4_VECTORS
+    i[3] = (i[3] == 0x8000000) ? 0 : i[3];
+    i[3] ^= i[3] >> 17;
     h ^= i[3] * 39916801;
 #endif
 

--- a/VM/src/lvmexecute.cpp
+++ b/VM/src/lvmexecute.cpp
@@ -601,7 +601,7 @@ static void luau_execute(lua_State* L)
                         const char* name = getstr(tsvalue(kv));
                         int ic = (name[0] | ' ') - 'x';
 
-#ifdef LUA_FLOAT4_VECTORS
+#if LUA_VECTOR_SIZE == 4
                         // 'w' is before 'x' in ascii, so ic is -1 when indexing with 'w'
                         if (ic == -1)
                             ic = 3;

--- a/VM/src/lvmexecute.cpp
+++ b/VM/src/lvmexecute.cpp
@@ -602,7 +602,8 @@ static void luau_execute(lua_State* L)
                         int ic = (name[0] | ' ') - 'x';
 
 #ifdef LUA_FLOAT4_VECTORS
-                        if(name[0] == 'w')
+                        // 'w' is before 'x' in ascii, so ic is -1 when the string is 'w'
+                        if (ic == -1)
                             ic = 3;
 #endif
 

--- a/VM/src/lvmexecute.cpp
+++ b/VM/src/lvmexecute.cpp
@@ -604,11 +604,9 @@ static void luau_execute(lua_State* L)
 #ifdef LUA_FLOAT4_VECTORS
                         if(name[0] == 'w')
                             ic = 3;
-
-                        if (unsigned(ic) < 4 && name[1] == '\0')
-#else
-                        if (unsigned(ic) < 3 && name[1] == '\0')
 #endif
+
+                        if (unsigned(ic) < LUA_VECTOR_SIZE && name[1] == '\0')
                         {
                             setnvalue(ra, rb->value.v[ic]);
                             VM_NEXT();
@@ -1533,11 +1531,9 @@ static void luau_execute(lua_State* L)
                 {
                     const float* vb = rb->value.v;
                     const float* vc = rc->value.v;
-#ifdef LUA_FLOAT4_VECTORS
-                    setvvalue(ra, vb[0] + vc[0], vb[1] + vc[1], vb[2] + vc[2], vb[3] + vc[3]);
-#else
-                    setvvalue(ra, vb[0] + vc[0], vb[1] + vc[1], vb[2] + vc[2]);
-#endif
+                    for (int i = 0; i < LUA_VECTOR_SIZE; i++)
+                        ra->value.v[i] = vb[i] + vc[i];
+                    setttype(ra, LUA_TVECTOR);
                     VM_NEXT();
                 }
                 else
@@ -1583,11 +1579,9 @@ static void luau_execute(lua_State* L)
                 {
                     const float* vb = rb->value.v;
                     const float* vc = rc->value.v;
-#ifdef LUA_FLOAT4_VECTORS
-                    setvvalue(ra, vb[0] - vc[0], vb[1] - vc[1], vb[2] - vc[2], vb[3] - vc[3]);
-#else
-                    setvvalue(ra, vb[0] - vc[0], vb[1] - vc[1], vb[2] - vc[2]);
-#endif
+                    for (int i = 0; i < LUA_VECTOR_SIZE; i++)
+                        ra->value.v[i] = vb[i] - vc[i];
+                    setttype(ra, LUA_TVECTOR);
                     VM_NEXT();
                 }
                 else
@@ -1633,33 +1627,27 @@ static void luau_execute(lua_State* L)
                 {
                     const float* vb = rb->value.v;
                     float vc = cast_to(float, nvalue(rc));
-#ifdef LUA_FLOAT4_VECTORS
-                    setvvalue(ra, vb[0] * vc, vb[1] * vc, vb[2] * vc, vb[2] * vc);
-#else
-                    setvvalue(ra, vb[0] * vc, vb[1] * vc, vb[2] * vc);
-#endif
+                    for (int i = 0; i < LUA_VECTOR_SIZE; i++)
+                        ra->value.v[i] = vb[i] * vc;
+                    setttype(ra, LUA_TVECTOR);
                     VM_NEXT();
                 }
                 else if (ttisvector(rb) && ttisvector(rc))
                 {
                     const float* vb = rb->value.v;
                     const float* vc = rc->value.v;
-#ifdef LUA_FLOAT4_VECTORS
-                    setvvalue(ra, vb[0] * vc[0], vb[1] * vc[1], vb[2] * vc[2], vb[3] * vc[3]);
-#else
-                    setvvalue(ra, vb[0] * vc[0], vb[1] * vc[1], vb[2] * vc[2]);
-#endif
+                    for (int i = 0; i < LUA_VECTOR_SIZE; i++)
+                        ra->value.v[i] = vb[i] * vc[i];
+                    setttype(ra, LUA_TVECTOR);
                     VM_NEXT();
                 }
                 else if (ttisnumber(rb) && ttisvector(rc))
                 {
                     float vb = cast_to(float, nvalue(rb));
                     const float* vc = rc->value.v;
-#ifdef LUA_FLOAT4_VECTORS
-                    setvvalue(ra, vb * vc[0], vb * vc[1], vb * vc[2], vb * vc[3]);
-#else
-                    setvvalue(ra, vb * vc[0], vb * vc[1], vb * vc[2]);
-#endif
+                    for (int i = 0; i < LUA_VECTOR_SIZE; i++)
+                        ra->value.v[i] = vb + vc[i];
+                    setttype(ra, LUA_TVECTOR);
                     VM_NEXT();
                 }
                 else
@@ -1706,33 +1694,27 @@ static void luau_execute(lua_State* L)
                 {
                     const float* vb = rb->value.v;
                     float vc = cast_to(float, nvalue(rc));
-#ifdef LUA_FLOAT4_VECTORS
-                    setvvalue(ra, vb[0] / vc, vb[1] / vc, vb[2] / vc, vb[3] / vc);
-#else
-                    setvvalue(ra, vb[0] / vc, vb[1] / vc, vb[2] / vc);
-#endif
+                    for (int i = 0; i < LUA_VECTOR_SIZE; i++)
+                        ra->value.v[i] = vb[i] / vc;
+                    setttype(ra, LUA_TVECTOR);
                     VM_NEXT();
                 }
                 else if (ttisvector(rb) && ttisvector(rc))
                 {
                     const float* vb = rb->value.v;
                     const float* vc = rc->value.v;
-#ifdef LUA_FLOAT4_VECTORS
-                    setvvalue(ra, vb[0] / vc[0], vb[1] / vc[1], vb[2] / vc[2], vb[3] / vc[3]);
-#else
-                    setvvalue(ra, vb[0] / vc[0], vb[1] / vc[1], vb[2] / vc[2]);
-#endif
+                    for (int i = 0; i < LUA_VECTOR_SIZE; i++)
+                        ra->value.v[i] = vb[i] / vc[i];
+                    setttype(ra, LUA_TVECTOR);
                     VM_NEXT();
                 }
                 else if (ttisnumber(rb) && ttisvector(rc))
                 {
                     float vb = cast_to(float, nvalue(rb));
                     const float* vc = rc->value.v;
-#ifdef LUA_FLOAT4_VECTORS
-                    setvvalue(ra, vb / vc[0], vb / vc[1], vb / vc[2], vb / vc[3]);
-#else
-                    setvvalue(ra, vb / vc[0], vb / vc[1], vb / vc[2]);
-#endif
+                    for (int i = 0; i < LUA_VECTOR_SIZE; i++)
+                        ra->value.v[i] = vb / vc[i];
+                    setttype(ra, LUA_TVECTOR);
                     VM_NEXT();
                 }
                 else
@@ -1865,11 +1847,9 @@ static void luau_execute(lua_State* L)
                 {
                     const float* vb = rb->value.v;
                     float vc = cast_to(float, nvalue(kv));
-#ifdef LUA_FLOAT4_VECTORS
-                    setvvalue(ra, vb[0] * vc, vb[1] * vc, vb[2] * vc, vb[3] * vc);
-#else
-                    setvvalue(ra, vb[0] * vc, vb[1] * vc, vb[2] * vc);
-#endif
+                    for (int i = 0; i < LUA_VECTOR_SIZE; i++)
+                        ra->value.v[i] = vb[i] * vc;
+                    setttype(ra, LUA_TVECTOR);
                     VM_NEXT();
                 }
                 else
@@ -1915,11 +1895,9 @@ static void luau_execute(lua_State* L)
                 {
                     const float* vb = rb->value.v;
                     float vc = cast_to(float, nvalue(kv));
-#ifdef LUA_FLOAT4_VECTORS
-                    setvvalue(ra, vb[0] / vc, vb[1] / vc, vb[2] / vc, vb[3] / vc);
-#else
-                    setvvalue(ra, vb[0] / vc, vb[1] / vc, vb[2] / vc);
-#endif
+                    for (int i = 0; i < LUA_VECTOR_SIZE; i++)
+                        ra->value.v[i] = vb[i] / vc;
+                    setttype(ra, LUA_TVECTOR);
                     VM_NEXT();
                 }
                 else
@@ -2084,11 +2062,9 @@ static void luau_execute(lua_State* L)
                 else if (ttisvector(rb))
                 {
                     const float* vb = rb->value.v;
-#ifdef LUA_FLOAT4_VECTORS
-                    setvvalue(ra, -vb[0], -vb[1], -vb[2], -vb[3]);
-#else
-                    setvvalue(ra, -vb[0], -vb[1], -vb[2]);
-#endif
+                    for (int i = 0; i < LUA_VECTOR_SIZE; i++)
+                        ra->value.v[i] = -vb[i];
+                    setttype(ra, LUA_TVECTOR);
                     VM_NEXT();
                 }
                 else

--- a/VM/src/lvmexecute.cpp
+++ b/VM/src/lvmexecute.cpp
@@ -1646,7 +1646,7 @@ static void luau_execute(lua_State* L)
                     float vb = cast_to(float, nvalue(rb));
                     const float* vc = rc->value.v;
                     for (int i = 0; i < LUA_VECTOR_SIZE; i++)
-                        ra->value.v[i] = vb + vc[i];
+                        ra->value.v[i] = vb * vc[i];
                     setttype(ra, LUA_TVECTOR);
                     VM_NEXT();
                 }

--- a/VM/src/lvmexecute.cpp
+++ b/VM/src/lvmexecute.cpp
@@ -601,7 +601,14 @@ static void luau_execute(lua_State* L)
                         const char* name = getstr(tsvalue(kv));
                         int ic = (name[0] | ' ') - 'x';
 
+#ifdef LUA_FLOAT4_VECTORS
+                        if(name[0] == 'w')
+                            ic = 3;
+
+                        if (unsigned(ic) < 4 && name[1] == '\0')
+#else
                         if (unsigned(ic) < 3 && name[1] == '\0')
+#endif
                         {
                             setnvalue(ra, rb->value.v[ic]);
                             VM_NEXT();
@@ -1526,7 +1533,11 @@ static void luau_execute(lua_State* L)
                 {
                     const float* vb = rb->value.v;
                     const float* vc = rc->value.v;
+#ifdef LUA_FLOAT4_VECTORS
+                    setvvalue(ra, vb[0] + vc[0], vb[1] + vc[1], vb[2] + vc[2], vb[3] + vc[3]);
+#else
                     setvvalue(ra, vb[0] + vc[0], vb[1] + vc[1], vb[2] + vc[2]);
+#endif
                     VM_NEXT();
                 }
                 else
@@ -1572,7 +1583,11 @@ static void luau_execute(lua_State* L)
                 {
                     const float* vb = rb->value.v;
                     const float* vc = rc->value.v;
+#ifdef LUA_FLOAT4_VECTORS
+                    setvvalue(ra, vb[0] - vc[0], vb[1] - vc[1], vb[2] - vc[2], vb[3] - vc[3]);
+#else
                     setvvalue(ra, vb[0] - vc[0], vb[1] - vc[1], vb[2] - vc[2]);
+#endif
                     VM_NEXT();
                 }
                 else
@@ -1618,21 +1633,33 @@ static void luau_execute(lua_State* L)
                 {
                     const float* vb = rb->value.v;
                     float vc = cast_to(float, nvalue(rc));
+#ifdef LUA_FLOAT4_VECTORS
+                    setvvalue(ra, vb[0] * vc, vb[1] * vc, vb[2] * vc, vb[2] * vc);
+#else
                     setvvalue(ra, vb[0] * vc, vb[1] * vc, vb[2] * vc);
+#endif
                     VM_NEXT();
                 }
                 else if (ttisvector(rb) && ttisvector(rc))
                 {
                     const float* vb = rb->value.v;
                     const float* vc = rc->value.v;
+#ifdef LUA_FLOAT4_VECTORS
+                    setvvalue(ra, vb[0] * vc[0], vb[1] * vc[1], vb[2] * vc[2], vb[3] * vc[3]);
+#else
                     setvvalue(ra, vb[0] * vc[0], vb[1] * vc[1], vb[2] * vc[2]);
+#endif
                     VM_NEXT();
                 }
                 else if (ttisnumber(rb) && ttisvector(rc))
                 {
                     float vb = cast_to(float, nvalue(rb));
                     const float* vc = rc->value.v;
+#ifdef LUA_FLOAT4_VECTORS
+                    setvvalue(ra, vb * vc[0], vb * vc[1], vb * vc[2], vb * vc[3]);
+#else
                     setvvalue(ra, vb * vc[0], vb * vc[1], vb * vc[2]);
+#endif
                     VM_NEXT();
                 }
                 else
@@ -1679,21 +1706,33 @@ static void luau_execute(lua_State* L)
                 {
                     const float* vb = rb->value.v;
                     float vc = cast_to(float, nvalue(rc));
+#ifdef LUA_FLOAT4_VECTORS
+                    setvvalue(ra, vb[0] / vc, vb[1] / vc, vb[2] / vc, vb[3] / vc);
+#else
                     setvvalue(ra, vb[0] / vc, vb[1] / vc, vb[2] / vc);
+#endif
                     VM_NEXT();
                 }
                 else if (ttisvector(rb) && ttisvector(rc))
                 {
                     const float* vb = rb->value.v;
                     const float* vc = rc->value.v;
+#ifdef LUA_FLOAT4_VECTORS
+                    setvvalue(ra, vb[0] / vc[0], vb[1] / vc[1], vb[2] / vc[2], vb[3] / vc[3]);
+#else
                     setvvalue(ra, vb[0] / vc[0], vb[1] / vc[1], vb[2] / vc[2]);
+#endif
                     VM_NEXT();
                 }
                 else if (ttisnumber(rb) && ttisvector(rc))
                 {
                     float vb = cast_to(float, nvalue(rb));
                     const float* vc = rc->value.v;
+#ifdef LUA_FLOAT4_VECTORS
+                    setvvalue(ra, vb / vc[0], vb / vc[1], vb / vc[2], vb / vc[3]);
+#else
                     setvvalue(ra, vb / vc[0], vb / vc[1], vb / vc[2]);
+#endif
                     VM_NEXT();
                 }
                 else
@@ -1826,7 +1865,11 @@ static void luau_execute(lua_State* L)
                 {
                     const float* vb = rb->value.v;
                     float vc = cast_to(float, nvalue(kv));
+#ifdef LUA_FLOAT4_VECTORS
+                    setvvalue(ra, vb[0] * vc, vb[1] * vc, vb[2] * vc, vb[3] * vc);
+#else
                     setvvalue(ra, vb[0] * vc, vb[1] * vc, vb[2] * vc);
+#endif
                     VM_NEXT();
                 }
                 else
@@ -1872,7 +1915,11 @@ static void luau_execute(lua_State* L)
                 {
                     const float* vb = rb->value.v;
                     float vc = cast_to(float, nvalue(kv));
+#ifdef LUA_FLOAT4_VECTORS
+                    setvvalue(ra, vb[0] / vc, vb[1] / vc, vb[2] / vc, vb[3] / vc);
+#else
                     setvvalue(ra, vb[0] / vc, vb[1] / vc, vb[2] / vc);
+#endif
                     VM_NEXT();
                 }
                 else
@@ -2037,7 +2084,11 @@ static void luau_execute(lua_State* L)
                 else if (ttisvector(rb))
                 {
                     const float* vb = rb->value.v;
+#ifdef LUA_FLOAT4_VECTORS
+                    setvvalue(ra, -vb[0], -vb[1], -vb[2], -vb[3]);
+#else
                     setvvalue(ra, -vb[0], -vb[1], -vb[2]);
+#endif
                     VM_NEXT();
                 }
                 else

--- a/VM/src/lvmexecute.cpp
+++ b/VM/src/lvmexecute.cpp
@@ -602,7 +602,7 @@ static void luau_execute(lua_State* L)
                         int ic = (name[0] | ' ') - 'x';
 
 #ifdef LUA_FLOAT4_VECTORS
-                        // 'w' is before 'x' in ascii, so ic is -1 when the string is 'w'
+                        // 'w' is before 'x' in ascii, so ic is -1 when indexing with 'w'
                         if (ic == -1)
                             ic = 3;
 #endif
@@ -1532,9 +1532,7 @@ static void luau_execute(lua_State* L)
                 {
                     const float* vb = rb->value.v;
                     const float* vc = rc->value.v;
-                    for (int i = 0; i < LUA_VECTOR_SIZE; i++)
-                        ra->value.v[i] = vb[i] + vc[i];
-                    setttype(ra, LUA_TVECTOR);
+                    setvvalue(ra, vb[0] + vc[0], vb[1] + vc[1], vb[2] + vc[2], vb[3] + vc[3]);
                     VM_NEXT();
                 }
                 else
@@ -1580,9 +1578,7 @@ static void luau_execute(lua_State* L)
                 {
                     const float* vb = rb->value.v;
                     const float* vc = rc->value.v;
-                    for (int i = 0; i < LUA_VECTOR_SIZE; i++)
-                        ra->value.v[i] = vb[i] - vc[i];
-                    setttype(ra, LUA_TVECTOR);
+                    setvvalue(ra, vb[0] - vc[0], vb[1] - vc[1], vb[2] - vc[2], vb[3] - vc[3]);
                     VM_NEXT();
                 }
                 else
@@ -1628,27 +1624,21 @@ static void luau_execute(lua_State* L)
                 {
                     const float* vb = rb->value.v;
                     float vc = cast_to(float, nvalue(rc));
-                    for (int i = 0; i < LUA_VECTOR_SIZE; i++)
-                        ra->value.v[i] = vb[i] * vc;
-                    setttype(ra, LUA_TVECTOR);
+                    setvvalue(ra, vb[0] * vc, vb[1] * vc, vb[2] * vc, vb[3] * vc);
                     VM_NEXT();
                 }
                 else if (ttisvector(rb) && ttisvector(rc))
                 {
                     const float* vb = rb->value.v;
                     const float* vc = rc->value.v;
-                    for (int i = 0; i < LUA_VECTOR_SIZE; i++)
-                        ra->value.v[i] = vb[i] * vc[i];
-                    setttype(ra, LUA_TVECTOR);
+                    setvvalue(ra, vb[0] * vc[0], vb[1] * vc[1], vb[2] * vc[2], vb[3] * vc[3]);
                     VM_NEXT();
                 }
                 else if (ttisnumber(rb) && ttisvector(rc))
                 {
                     float vb = cast_to(float, nvalue(rb));
                     const float* vc = rc->value.v;
-                    for (int i = 0; i < LUA_VECTOR_SIZE; i++)
-                        ra->value.v[i] = vb * vc[i];
-                    setttype(ra, LUA_TVECTOR);
+                    setvvalue(ra, vb * vc[0], vb * vc[1], vb * vc[2], vb * vc[3]);
                     VM_NEXT();
                 }
                 else
@@ -1695,27 +1685,21 @@ static void luau_execute(lua_State* L)
                 {
                     const float* vb = rb->value.v;
                     float vc = cast_to(float, nvalue(rc));
-                    for (int i = 0; i < LUA_VECTOR_SIZE; i++)
-                        ra->value.v[i] = vb[i] / vc;
-                    setttype(ra, LUA_TVECTOR);
+                    setvvalue(ra, vb[0] / vc, vb[1] / vc, vb[2] / vc, vb[3] / vc);
                     VM_NEXT();
                 }
                 else if (ttisvector(rb) && ttisvector(rc))
                 {
                     const float* vb = rb->value.v;
                     const float* vc = rc->value.v;
-                    for (int i = 0; i < LUA_VECTOR_SIZE; i++)
-                        ra->value.v[i] = vb[i] / vc[i];
-                    setttype(ra, LUA_TVECTOR);
+                    setvvalue(ra, vb[0] / vc[0], vb[1] / vc[1], vb[2] / vc[2], vb[3] / vc[3]);
                     VM_NEXT();
                 }
                 else if (ttisnumber(rb) && ttisvector(rc))
                 {
                     float vb = cast_to(float, nvalue(rb));
                     const float* vc = rc->value.v;
-                    for (int i = 0; i < LUA_VECTOR_SIZE; i++)
-                        ra->value.v[i] = vb / vc[i];
-                    setttype(ra, LUA_TVECTOR);
+                    setvvalue(ra, vb / vc[0], vb / vc[1], vb / vc[2], vb / vc[3]);
                     VM_NEXT();
                 }
                 else
@@ -1848,9 +1832,7 @@ static void luau_execute(lua_State* L)
                 {
                     const float* vb = rb->value.v;
                     float vc = cast_to(float, nvalue(kv));
-                    for (int i = 0; i < LUA_VECTOR_SIZE; i++)
-                        ra->value.v[i] = vb[i] * vc;
-                    setttype(ra, LUA_TVECTOR);
+                    setvvalue(ra, vb[0] * vc, vb[1] * vc, vb[2] * vc, vb[3] * vc);
                     VM_NEXT();
                 }
                 else
@@ -1896,9 +1878,7 @@ static void luau_execute(lua_State* L)
                 {
                     const float* vb = rb->value.v;
                     float vc = cast_to(float, nvalue(kv));
-                    for (int i = 0; i < LUA_VECTOR_SIZE; i++)
-                        ra->value.v[i] = vb[i] / vc;
-                    setttype(ra, LUA_TVECTOR);
+                    setvvalue(ra, vb[0] / vc, vb[1] / vc, vb[2] / vc, vb[3] / vc);
                     VM_NEXT();
                 }
                 else
@@ -2063,9 +2043,7 @@ static void luau_execute(lua_State* L)
                 else if (ttisvector(rb))
                 {
                     const float* vb = rb->value.v;
-                    for (int i = 0; i < LUA_VECTOR_SIZE; i++)
-                        ra->value.v[i] = -vb[i];
-                    setttype(ra, LUA_TVECTOR);
+                    setvvalue(ra, -vb[0], -vb[1], -vb[2], -vb[3]);
                     VM_NEXT();
                 }
                 else

--- a/VM/src/lvmutils.cpp
+++ b/VM/src/lvmutils.cpp
@@ -398,29 +398,22 @@ void luaV_doarith(lua_State* L, StkId ra, const TValue* rb, const TValue* rc, TM
 
         if (vb && vc)
         {
-            setttype(ra, LUA_TVECTOR);
-
             switch (op)
             {
             case TM_ADD:
-                for (int i = 0; i < LUA_VECTOR_SIZE; i++)
-                    ra->value.v[i] = vb[i] + vc[i];
+                setvvalue(ra, vb[0] + vc[0], vb[1] + vc[1], vb[2] + vc[2], vb[3] + vc[3]);
                 return;
             case TM_SUB:
-                for (int i = 0; i < LUA_VECTOR_SIZE; i++)
-                    ra->value.v[i] = vb[i] - vc[i];
+                setvvalue(ra, vb[0] - vc[0], vb[1] - vc[1], vb[2] - vc[2], vb[3] - vc[3]);
                 return;
             case TM_MUL:
-                for (int i = 0; i < LUA_VECTOR_SIZE; i++)
-                    ra->value.v[i] = vb[i] * vc[i];
+                setvvalue(ra, vb[0] * vc[0], vb[1] * vc[1], vb[2] * vc[2], vb[3] * vc[3]);
                 return;
             case TM_DIV:
-                for (int i = 0; i < LUA_VECTOR_SIZE; i++)
-                    ra->value.v[i] = vb[i] / vc[i];
+                setvvalue(ra, vb[0] / vc[0], vb[1] / vc[1], vb[2] / vc[2], vb[3] / vc[3]);
                 return;
             case TM_UNM:
-                for (int i = 0; i < LUA_VECTOR_SIZE; i++)
-                    ra->value.v[i] = -vb[i];
+                setvvalue(ra, -vb[0], -vb[1], -vb[2], -vb[3]);
                 return;
             default:
                 break;
@@ -433,17 +426,14 @@ void luaV_doarith(lua_State* L, StkId ra, const TValue* rb, const TValue* rc, TM
             if (c)
             {
                 float nc = cast_to(float, nvalue(c));
-                setttype(ra, LUA_TVECTOR);
 
                 switch (op)
                 {
                 case TM_MUL:
-                    for (int i = 0; i < LUA_VECTOR_SIZE; i++)
-                        ra->value.v[i] = vb[i] * nc;
+                    setvvalue(ra, vb[0] * nc, vb[1] * nc, vb[2] * nc, vb[3] * nc);
                     return;
                 case TM_DIV:
-                    for (int i = 0; i < LUA_VECTOR_SIZE; i++)
-                        ra->value.v[i] = vb[i] / nc;
+                    setvvalue(ra, vb[0] / nc, vb[1] / nc, vb[2] / nc, vb[3] / nc);
                     return;
                 default:
                     break;
@@ -457,17 +447,14 @@ void luaV_doarith(lua_State* L, StkId ra, const TValue* rb, const TValue* rc, TM
             if (b)
             {
                 float nb = cast_to(float, nvalue(b));
-                setttype(ra, LUA_TVECTOR);
 
                 switch (op)
                 {
                 case TM_MUL:
-                    for (int i = 0; i < LUA_VECTOR_SIZE; i++)
-                        ra->value.v[i] = nb * vc[i];
+                    setvvalue(ra, nb * vc[0], nb * vc[1], nb * vc[2], nb * vc[3]);
                     return;
                 case TM_DIV:
-                    for (int i = 0; i < LUA_VECTOR_SIZE; i++)
-                        ra->value.v[i] = nb / vc[i];
+                    setvvalue(ra, nb / vc[0], nb / vc[1], nb / vc[2], nb / vc[3]);
                     return;
                 default:
                     break;

--- a/VM/src/lvmutils.cpp
+++ b/VM/src/lvmutils.cpp
@@ -398,6 +398,28 @@ void luaV_doarith(lua_State* L, StkId ra, const TValue* rb, const TValue* rc, TM
 
         if (vb && vc)
         {
+#ifdef LUA_FLOAT4_VECTORS
+            switch (op)
+            {
+            case TM_ADD:
+                setvvalue(ra, vb[0] + vc[0], vb[1] + vc[1], vb[2] + vc[2], vb[3] + vc[3]);
+                return;
+            case TM_SUB:
+                setvvalue(ra, vb[0] - vc[0], vb[1] - vc[1], vb[2] - vc[2], vb[2] - vc[2]);
+                return;
+            case TM_MUL:
+                setvvalue(ra, vb[0] * vc[0], vb[1] * vc[1], vb[2] * vc[2], vb[2] * vc[2]);
+                return;
+            case TM_DIV:
+                setvvalue(ra, vb[0] / vc[0], vb[1] / vc[1], vb[2] / vc[2], vb[2] / vc[2]);
+                return;
+            case TM_UNM:
+                setvvalue(ra, -vb[0], -vb[1], -vb[2], -vb[3]);
+                return;
+            default:
+                break;
+            }
+#else
             switch (op)
             {
             case TM_ADD:
@@ -418,6 +440,7 @@ void luaV_doarith(lua_State* L, StkId ra, const TValue* rb, const TValue* rc, TM
             default:
                 break;
             }
+#endif
         }
         else if (vb)
         {
@@ -426,7 +449,19 @@ void luaV_doarith(lua_State* L, StkId ra, const TValue* rb, const TValue* rc, TM
             if (c)
             {
                 float nc = cast_to(float, nvalue(c));
-
+#ifdef LUA_FLOAT4_VECTORS
+                switch (op)
+                {
+                case TM_MUL:
+                    setvvalue(ra, vb[0] * nc, vb[1] * nc, vb[2] * nc, vb[3] * nc);
+                    return;
+                case TM_DIV:
+                    setvvalue(ra, vb[0] / nc, vb[1] / nc, vb[2] / nc, vb[3] / nc);
+                    return;
+                default:
+                    break;
+                }
+#else
                 switch (op)
                 {
                 case TM_MUL:
@@ -438,6 +473,7 @@ void luaV_doarith(lua_State* L, StkId ra, const TValue* rb, const TValue* rc, TM
                 default:
                     break;
                 }
+#endif
             }
         }
         else if (vc)
@@ -447,7 +483,19 @@ void luaV_doarith(lua_State* L, StkId ra, const TValue* rb, const TValue* rc, TM
             if (b)
             {
                 float nb = cast_to(float, nvalue(b));
-
+#ifdef LUA_FLOAT4_VECTORS
+                switch (op)
+                {
+                case TM_MUL:
+                    setvvalue(ra, nb * vc[0], nb * vc[1], nb * vc[2], nb * vc[3]);
+                    return;
+                case TM_DIV:
+                    setvvalue(ra, nb / vc[0], nb / vc[1], nb / vc[2], nb / vc[2]);
+                    return;
+                default:
+                    break;
+                }
+#else
                 switch (op)
                 {
                 case TM_MUL:
@@ -459,6 +507,7 @@ void luaV_doarith(lua_State* L, StkId ra, const TValue* rb, const TValue* rc, TM
                 default:
                     break;
                 }
+#endif
             }
         }
 

--- a/VM/src/lvmutils.cpp
+++ b/VM/src/lvmutils.cpp
@@ -398,49 +398,33 @@ void luaV_doarith(lua_State* L, StkId ra, const TValue* rb, const TValue* rc, TM
 
         if (vb && vc)
         {
-#ifdef LUA_FLOAT4_VECTORS
             switch (op)
             {
             case TM_ADD:
-                setvvalue(ra, vb[0] + vc[0], vb[1] + vc[1], vb[2] + vc[2], vb[3] + vc[3]);
+                for (int i = 0; i < LUA_VECTOR_SIZE; i++)
+                    ra->value.v[i] = vb[i] + vc[i];
                 return;
             case TM_SUB:
-                setvvalue(ra, vb[0] - vc[0], vb[1] - vc[1], vb[2] - vc[2], vb[2] - vc[2]);
+                for (int i = 0; i < LUA_VECTOR_SIZE; i++)
+                    ra->value.v[i] = vb[i] - vc[i];
                 return;
             case TM_MUL:
-                setvvalue(ra, vb[0] * vc[0], vb[1] * vc[1], vb[2] * vc[2], vb[2] * vc[2]);
+                for (int i = 0; i < LUA_VECTOR_SIZE; i++)
+                    ra->value.v[i] = vb[i] * vc[i];
                 return;
             case TM_DIV:
-                setvvalue(ra, vb[0] / vc[0], vb[1] / vc[1], vb[2] / vc[2], vb[2] / vc[2]);
+                for (int i = 0; i < LUA_VECTOR_SIZE; i++)
+                    ra->value.v[i] = vb[i] / vc[i];
                 return;
             case TM_UNM:
-                setvvalue(ra, -vb[0], -vb[1], -vb[2], -vb[3]);
+                for (int i = 0; i < LUA_VECTOR_SIZE; i++)
+                    ra->value.v[i] = -vb[i];
                 return;
             default:
                 break;
             }
-#else
-            switch (op)
-            {
-            case TM_ADD:
-                setvvalue(ra, vb[0] + vc[0], vb[1] + vc[1], vb[2] + vc[2]);
-                return;
-            case TM_SUB:
-                setvvalue(ra, vb[0] - vc[0], vb[1] - vc[1], vb[2] - vc[2]);
-                return;
-            case TM_MUL:
-                setvvalue(ra, vb[0] * vc[0], vb[1] * vc[1], vb[2] * vc[2]);
-                return;
-            case TM_DIV:
-                setvvalue(ra, vb[0] / vc[0], vb[1] / vc[1], vb[2] / vc[2]);
-                return;
-            case TM_UNM:
-                setvvalue(ra, -vb[0], -vb[1], -vb[2]);
-                return;
-            default:
-                break;
-            }
-#endif
+
+            setttype(ra, LUA_TVECTOR);
         }
         else if (vb)
         {
@@ -449,31 +433,20 @@ void luaV_doarith(lua_State* L, StkId ra, const TValue* rb, const TValue* rc, TM
             if (c)
             {
                 float nc = cast_to(float, nvalue(c));
-#ifdef LUA_FLOAT4_VECTORS
                 switch (op)
                 {
                 case TM_MUL:
-                    setvvalue(ra, vb[0] * nc, vb[1] * nc, vb[2] * nc, vb[3] * nc);
+                    for (int i = 0; i < LUA_VECTOR_SIZE; i++)
+                        ra->value.v[i] = vb[i] * nc;
                     return;
                 case TM_DIV:
-                    setvvalue(ra, vb[0] / nc, vb[1] / nc, vb[2] / nc, vb[3] / nc);
+                    for (int i = 0; i < LUA_VECTOR_SIZE; i++)
+                        ra->value.v[i] = vb[i] / nc;
                     return;
                 default:
                     break;
                 }
-#else
-                switch (op)
-                {
-                case TM_MUL:
-                    setvvalue(ra, vb[0] * nc, vb[1] * nc, vb[2] * nc);
-                    return;
-                case TM_DIV:
-                    setvvalue(ra, vb[0] / nc, vb[1] / nc, vb[2] / nc);
-                    return;
-                default:
-                    break;
-                }
-#endif
+                setttype(ra, LUA_TVECTOR);
             }
         }
         else if (vc)
@@ -483,31 +456,20 @@ void luaV_doarith(lua_State* L, StkId ra, const TValue* rb, const TValue* rc, TM
             if (b)
             {
                 float nb = cast_to(float, nvalue(b));
-#ifdef LUA_FLOAT4_VECTORS
                 switch (op)
                 {
                 case TM_MUL:
-                    setvvalue(ra, nb * vc[0], nb * vc[1], nb * vc[2], nb * vc[3]);
+                    for (int i = 0; i < LUA_VECTOR_SIZE; i++)
+                        ra->value.v[i] = nb * vc[i];
                     return;
                 case TM_DIV:
-                    setvvalue(ra, nb / vc[0], nb / vc[1], nb / vc[2], nb / vc[2]);
+                    for (int i = 0; i < LUA_VECTOR_SIZE; i++)
+                        ra->value.v[i] = nb / vc[i];
                     return;
                 default:
                     break;
                 }
-#else
-                switch (op)
-                {
-                case TM_MUL:
-                    setvvalue(ra, nb * vc[0], nb * vc[1], nb * vc[2]);
-                    return;
-                case TM_DIV:
-                    setvvalue(ra, nb / vc[0], nb / vc[1], nb / vc[2]);
-                    return;
-                default:
-                    break;
-                }
-#endif
+                setttype(ra, LUA_TVECTOR);
             }
         }
 

--- a/VM/src/lvmutils.cpp
+++ b/VM/src/lvmutils.cpp
@@ -398,6 +398,8 @@ void luaV_doarith(lua_State* L, StkId ra, const TValue* rb, const TValue* rc, TM
 
         if (vb && vc)
         {
+            setttype(ra, LUA_TVECTOR);
+
             switch (op)
             {
             case TM_ADD:
@@ -423,8 +425,6 @@ void luaV_doarith(lua_State* L, StkId ra, const TValue* rb, const TValue* rc, TM
             default:
                 break;
             }
-
-            setttype(ra, LUA_TVECTOR);
         }
         else if (vb)
         {
@@ -433,6 +433,8 @@ void luaV_doarith(lua_State* L, StkId ra, const TValue* rb, const TValue* rc, TM
             if (c)
             {
                 float nc = cast_to(float, nvalue(c));
+                setttype(ra, LUA_TVECTOR);
+
                 switch (op)
                 {
                 case TM_MUL:
@@ -446,7 +448,6 @@ void luaV_doarith(lua_State* L, StkId ra, const TValue* rb, const TValue* rc, TM
                 default:
                     break;
                 }
-                setttype(ra, LUA_TVECTOR);
             }
         }
         else if (vc)
@@ -456,6 +457,8 @@ void luaV_doarith(lua_State* L, StkId ra, const TValue* rb, const TValue* rc, TM
             if (b)
             {
                 float nb = cast_to(float, nvalue(b));
+                setttype(ra, LUA_TVECTOR);
+
                 switch (op)
                 {
                 case TM_MUL:
@@ -469,7 +472,6 @@ void luaV_doarith(lua_State* L, StkId ra, const TValue* rb, const TValue* rc, TM
                 default:
                     break;
                 }
-                setttype(ra, LUA_TVECTOR);
             }
         }
 

--- a/tests/Conformance.test.cpp
+++ b/tests/Conformance.test.cpp
@@ -64,7 +64,12 @@ static int lua_vector(lua_State* L)
     double y = luaL_checknumber(L, 2);
     double z = luaL_checknumber(L, 3);
 
+#if LUA_VECTOR_SIZE == 4
+    double w = luaL_optnumber(L, 4, 0.0);
+    lua_pushvector(L, float(x), float(y), float(z), float(w));
+#else
     lua_pushvector(L, float(x), float(y), float(z));
+#endif
     return 1;
 }
 
@@ -366,11 +371,17 @@ TEST_CASE("Pack")
 
 TEST_CASE("Vector")
 {
+    ScopedFastFlag sff{"LuauIfElseExpressionBaseSupport", true};
+
     runConformance("vector.lua", [](lua_State* L) {
         lua_pushcfunction(L, lua_vector);
         lua_setglobal(L, "vector");
 
+#if LUA_VECTOR_SIZE == 4
+        lua_pushvector(L, 0.0f, 0.0f, 0.0f, 0.0f);
+#else
         lua_pushvector(L, 0.0f, 0.0f, 0.0f);
+#endif
         luaL_newmetatable(L, "vector");
 
         lua_pushstring(L, "__index");

--- a/tests/conformance/vector.lua
+++ b/tests/conformance/vector.lua
@@ -1,6 +1,9 @@
 -- This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
 print('testing vectors')
 
+-- detect vector size
+local vector_size = if pcall(function() return vector(0, 0, 0).w end) then 4 else 3
+
 -- equality
 assert(vector(1, 2, 3) == vector(1, 2, 3))
 assert(vector(0, 1, 2) == vector(-0, 1, 2))
@@ -13,8 +16,14 @@ assert(not rawequal(vector(1, 2, 3), vector(1, 2, 4)))
 
 -- type & tostring
 assert(type(vector(1, 2, 3)) == "vector")
-assert(tostring(vector(1, 2, 3)) == "1, 2, 3")
-assert(tostring(vector(-1, 2, 0.5)) == "-1, 2, 0.5")
+
+if vector_size == 4 then
+	assert(tostring(vector(1, 2, 3, 4)) == "1, 2, 3, 4")
+	assert(tostring(vector(-1, 2, 0.5, 0)) == "-1, 2, 0.5, 0")
+else
+	assert(tostring(vector(1, 2, 3)) == "1, 2, 3")
+	assert(tostring(vector(-1, 2, 0.5)) == "-1, 2, 0.5")
+end
 
 local t = {}
 
@@ -42,12 +51,19 @@ assert(8 * vector(8, 16, 24) == vector(64, 128, 192));
 assert(vector(1, 2, 4) * '8' == vector(8, 16, 32));
 assert('8' * vector(8, 16, 24) == vector(64, 128, 192));
 
-assert(vector(1, 2, 4) / vector(8, 16, 24) == vector(1/8, 2/16, 4/24));
+if vector_size == 4 then
+	assert(vector(1, 2, 4, 8) / vector(8, 16, 24, 32) == vector(1/8, 2/16, 4/24, 8/32));
+	assert(8 / vector(8, 16, 24, 32) == vector(1, 1/2, 1/3, 1/4));
+	assert('8' / vector(8, 16, 24, 32) == vector(1, 1/2, 1/3, 1/4));
+else
+	assert(vector(1, 2, 4) / vector(8, 16, 24, 1) == vector(1/8, 2/16, 4/24));
+	assert(8 / vector(8, 16, 24) == vector(1, 1/2, 1/3));
+	assert('8' / vector(8, 16, 24) == vector(1, 1/2, 1/3));
+end
+
 assert(vector(1, 2, 4) / 8 == vector(1/8, 1/4, 1/2));
 assert(vector(1, 2, 4) / (1 / val) == vector(1/8, 2/8, 4/8));
-assert(8 / vector(8, 16, 24) == vector(1, 1/2, 1/3));
 assert(vector(1, 2, 4) / '8' == vector(1/8, 1/4, 1/2));
-assert('8' / vector(8, 16, 24) == vector(1, 1/2, 1/3));
 
 assert(-vector(1, 2, 4) == vector(-1, -2, -4));
 
@@ -70,5 +86,10 @@ assert(pcall(function() local t = {} rawset(t, vector(0/0, 2, 3), 1) end) == fal
 
 -- make sure we cover both builtin and C impl
 assert(vector(1, 2, 4) == vector("1", "2", "4"))
+
+-- additional checks for 4-component vectors
+if vector_size == 4 then
+	assert(vector(1, 2, 3, 4).w == 4)
+end
 
 return 'OK'


### PR DESCRIPTION
This adds a new define LUA_VECTOR_SIZE to luaconf.h. Possible values for it are 3 (default) and 4. When the vector size is 4, extra data in tagged value will be expanded by 4 bytes to make room for float4 vectors (this will increase tagged value to 24 bytes in total due to alignment) and all VM vector ops are patched to work with 4 components.

I've verified that unit and conformance tests pass on MSVC.

resolves Roblox/luau#196