### PR TITLE
Fix luau_load 'env' to work with absolute stack index & add lua_absindex

### DIFF
--- a/VM/include/lua.h
+++ b/VM/include/lua.h
@@ -21,6 +21,7 @@
 #define LUA_ENVIRONINDEX (-10001)
 #define LUA_GLOBALSINDEX (-10002)
 #define lua_upvalueindex(i) (LUA_GLOBALSINDEX - (i))
+#define lua_ispseudo(i) ((i) <= LUA_REGISTRYINDEX)
 
 /* thread status; 0 is OK */
 enum lua_Status
@@ -108,6 +109,7 @@ LUA_API int lua_isthreadreset(lua_State* L);
 /*
 ** basic stack manipulation
 */
+LUA_API int lua_absindex(lua_State* L, int idx);
 LUA_API int lua_gettop(lua_State* L);
 LUA_API void lua_settop(lua_State* L, int idx);
 LUA_API void lua_pushvalue(lua_State* L, int idx);

--- a/VM/src/lapi.cpp
+++ b/VM/src/lapi.cpp
@@ -170,6 +170,12 @@ lua_State* lua_mainthread(lua_State* L)
 ** basic stack manipulation
 */
 
+int lua_absindex(lua_State* L, int idx)
+{
+    api_check(L, (idx > 0 && idx <= L->top - L->base) || (idx < 0 && -idx <= L->top - L->base) || lua_ispseudo(idx));
+    return idx > 0 || lua_ispseudo(idx) ? idx : cast_int(L->top - L->base) + idx + 1;
+}
+
 int lua_gettop(lua_State* L)
 {
     return cast_int(L->top - L->base);

--- a/VM/src/lvmload.cpp
+++ b/VM/src/lvmload.cpp
@@ -9,6 +9,7 @@
 #include "lgc.h"
 #include "lmem.h"
 #include "lbytecode.h"
+#include "lapi.h"
 
 #include <string.h>
 
@@ -162,9 +163,8 @@ int luau_load(lua_State* L, const char* chunkname, const char* data, size_t size
     size_t GCthreshold = L->global->GCthreshold;
     L->global->GCthreshold = SIZE_MAX;
 
-    // env is 0 for current environment and a stack relative index otherwise
-    LUAU_ASSERT(env <= 0 && L->top - L->base >= -env);
-    Table* envt = (env == 0) ? hvalue(gt(L)) : hvalue(L->top + env);
+    // env is 0 for current environment and a stack index otherwise
+    Table* envt = (env == 0) ? hvalue(gt(L)) : hvalue(luaA_toobject(L, env));
 
     TString* source = luaS_new(L, chunkname);
 


### PR DESCRIPTION
As per discussion with @zeux this fixes the stack index issue with luau_load and also adds missing function lua_absindex from standard Lua.

resolves #258