### PR TITLE
RFC: Amend 'Default type alias type parameters' for type pack parameters

### DIFF
--- a/rfcs/syntax-default-type-alias-type-parameters.md
+++ b/rfcs/syntax-default-type-alias-type-parameters.md
@@ -48,11 +48,12 @@ type A<T, U = V, V = T> = ... -- not allowed
 
 Default type parameter values are also allowed for type packs:
 ```lua
-type A<T, U... = ...string> -- ok, variadic type pack
-type C<T, U... = (string)>  -- ok, type pack with one element
-type C<T, U... = (string,number)>  -- ok, type pack with two elements
-type C<T, U... = ()>  -- ok, type pack with no elements
-type D<T..., U... = T...>   -- ok
+type A<T, U... = ...string>           -- ok, variadic type pack
+type B<T, U... = ()>                  -- ok, type pack with no elements
+type C<T, U... = (string)>            -- ok, type pack with one element
+type D<T, U... = (string, number)>    -- ok, type pack with two elements
+type E<T, U... = (string, ...number)> -- ok, variadic type pack with a different first element
+type F<T..., U... = T...>             -- ok, same type pack as T...
 ```
 
 ---

--- a/rfcs/syntax-default-type-alias-type-parameters.md
+++ b/rfcs/syntax-default-type-alias-type-parameters.md
@@ -68,7 +68,7 @@ If all type parameters have a default type value, it is now possible to referenc
 type All<T = string, U = number> = ...
 
 local a: All -- ok
-local b: All<> -- not allowed
+local b: All<> -- ok as well
 ```
 
 If type is exported from a module, default type parameter values will still be available when module is imported.

--- a/rfcs/syntax-default-type-alias-type-parameters.md
+++ b/rfcs/syntax-default-type-alias-type-parameters.md
@@ -49,7 +49,7 @@ type A<T, U = V, V = T> = ... -- not allowed
 Default type parameter values are also allowed for type packs:
 ```lua
 type A<T, U... = ...string> -- ok, variadic type pack
-type C<T, U... = string>    -- ok, type pack with one element
+type C<T, U... = (string)>  -- ok, type pack with one element
 type D<T..., U... = T...>   -- ok
 ```
 

--- a/rfcs/syntax-default-type-alias-type-parameters.md
+++ b/rfcs/syntax-default-type-alias-type-parameters.md
@@ -50,6 +50,8 @@ Default type parameter values are also allowed for type packs:
 ```lua
 type A<T, U... = ...string> -- ok, variadic type pack
 type C<T, U... = (string)>  -- ok, type pack with one element
+type C<T, U... = (string,number)>  -- ok, type pack with two elements
+type C<T, U... = ()>  -- ok, type pack with no elements
 type D<T..., U... = T...>   -- ok
 ```
 


### PR DESCRIPTION
When the original RFC for [Default type alias type parameters](https://github.com/Roblox/luau/blob/master/rfcs/syntax-default-type-alias-type-parameters.md) was accepted, we didn't have explicit type pack syntax from [Type alias type packs](https://github.com/Roblox/luau/blob/master/rfcs/syntax-type-alias-type-packs.md) available.

Originally, these ways of defining default type pack parameters were proposed:
```lua
type A<T, U... = ...string> -- ok, variadic type pack
type C<T, U... = string>    -- ok, type pack with one element
type D<T..., U... = T...>   -- ok
```

Type 'C' uses a regular `string` type as a type pack of one element.
I propose that we remove support for a single regular type and require an explicit type pack with one element:
```lua
type C<T, U... = (string)>    -- ok, type pack with one element
```

---
Another point is the empty parameter list:
```lua
type A<T = number> = T
type B = A<>
```

Before type pack parameter support, this instantiation form was not supported and since RFC did not propose to extend the syntax for that at the time, it was specified as:
```lua
local a: All -- ok
local b: All<> -- not allowed
```

The intention was that it is 'still not allowed'. Now that it is, we will write:
```lua
local a: All -- ok
local b: All<> -- ok as well
```