### PR TITLE
Allow reconfiguring VM defaults 

### DIFF
--- a/VM/include/luaconf.h
+++ b/VM/include/luaconf.h
@@ -47,10 +47,14 @@
 #endif
 
 /* Can be used to reconfigure internal error handling to use longjmp instead of C++ EH */
+#ifndef LUA_USE_LONGJMP
 #define LUA_USE_LONGJMP 0
+#endif
 
 /* LUA_IDSIZE gives the maximum size for the description of the source */
+#ifndef LUA_IDSIZE
 #define LUA_IDSIZE 256
+#endif
 
 /*
 @@ LUAI_GCGOAL defines the desired top heap size in relation to the live heap
@@ -59,7 +63,9 @@
 ** mean larger GC pauses which mean slower collection.) You can also change
 ** this value dynamically.
 */
+#ifndef LUAI_GCGOAL
 #define LUAI_GCGOAL 200 /* 200% (allow heap to double compared to live heap size) */
+#endif
 
 /*
 @@ LUAI_GCSTEPMUL / LUAI_GCSTEPSIZE define the default speed of garbage collection
@@ -69,38 +75,63 @@
 ** CHANGE it if you want to change the granularity of the garbage
 ** collection.
 */
+#ifndef LUAI_GCSTEPMUL
 #define LUAI_GCSTEPMUL 200 /* GC runs 'twice the speed' of memory allocation */
+#endif
+
+#ifndef LUAI_GCSTEPSIZE
 #define LUAI_GCSTEPSIZE 1  /* GC runs every KB of memory allocation */
+#endif
 
 /* LUA_MINSTACK is the guaranteed number of Lua stack slots available to a C function */
+#ifndef LUA_MINSTACK
 #define LUA_MINSTACK 20
+#endif
 
 /* LUAI_MAXCSTACK limits the number of Lua stack slots that a C function can use */
+#ifndef LUAI_MAXCSTACK
 #define LUAI_MAXCSTACK 8000
+#endif
 
 /* LUAI_MAXCALLS limits the number of nested calls */
+#ifndef LUAI_MAXCALLS
 #define LUAI_MAXCALLS 20000
+#endif
 
 /* LUAI_MAXCCALLS is the maximum depth for nested C calls; this limit depends on native stack size */
+#ifndef LUAI_MAXCCALLS
 #define LUAI_MAXCCALLS 200
+#endif
 
 /* buffer size used for on-stack string operations; this limit depends on native stack size */
+#ifndef LUA_BUFFERSIZE
 #define LUA_BUFFERSIZE 512
+#endif
 
 /* number of valid Lua userdata tags */
+#ifndef LUA_UTAG_LIMIT
 #define LUA_UTAG_LIMIT 128
+#endif
 
 /* upper bound for number of size classes used by page allocator */
+#ifndef LUA_SIZECLASSES
 #define LUA_SIZECLASSES 32
+#endif
 
 /* available number of separate memory categories */
+#ifndef LUA_MEMORY_CATEGORIES
 #define LUA_MEMORY_CATEGORIES 256
+#endif
 
 /* minimum size for the string table (must be power of 2) */
+#ifndef LUA_MINSTRTABSIZE
 #define LUA_MINSTRTABSIZE 32
+#endif
 
 /* maximum number of captures supported by pattern matching */
+#ifndef LUA_MAXCAPTURES
 #define LUA_MAXCAPTURES 32
+#endif
 
 /* }================================================================== */
 

--- a/VM/include/luaconf.h
+++ b/VM/include/luaconf.h
@@ -34,7 +34,10 @@
 #endif
 
 /* Can be used to reconfigure visibility/exports for public APIs */
+#ifndef LUA_API
 #define LUA_API extern
+#endif
+
 #define LUALIB_API LUA_API
 
 /* Can be used to reconfigure visibility for internal APIs */


### PR DESCRIPTION
This change allows to configure VM defaults from the build system (with defines `-D` or `/D`) without requiring changes to luau source code.

I frequently override `LUA_USE_LONGJMP` in cmake to build the test suite with and without exceptions, so this comes in handy.