### PR TITLE
Ignore errors during upload coverage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,6 +79,7 @@ jobs:
       with:
         path-to-lcov: ./coverage.info
         github-token: ${{ secrets.GITHUB_TOKEN }}
+      continue-on-error: true
     - uses: actions/upload-artifact@v2
       with:
         name: coverage


### PR DESCRIPTION
Coveralls coverage upload seems rather flaky and fails several times per week on various PRs.
Coveralls issue: https://github.com/lemurheavy/coveralls-public/issues/1595

Until this is resolved we'll just have to live with occasionally missing coverage uploads as it's too disruptive otherwise.