### PR TITLE
[Demo] Use latest release url

### DIFF
--- a/docs/_includes/repl.html
+++ b/docs/_includes/repl.html
@@ -47,4 +47,4 @@
         }
     }
 </script>
-<script async src="https://github.com/Roblox/luau/releases/download/0.505/Luau.Web.js"></script>
+<script async src="https://github.com/Roblox/luau/releases/latest/download/Luau.Web.js"></script>


### PR DESCRIPTION
It turns out that GitHub allows you to directly reference the latest release in a download URL, so this is a lot easier than I thought.

As far as I can tell these download URLs aren't subject to rate limiting like other parts of the GitHub API. Or if they are, they don't include rate limit headers in the requests. Normal GitHub APIs have a limit of 60 requests per **hour** per IP address for unauthenticated clients.