### PR TITLE
Add web workflow to build Repl with Emscripten

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,4 +101,4 @@ jobs:
       run: |
         source emsdk/emsdk_env.sh
         emcmake cmake . -DCMAKE_BUILD_TYPE=Release
-        make -j2 Luau.Repl.CLI
+        make -j2 Luau.Web

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,3 +83,22 @@ jobs:
       with:
         name: coverage
         path: coverage
+
+  web:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
+      with:
+        repository: emscripten-core/emsdk
+        path: emsdk
+    - name: emsdk install
+      run: |
+        cd emsdk
+        ./emsdk install latest
+        ./emsdk activate latest
+    - name: make
+      run: |
+        source emsdk/emsdk_env.sh
+        emcmake cmake . -DCMAKE_BUILD_TYPE=Release
+        make -j2 Luau.Repl.CLI

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,5 +100,5 @@ jobs:
     - name: make
       run: |
         source emsdk/emsdk_env.sh
-        emcmake cmake . -DCMAKE_BUILD_TYPE=Release
+        emcmake cmake . -DLUAU_BUILD_WEB=ON -DCMAKE_BUILD_TYPE=Release
         make -j2 Luau.Web

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,3 +33,26 @@ jobs:
       with:
         name: luau-${{matrix.os}}
         path: Release\luau*.exe
+
+  web:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
+      with:
+        repository: emscripten-core/emsdk
+        path: emsdk
+    - name: emsdk install
+      run: |
+        cd emsdk
+        ./emsdk install latest
+        ./emsdk activate latest
+    - name: make
+      run: |
+        source emsdk/emsdk_env.sh
+        emcmake cmake . -DLUAU_BUILD_WEB=ON -DCMAKE_BUILD_TYPE=Release
+        make -j2 Luau.Web
+    - uses: actions/upload-artifact@v2
+      with:
+        name: Luau.Web.js
+        path: Luau.Web.js

--- a/CLI/Repl.cpp
+++ b/CLI/Repl.cpp
@@ -198,11 +198,6 @@ static std::string runCode(lua_State* L, const std::string& source)
         error += "\nstack backtrace:\n";
         error += lua_debugtrace(T);
 
-#ifdef __EMSCRIPTEN__
-        // nicer formatting for errors in web repl
-        error = "Error:" + error;
-#endif
-
         fprintf(stdout, "%s", error.c_str());
     }
 
@@ -210,39 +205,6 @@ static std::string runCode(lua_State* L, const std::string& source)
     return std::string();
 }
 
-#ifdef __EMSCRIPTEN__
-extern "C"
-{
-    const char* executeScript(const char* source)
-    {
-        // setup flags
-        for (Luau::FValue<bool>* flag = Luau::FValue<bool>::list; flag; flag = flag->next)
-            if (strncmp(flag->name, "Luau", 4) == 0)
-                flag->value = true;
-
-        // create new state
-        std::unique_ptr<lua_State, void (*)(lua_State*)> globalState(luaL_newstate(), lua_close);
-        lua_State* L = globalState.get();
-
-        // setup state
-        setupState(L);
-
-        // sandbox thread
-        luaL_sandboxthread(L);
-
-        // static string for caching result (prevents dangling ptr on function exit)
-        static std::string result;
-
-        // run code + collect error
-        result = runCode(L, source);
-
-        return result.empty() ? NULL : result.c_str();
-    }
-}
-#endif
-
-// Excluded from emscripten compilation to avoid -Wunused-function errors.
-#ifndef __EMSCRIPTEN__
 static void completeIndexer(lua_State* L, const char* editBuffer, size_t start, std::vector<std::string>& completions)
 {
     std::string_view lookup = editBuffer + start;
@@ -564,5 +526,4 @@ int main(int argc, char** argv)
         return failed;
     }
 }
-#endif
 

--- a/CLI/Web.cpp
+++ b/CLI/Web.cpp
@@ -79,31 +79,28 @@ static std::string runCode(lua_State* L, const std::string& source)
     return std::string();
 }
 
-extern "C"
+extern "C" const char* executeScript(const char* source)
 {
-    const char* executeScript(const char* source)
-    {
-        // setup flags
-        for (Luau::FValue<bool>* flag = Luau::FValue<bool>::list; flag; flag = flag->next)
-            if (strncmp(flag->name, "Luau", 4) == 0)
-                flag->value = true;
+    // setup flags
+    for (Luau::FValue<bool>* flag = Luau::FValue<bool>::list; flag; flag = flag->next)
+        if (strncmp(flag->name, "Luau", 4) == 0)
+            flag->value = true;
 
-        // create new state
-        std::unique_ptr<lua_State, void (*)(lua_State*)> globalState(luaL_newstate(), lua_close);
-        lua_State* L = globalState.get();
+    // create new state
+    std::unique_ptr<lua_State, void (*)(lua_State*)> globalState(luaL_newstate(), lua_close);
+    lua_State* L = globalState.get();
 
-        // setup state
-        setupState(L);
+    // setup state
+    setupState(L);
 
-        // sandbox thread
-        luaL_sandboxthread(L);
+    // sandbox thread
+    luaL_sandboxthread(L);
 
-        // static string for caching result (prevents dangling ptr on function exit)
-        static std::string result;
+    // static string for caching result (prevents dangling ptr on function exit)
+    static std::string result;
 
-        // run code + collect error
-        result = runCode(L, source);
+    // run code + collect error
+    result = runCode(L, source);
 
-        return result.empty() ? NULL : result.c_str();
-    }
+    return result.empty() ? NULL : result.c_str();
 }

--- a/CLI/Web.cpp
+++ b/CLI/Web.cpp
@@ -1,0 +1,109 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+#include "lua.h"
+#include "lualib.h"
+#include "luacode.h"
+
+#include "Luau/Common.h"
+
+#include <string>
+
+#include <string.h>
+
+static void setupState(lua_State* L)
+{
+    luaL_openlibs(L);
+
+    luaL_sandbox(L);
+}
+
+static std::string runCode(lua_State* L, const std::string& source)
+{
+    size_t bytecodeSize = 0;
+    char* bytecode = luau_compile(source.data(), source.length(), nullptr, &bytecodeSize);
+    int result = luau_load(L, "=stdin", bytecode, bytecodeSize, 0);
+    free(bytecode);
+
+    if (result != 0)
+    {
+        size_t len;
+        const char* msg = lua_tolstring(L, -1, &len);
+
+        std::string error(msg, len);
+        lua_pop(L, 1);
+
+        return error;
+    }
+
+    lua_State* T = lua_newthread(L);
+
+    lua_pushvalue(L, -2);
+    lua_remove(L, -3);
+    lua_xmove(L, T, 1);
+
+    int status = lua_resume(T, NULL, 0);
+
+    if (status == 0)
+    {
+        int n = lua_gettop(T);
+
+        if (n)
+        {
+            luaL_checkstack(T, LUA_MINSTACK, "too many results to print");
+            lua_getglobal(T, "print");
+            lua_insert(T, 1);
+            lua_pcall(T, n, 0, 0);
+        }
+    }
+    else
+    {
+        std::string error;
+
+        if (status == LUA_YIELD)
+        {
+            error = "thread yielded unexpectedly";
+        }
+        else if (const char* str = lua_tostring(T, -1))
+        {
+            error = str;
+        }
+
+        error += "\nstack backtrace:\n";
+        error += lua_debugtrace(T);
+
+        error = "Error:" + error;
+
+        fprintf(stdout, "%s", error.c_str());
+    }
+
+    lua_pop(L, 1);
+    return std::string();
+}
+
+extern "C"
+{
+    const char* executeScript(const char* source)
+    {
+        // setup flags
+        for (Luau::FValue<bool>* flag = Luau::FValue<bool>::list; flag; flag = flag->next)
+            if (strncmp(flag->name, "Luau", 4) == 0)
+                flag->value = true;
+
+        // create new state
+        std::unique_ptr<lua_State, void (*)(lua_State*)> globalState(luaL_newstate(), lua_close);
+        lua_State* L = globalState.get();
+
+        // setup state
+        setupState(L);
+
+        // sandbox thread
+        luaL_sandboxthread(L);
+
+        // static string for caching result (prevents dangling ptr on function exit)
+        static std::string result;
+
+        // run code + collect error
+        result = runCode(L, source);
+
+        return result.empty() ? NULL : result.c_str();
+    }
+}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,13 +107,14 @@ endif()
 
 if(LUAU_BUILD_WEB)
     target_compile_options(Luau.Web PRIVATE ${LUAU_OPTIONS})
-    target_include_directories(Luau.Web PRIVATE extern)
     target_link_libraries(Luau.Web PRIVATE Luau.Compiler Luau.VM)
 
     # declare exported functions to emscripten
     target_link_options(Luau.Web PRIVATE -sEXPORTED_FUNCTIONS=['_executeScript'] -sEXPORTED_RUNTIME_METHODS=['ccall','cwrap'] -fexceptions)
-    target_link_options(Luau.Web PRIVATE -sSINGLE_FILE=1)
 
-    # custom output directory for wasm + js file
-    # set_target_properties(Luau.Repl.CLI PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/docs/assets/luau)
+    # add -fexceptions for emscripten to allow exceptions to be caught in C++
+    target_link_options(Luau.Web PRIVATE -fexceptions)
+
+    # the output is a single .js file with an embedded wasm blob
+    target_link_options(Luau.Web PRIVATE -sSINGLE_FILE=1)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ project(Luau LANGUAGES CXX)
 
 option(LUAU_BUILD_CLI "Build CLI" ON)
 option(LUAU_BUILD_TESTS "Build tests" ON)
+option(LUAU_BUILD_WEB "Build Web module" OFF)
 option(LUAU_WERROR "Warnings as errors" OFF)
 
 add_library(Luau.Ast STATIC)
@@ -18,24 +19,20 @@ add_library(Luau.VM STATIC)
 
 if(LUAU_BUILD_CLI)
     add_executable(Luau.Repl.CLI)
-    if(NOT EMSCRIPTEN)
-        add_executable(Luau.Analyze.CLI)
-    else()
-        # add -fexceptions for emscripten to allow exceptions to be caught in C++
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fexceptions")
-    endif()
+    add_executable(Luau.Analyze.CLI)
 
     # This also adds target `name` on Linux/macOS and `name.exe` on Windows
     set_target_properties(Luau.Repl.CLI PROPERTIES OUTPUT_NAME luau)
-
-    if(NOT EMSCRIPTEN)
-        set_target_properties(Luau.Analyze.CLI PROPERTIES OUTPUT_NAME luau-analyze)
-    endif()
+    set_target_properties(Luau.Analyze.CLI PROPERTIES OUTPUT_NAME luau-analyze)
 endif()
 
-if(LUAU_BUILD_TESTS AND NOT EMSCRIPTEN)
+if(LUAU_BUILD_TESTS)
     add_executable(Luau.UnitTest)
     add_executable(Luau.Conformance)
+endif()
+
+if(LUAU_BUILD_WEB)
+    add_executable(Luau.Web)
 endif()
 
 include(Sources.cmake)
@@ -72,16 +69,18 @@ if(LUAU_WERROR)
     endif()
 endif()
 
+if(LUAU_BUILD_WEB)
+    # add -fexceptions for emscripten to allow exceptions to be caught in C++
+    list(APPEND LUAU_OPTIONS -fexceptions)
+endif()
+
 target_compile_options(Luau.Ast PRIVATE ${LUAU_OPTIONS})
 target_compile_options(Luau.Analysis PRIVATE ${LUAU_OPTIONS})
 target_compile_options(Luau.VM PRIVATE ${LUAU_OPTIONS})
 
 if(LUAU_BUILD_CLI)
     target_compile_options(Luau.Repl.CLI PRIVATE ${LUAU_OPTIONS})
-
-    if(NOT EMSCRIPTEN)
-        target_compile_options(Luau.Analyze.CLI PRIVATE ${LUAU_OPTIONS})
-    endif()
+    target_compile_options(Luau.Analyze.CLI PRIVATE ${LUAU_OPTIONS})
 
     target_include_directories(Luau.Repl.CLI PRIVATE extern)
     target_link_libraries(Luau.Repl.CLI PRIVATE Luau.Compiler Luau.VM)
@@ -93,20 +92,10 @@ if(LUAU_BUILD_CLI)
         endif()
     endif()
 
-    if(NOT EMSCRIPTEN)
-        target_link_libraries(Luau.Analyze.CLI PRIVATE Luau.Analysis)
-    endif()
-
-    if(EMSCRIPTEN)
-        # declare exported functions to emscripten
-        target_link_options(Luau.Repl.CLI PRIVATE -sEXPORTED_FUNCTIONS=['_executeScript'] -sEXPORTED_RUNTIME_METHODS=['ccall','cwrap'] -fexceptions)
-
-        # custom output directory for wasm + js file
-        set_target_properties(Luau.Repl.CLI PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/docs/assets/luau)
-    endif()
+    target_link_libraries(Luau.Analyze.CLI PRIVATE Luau.Analysis)
 endif()
 
-if(LUAU_BUILD_TESTS AND NOT EMSCRIPTEN)
+if(LUAU_BUILD_TESTS)
     target_compile_options(Luau.UnitTest PRIVATE ${LUAU_OPTIONS})
     target_include_directories(Luau.UnitTest PRIVATE extern)
     target_link_libraries(Luau.UnitTest PRIVATE Luau.Analysis Luau.Compiler)
@@ -114,4 +103,17 @@ if(LUAU_BUILD_TESTS AND NOT EMSCRIPTEN)
     target_compile_options(Luau.Conformance PRIVATE ${LUAU_OPTIONS})
     target_include_directories(Luau.Conformance PRIVATE extern)
     target_link_libraries(Luau.Conformance PRIVATE Luau.Analysis Luau.Compiler Luau.VM)
+endif()
+
+if(LUAU_BUILD_WEB)
+    target_compile_options(Luau.Web PRIVATE ${LUAU_OPTIONS})
+    target_include_directories(Luau.Web PRIVATE extern)
+    target_link_libraries(Luau.Web PRIVATE Luau.Compiler Luau.VM)
+
+    # declare exported functions to emscripten
+    target_link_options(Luau.Web PRIVATE -sEXPORTED_FUNCTIONS=['_executeScript'] -sEXPORTED_RUNTIME_METHODS=['ccall','cwrap'] -fexceptions)
+    target_link_options(Luau.Web PRIVATE -sSINGLE_FILE=1)
+
+    # custom output directory for wasm + js file
+    # set_target_properties(Luau.Repl.CLI PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/docs/assets/luau)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,7 +110,7 @@ if(LUAU_BUILD_WEB)
     target_link_libraries(Luau.Web PRIVATE Luau.Compiler Luau.VM)
 
     # declare exported functions to emscripten
-    target_link_options(Luau.Web PRIVATE -sEXPORTED_FUNCTIONS=['_executeScript'] -sEXPORTED_RUNTIME_METHODS=['ccall','cwrap'] -fexceptions)
+    target_link_options(Luau.Web PRIVATE -sEXPORTED_FUNCTIONS=['_executeScript'] -sEXPORTED_RUNTIME_METHODS=['ccall','cwrap'])
 
     # add -fexceptions for emscripten to allow exceptions to be caught in C++
     target_link_options(Luau.Web PRIVATE -fexceptions)

--- a/Sources.cmake
+++ b/Sources.cmake
@@ -228,9 +228,5 @@ endif()
 if(TARGET Luau.Web)
     # Luau.Web Sources
     target_sources(Luau.Web PRIVATE
-        CLI/FileUtils.h
-        CLI/FileUtils.cpp
-        CLI/Profiler.h
-        CLI/Profiler.cpp
-        CLI/Repl.cpp)
+        CLI/Web.cpp)
 endif()

--- a/Sources.cmake
+++ b/Sources.cmake
@@ -224,3 +224,13 @@ if(TARGET Luau.Conformance)
         tests/Conformance.test.cpp
         tests/main.cpp)
 endif()
+
+if(TARGET Luau.Web)
+    # Luau.Web Sources
+    target_sources(Luau.Web PRIVATE
+        CLI/FileUtils.h
+        CLI/FileUtils.cpp
+        CLI/Profiler.h
+        CLI/Profiler.cpp
+        CLI/Repl.cpp)
+endif()


### PR DESCRIPTION
Fixes #177

The build artifact produced after this change can be attached to releases; https://luau-lang.org/demo references a specific pinned release (0.505 at the moment) to fetch the JS binary.

We can probably change the JS code later to try to find the latest release using a GitHub API or binary search...