### PR TITLE
Export Luau public symbols to WebAssembly

### DIFF
--- a/CLI/Web.cpp
+++ b/CLI/Web.cpp
@@ -79,7 +79,7 @@ static std::string runCode(lua_State* L, const std::string& source)
     return std::string();
 }
 
-extern "C" const char* executeScript(const char* source)
+LUA_API const char* executeScript(const char* source)
 {
     // setup flags
     for (Luau::FValue<bool>* flag = Luau::FValue<bool>::list; flag; flag = flag->next)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,7 +110,7 @@ if(LUAU_BUILD_WEB)
     target_link_libraries(Luau.Web PRIVATE Luau.Compiler Luau.VM)
 
     # declare exported functions to emscripten
-    target_link_options(Luau.Web PRIVATE -sEXPORTED_FUNCTIONS=['_executeScript'] -sEXPORTED_RUNTIME_METHODS=['ccall','cwrap'])
+    target_link_options(Luau.Web PRIVATE -sEXPORTED_RUNTIME_METHODS=['ccall','cwrap'])
 
     # add -fexceptions for emscripten to allow exceptions to be caught in C++
     target_link_options(Luau.Web PRIVATE -fexceptions)

--- a/VM/include/luaconf.h
+++ b/VM/include/luaconf.h
@@ -2,6 +2,10 @@
 // This code is based on Lua 5.x implementation licensed under MIT License; see lua_LICENSE.txt for details
 #pragma once
 
+#ifdef __EMSCRIPTEN__
+#include <emscripten.h>
+#endif
+
 // When debugging complex issues, consider enabling one of these:
 // This will reallocate the stack very aggressively at every opportunity; use this with asan to catch stale stack pointers
 // #define HARDSTACKTESTS 1
@@ -34,7 +38,11 @@
 #endif
 
 /* Can be used to reconfigure visibility/exports for public APIs */
+#ifdef __EMSCRIPTEN__
+#define LUA_API extern "C" EMSCRIPTEN_KEEPALIVE
+#else
 #define LUA_API extern
+#endif
 #define LUALIB_API LUA_API
 
 /* Can be used to reconfigure visibility for internal APIs */


### PR DESCRIPTION
Instead of only exporting the symbols for the web repl, export all public Luau symbols to the wasm build.