### PR TITLE
Add configurable extra data at the end of lua_State

### DIFF
--- a/VM/include/luaconf.h
+++ b/VM/include/luaconf.h
@@ -126,3 +126,6 @@
 #define LUA_VECTOR_SIZE 3	/* must be 3 or 4 */
 
 #define LUA_EXTRA_SIZE LUA_VECTOR_SIZE - 2
+
+/* size of optional extra data in bytes added at the end of lua_State. */
+#define LUA_STATE_EXTRA 0

--- a/VM/src/lstate.cpp
+++ b/VM/src/lstate.cpp
@@ -10,6 +10,8 @@
 #include "ldo.h"
 #include "ldebug.h"
 
+#include <string.h>
+
 /*
 ** Main thread combines a thread state and the global state
 */
@@ -78,6 +80,9 @@ static void preinit_state(lua_State* L, global_State* g)
     L->stackstate = 0;
     L->activememcat = 0;
     L->userdata = NULL;
+#if LUA_STATE_EXTRA > 0
+    memset(L->extra, 0, LUA_STATE_EXTRA);
+#endif
     setnilvalue(gt(L));
 }
 

--- a/VM/src/lstate.h
+++ b/VM/src/lstate.h
@@ -237,6 +237,9 @@ struct lua_State
     TString* namecall; /* when invoked from Luau using NAMECALL, what method do we need to invoke? */
 
     void* userdata;
+#if LUA_STATE_EXTRA > 0
+    char extra[LUA_STATE_EXTRA];
+#endif
 };
 // clang-format on
 


### PR DESCRIPTION
Sorry for throwing this pull request at you without giving a warning first. We are using the LUA_EXTRASPACE feature from the standard Lua which allows placing a raw memory block at the end of Lua state. We are stashing there some per state pointers which are heavily used in our Lua bindings. In Luau there's already a per state user data pointer but storing multiple values means the data would have to be accessed through the pointer, which leads to reduced cache coherency and also performs a dependent read which makes it extra costly on a cache miss. Expanding the lua_State by configurable extra data solves this problem nicely.

Since the extra data is 0 bytes by default, this would normally raise a warning about nonstandard zero-sized array support, at least on MSVC. This has been worked around using #if LUA_STATE_EXTRA > 0. 

Alternatively we could consider removing "void* userdata" from lua_State altogether and replacing it with this new extra data feature. But this would mean getting rid of lua_getthreaddata and lua_setthreaddata from the API, so I did not go that route.

What do you think?