### PR TITLE
Add LUA_GCCOUNTB option for lua_gc

### DIFF
--- a/VM/include/lua.h
+++ b/VM/include/lua.h
@@ -231,6 +231,7 @@ enum lua_GCOp
     LUA_GCRESTART,
     LUA_GCCOLLECT,
     LUA_GCCOUNT,
+    LUA_GCCOUNTB,
     LUA_GCISRUNNING,
 
     // garbage collection is handled by 'assists' that perform some amount of GC work matching pace of allocation

--- a/VM/src/lapi.cpp
+++ b/VM/src/lapi.cpp
@@ -1039,6 +1039,11 @@ int lua_gc(lua_State* L, int what, int data)
         res = cast_int(g->totalbytes >> 10);
         break;
     }
+    case LUA_GCCOUNTB:
+    {
+        res = cast_int(g->totalbytes & 1023);
+        break;
+    }
     case LUA_GCISRUNNING:
     {
         res = (g->GCthreshold != SIZE_MAX);


### PR DESCRIPTION
This option from PUC Lua is useful for more fine-grained memory profiling.

resolves #249