### PR TITLE
Add Grammar documentation

### DIFF
--- a/docs/_data/navigation.yml
+++ b/docs/_data/navigation.yml
@@ -29,3 +29,5 @@ pages:
     url: /profile
   - title: Library
     url: /library
+  - title: Grammar
+    url: /grammar

--- a/docs/_pages/grammar.md
+++ b/docs/_pages/grammar.md
@@ -22,7 +22,7 @@ stat ::= varlist `=' explist |
     function funcname funcbody |
     local function NAME funcbody |
     local bindinglist [`=' explist] |
-    [export] type NAME [`<' GenericTypeList `>'] `=' TypeAnnotation
+    [export] type NAME [`<' GenericTypeList `>'] `=' Type
 
 laststat ::= return [explist] | break | continue
 
@@ -40,7 +40,7 @@ exp ::= (asexp | unop exp) { binop exp }
 ifelseexp ::= if exp then exp {elseif exp then exp} else exp
 prefixexp ::= NAME | '(' exp ')'
 primaryexp ::= prefixexp { `.' NAME | `[' exp `]' | `:' NAME funcargs | funcargs }
-asexp ::= simpleexp [`::' TypeAnnotation]
+asexp ::= simpleexp [`::' Type]
 simpleexp ::= NUMBER | STRING | nil | true | false | `...' | tableconstructor | function body | primaryexp | ifelseexp
 funcargs ::=  `(' [explist] `)' | tableconstructor | STRING
 
@@ -53,25 +53,25 @@ compoundop :: `+=' | `-=' | `*=' | `/=' | `%=' | `^=' | `..='
 binop ::= `+' | `-' | `*' | `/' | `^' | `%' | `..' | `<' | `<=' | `>' | `>=' | `==' | `~=' | and | or
 unop ::= `-' | not | `#'
 
-SimpleTypeAnnotation ::=
+SimpleType ::=
     nil |
-    NAME[`.' NAME] [ `<' TypeAnnotation [`,' ...] `>' ] |
+    NAME[`.' NAME] [ `<' Type {`,' Type} `>' ] |
     `typeof' `(' exp `)' |
-    `{' [PropList] `}' |
-    FunctionTypeAnnotation
+    TableType |
+    FunctionType
 
-TypeAnnotation ::=
-    SimpleTypeAnnotation [`?`] |
-    SimpleTypeAnnotation [`|` TypeAnnotation] |
-    SimpleTypeAnnotation [`&` TypeAnnotation]
+Type ::=
+    SimpleType [`?`] |
+    SimpleType [`|` Type] |
+    SimpleType [`&` Type]
 
 GenericTypeList ::= NAME [`...'] {`,' NAME}
-TypeList ::= TypeAnnotation [`,' TypeList] | ...TypeAnnotation
-ReturnType ::= TypeAnnotation | `(' TypeList `)'
-TableIndexer ::= `[' TypeAnnotation `]' `:' TypeAnnotation
-TableProp ::= NAME `:' TypeAnnotation
+TypeList ::= Type [`,' TypeList] | ...Type
+ReturnType ::= Type | `(' TypeList `)'
+TableIndexer ::= `[' Type `]' `:' Type
+TableProp ::= NAME `:' Type
 TablePropOrIndexer ::= TableProp | TableIndexer
 PropList ::= TablePropOrIndexer {fieldsep TablePropOrIndexer} [fieldsep]
-TableTypeAnnotation ::= `{' PropList `}'
-FunctionTypeAnnotation ::= [`<' GenericTypeList `>'] `(' [TypeList] `)' `->` ReturnType
+TableType ::= `{' PropList `}'
+FunctionType ::= [`<' GenericTypeList `>'] `(' [TypeList] `)' `->` ReturnType
 ```

--- a/docs/_pages/grammar.md
+++ b/docs/_pages/grammar.md
@@ -19,7 +19,7 @@ stat ::= varlist `=' explist |
     function funcname funcbody |
     local function Name funcbody |
     local namelist [`=' explist] |
-    [export] type Name [`<' varlist `>'] `=' typeannotation
+    [export] type Name [`<' GenericTypeList `>'] `=' typeannotation
 
 laststat ::= return [explist] | break | continue
 
@@ -52,8 +52,9 @@ typeannotation ::=
       `(' [TypeList] `)' `->` ReturnType
       `typeof` typeannotation
 
-typeannotation ::= nil | Name[`.' Name] [ `<' typeannotation [`,' ...] `>' ] | `typeof' `(' expr `)' | `{' [PropList] `}' | [`<' varlist `>'] `(' [TypeList] `)' `->` ReturnType
+typeannotation ::= nil | Name[`.' Name] [ `<' typeannotation [`,' ...] `>' ] | `typeof' `(' expr `)' | `{' [PropList] `}' | [`<' GenericTypeList `>'] `(' [TypeList] `)' `->` ReturnType
 
+GenericTypeList ::= NAME [`...'] {`,' NAME}
 TypeList ::= TypeAnnotation [`,' TypeList] | ...TypeAnnotation
 ReturnType ::= TypeAnnotation | `(' TypeList `)'
 TableIndexer ::= `[' TypeAnnotation `]' `:' TypeAnnotation
@@ -61,6 +62,6 @@ TableProp ::= Name `:' TypeAnnotation
 TablePropOrIndexer ::= TableProp | TableIndexer
 PropList ::= TablePropOrIndexer {fieldsep TablePropOrIndexer} [fieldsep]
 TableTypeAnnotation ::= `{' PropList `}'
-FunctionTypeAnnotation ::= [`<' varlist `>'] `(' [TypeList] `)' `->` ReturnType
+FunctionTypeAnnotation ::= [`<' GenericTypeList `>'] `(' [TypeList] `)' `->` ReturnType
 
 ```

--- a/docs/_pages/grammar.md
+++ b/docs/_pages/grammar.md
@@ -7,7 +7,7 @@ toc: true
 This is the complete syntax grammar for Luau in EBNF. More information about the terminal nodes String and Number
 is available in the [syntax section](syntax).
 
-```
+```ebnf
 chunk ::= {stat [`;']} [laststat [`;']]
 block ::= chunk
 stat ::= varlist `=' explist |
@@ -34,7 +34,7 @@ explist ::= {exp `,'} exp
 namelist ::= NAME {`,' NAME}
 
 binding ::= NAME [`:' TypeAnnotation]
-bindinglist ::= binding [`,' bindinglist]
+bindinglist ::= binding [`,' bindinglist] (* equivalent of Lua 5.1 `namelist`, except with optional type annotations *)
 
 var ::= NAME | prefixexp `[' exp `]' | prefixexp `.' Name
 varlist ::= var {`,' var}
@@ -58,7 +58,7 @@ unop ::= `-' | not | `#'
 
 SimpleType ::=
     nil |
-    NAME[`.' NAME] [ `<' Type {`,' Type} `>' ] |
+    NAME[`.' NAME] [ `<' TypeList `>' ] |
     `typeof' `(' exp `)' |
     TableType |
     FunctionType

--- a/docs/_pages/grammar.md
+++ b/docs/_pages/grammar.md
@@ -27,6 +27,7 @@ funcname ::= Name {`.' Name} [`:' Name]
 funcbody ::= `(' [parlist] `)' [`:' ReturnType] block end
 parlist ::= bindinglist [`,' `...'] | `...'
 explist ::= {exp `,'} exp
+namelist ::= Name {`,' Name}
 bindinglist ::= (binding | `...') [`,' bindinglist]
 
 subexpr ::= (asexp | unop subexpr) { binop subexpr }

--- a/docs/_pages/grammar.md
+++ b/docs/_pages/grammar.md
@@ -65,7 +65,7 @@ Type ::=
     SimpleType [`|` Type] |
     SimpleType [`&` Type]
 
-GenericTypeList ::= NAME [`...'] {`,' NAME}
+GenericTypeList ::= NAME [`...'] {`,' NAME [`...']}
 TypeList ::= Type [`,' TypeList] | ...Type
 ReturnType ::= Type | `(' TypeList `)'
 TableIndexer ::= `[' Type `]' `:' Type

--- a/docs/_pages/grammar.md
+++ b/docs/_pages/grammar.md
@@ -19,7 +19,7 @@ stat ::= varlist `=' explist |
     function funcname funcbody |
     local function Name funcbody |
     local bindinglist [`=' explist] |
-    [export] type Name [`<' GenericTypeList `>'] `=' typeannotation
+    [export] type Name [`<' GenericTypeList `>'] `=' TypeAnnotation
 
 laststat ::= return [explist] | break | continue
 
@@ -29,14 +29,14 @@ parlist ::= bindinglist [`,' `...'] | `...'
 explist ::= {exp `,'} exp
 namelist ::= Name {`,' Name}
 
-binding ::= Name [`:' typeannotation]
+binding ::= Name [`:' TypeAnnotation]
 bindinglist ::= (binding | `...') [`,' bindinglist]
 
 subexpr ::= (asexp | unop subexpr) { binop subexpr }
 ifelseexp ::= if exp then exp {elseif exp then exp} else exp
 prefixexp ::= NAME | '(' expr ')'
 primaryexp ::= prefixexp { `.' NAME | `[' exp `]' | `:' NAME funcargs | funcargs }
-asexp ::= simpleexp [`::' typeannotation]
+asexp ::= simpleexp [`::' TypeAnnotation]
 simpleexp ::= NUMBER | STRING | NIL | true | false | ... | constructor | FUNCTION body | primaryexp | ifelseexp
 funcargs ::=  `(' [explist] `)' | tableconstructor | String
 
@@ -49,14 +49,17 @@ fieldlist ::= field {fieldsep field} [fieldsep]
 field ::= `[' exp `]' `=' exp | Name `=' exp | exp
 fieldsep ::= `,' | `;'
 
-typeannotation ::=
-      nil |
-      Name[`.' Name] [`<' namelist `>'] |
-     `{' [PropList] `}' |
-      `(' [TypeList] `)' `->` ReturnType
-      `typeof` typeannotation
+SimpleTypeAnnotation ::=
+    nil |
+    Name[`.' Name] [ `<' TypeAnnotation [`,' ...] `>' ] |
+    `typeof' `(' expr `)' |
+    `{' [PropList] `}' |
+    FunctionTypeAnnotation
 
-typeannotation ::= nil | Name[`.' Name] [ `<' typeannotation [`,' ...] `>' ] | `typeof' `(' expr `)' | `{' [PropList] `}' | [`<' GenericTypeList `>'] `(' [TypeList] `)' `->` ReturnType
+TypeAnnotation ::=
+    SimpleTypeAnnotation [`?`] |
+    SimpleTypeAnnotation [`|` TypeAnnotation] |
+    SimpleTypeAnnotation [`&` TypeAnnotation]
 
 GenericTypeList ::= NAME [`...'] {`,' NAME}
 TypeList ::= TypeAnnotation [`,' TypeList] | ...TypeAnnotation
@@ -67,5 +70,4 @@ TablePropOrIndexer ::= TableProp | TableIndexer
 PropList ::= TablePropOrIndexer {fieldsep TablePropOrIndexer} [fieldsep]
 TableTypeAnnotation ::= `{' PropList `}'
 FunctionTypeAnnotation ::= [`<' GenericTypeList `>'] `(' [TypeList] `)' `->` ReturnType
-
 ```

--- a/docs/_pages/grammar.md
+++ b/docs/_pages/grammar.md
@@ -8,6 +8,7 @@ toc: true
 chunk ::= {stat [`;']} [laststat [`;']]
 block ::= chunk
 stat ::= varlist `=' explist |
+    var compoundop exp |
     functioncall |
     do block end |
     while exp do block end |
@@ -17,9 +18,10 @@ stat ::= varlist `=' explist |
     for namelist in explist do block end |
     function funcname funcbody |
     local function Name funcbody |
-    local namelist [`=' explist]
+    local namelist [`=' explist] |
+    [export] type Name [`<' varlist `>'] `=' typeannotation
 
-laststat ::= return [explist] | break
+laststat ::= return [explist] | break | continue
 
 funcname ::= Name {`.' Name} [`:' Name]
 funcbody ::= `(' [parlist] `)' [`:' ReturnType] block end
@@ -34,6 +36,7 @@ asexp ::= simpleexp [`::' typeannotation]
 simpleexp ::= NUMBER | STRING | NIL | true | false | ... | constructor | FUNCTION body | primaryexp
 args ::=  `(' [explist] `)' | tableconstructor | String
 
+compoundop :: `+=' | `-=' | `*=' | `/=' | `%=' | `^=' | `..='
 binop ::= `+' | `-' | `*' | `/' | `^' | `%' | `..' | `<' | `<=' | `>' | `>=' | `==' | `~=' | and | or
 unop ::= `-' | not | `#´
 

--- a/docs/_pages/grammar.md
+++ b/docs/_pages/grammar.md
@@ -34,14 +34,14 @@ explist ::= {exp `,'} exp
 namelist ::= NAME {`,' NAME}
 
 binding ::= NAME [`:' TypeAnnotation]
-bindinglist ::= (binding | `...') [`,' bindinglist]
+bindinglist ::= binding [`,' bindinglist]
 
 exp ::= (asexp | unop exp) { binop exp }
 ifelseexp ::= if exp then exp {elseif exp then exp} else exp
 prefixexp ::= NAME | '(' exp ')'
 primaryexp ::= prefixexp { `.' NAME | `[' exp `]' | `:' NAME funcargs | funcargs }
 asexp ::= simpleexp [`::' TypeAnnotation]
-simpleexp ::= NUMBER | STRING | nil | true | false | ... | tableconstructor | function body | primaryexp | ifelseexp
+simpleexp ::= NUMBER | STRING | nil | true | false | `...' | tableconstructor | function body | primaryexp | ifelseexp
 funcargs ::=  `(' [explist] `)' | tableconstructor | STRING
 
 tableconstructor ::= `{' [fieldlist] `}'

--- a/docs/_pages/grammar.md
+++ b/docs/_pages/grammar.md
@@ -4,7 +4,7 @@ title: Grammar
 toc: true
 ---
 
-This is the complete syntax grammar for Luau in EBNF. More information about the terminal nodes Name, String and Number
+This is the complete syntax grammar for Luau in EBNF. More information about the terminal nodes String and Number
 is available in the [syntax section](syntax).
 
 ```
@@ -36,9 +36,9 @@ namelist ::= NAME {`,' NAME}
 binding ::= NAME [`:' TypeAnnotation]
 bindinglist ::= (binding | `...') [`,' bindinglist]
 
-subexpr ::= (asexp | unop subexpr) { binop subexpr }
+exp ::= (asexp | unop exp) { binop exp }
 ifelseexp ::= if exp then exp {elseif exp then exp} else exp
-prefixexp ::= NAME | '(' expr ')'
+prefixexp ::= NAME | '(' exp ')'
 primaryexp ::= prefixexp { `.' NAME | `[' exp `]' | `:' NAME funcargs | funcargs }
 asexp ::= simpleexp [`::' TypeAnnotation]
 simpleexp ::= NUMBER | STRING | nil | true | false | ... | tableconstructor | function body | primaryexp | ifelseexp
@@ -51,12 +51,12 @@ fieldsep ::= `,' | `;'
 
 compoundop :: `+=' | `-=' | `*=' | `/=' | `%=' | `^=' | `..='
 binop ::= `+' | `-' | `*' | `/' | `^' | `%' | `..' | `<' | `<=' | `>' | `>=' | `==' | `~=' | and | or
-unop ::= `-' | not | `#´
+unop ::= `-' | not | `#'
 
 SimpleTypeAnnotation ::=
     nil |
     NAME[`.' NAME] [ `<' TypeAnnotation [`,' ...] `>' ] |
-    `typeof' `(' expr `)' |
+    `typeof' `(' exp `)' |
     `{' [PropList] `}' |
     FunctionTypeAnnotation
 

--- a/docs/_pages/grammar.md
+++ b/docs/_pages/grammar.md
@@ -36,12 +36,15 @@ namelist ::= NAME {`,' NAME}
 binding ::= NAME [`:' TypeAnnotation]
 bindinglist ::= binding [`,' bindinglist]
 
+var ::= NAME | prefixexp `[' exp `]' | prefixexp `.' Name
+varlist ::= var {`,' var}
+prefixexp ::= var | functioncall | `(' exp `)'
+functioncall ::= prefixexp funcargs | prefixexp `:' NAME funcargs
+
 exp ::= (asexp | unop exp) { binop exp }
 ifelseexp ::= if exp then exp {elseif exp then exp} else exp
-prefixexp ::= NAME | '(' exp ')'
-primaryexp ::= prefixexp { `.' NAME | `[' exp `]' | `:' NAME funcargs | funcargs }
 asexp ::= simpleexp [`::' Type]
-simpleexp ::= NUMBER | STRING | nil | true | false | `...' | tableconstructor | function body | primaryexp | ifelseexp
+simpleexp ::= NUMBER | STRING | nil | true | false | `...' | tableconstructor | function body | prefixexp | ifelseexp
 funcargs ::=  `(' [explist] `)' | tableconstructor | STRING
 
 tableconstructor ::= `{' [fieldlist] `}'

--- a/docs/_pages/grammar.md
+++ b/docs/_pages/grammar.md
@@ -34,6 +34,9 @@ asexp ::= simpleexp [`::' typeannotation]
 simpleexp ::= NUMBER | STRING | NIL | true | false | ... | constructor | FUNCTION body | primaryexp
 args ::=  `(' [explist] `)' | tableconstructor | String
 
+binop ::= `+' | `-' | `*' | `/' | `^' | `%' | `..' | `<' | `<=' | `>' | `>=' | `==' | `~=' | and | or
+unop ::= `-' | not | `#´
+
 tableconstructor ::= `{' [fieldlist] `}'
 fieldlist ::= field {fieldsep field} [fieldsep]
 field ::= `[' exp `]' `=' exp | Name `=' exp | exp

--- a/docs/_pages/grammar.md
+++ b/docs/_pages/grammar.md
@@ -33,10 +33,11 @@ binding ::= Name [`:' typeannotation]
 bindinglist ::= (binding | `...') [`,' bindinglist]
 
 subexpr ::= (asexp | unop subexpr) { binop subexpr }
+ifelseexp ::= if exp then exp {elseif exp then exp} else exp
 prefixexp ::= NAME | '(' expr ')'
 primaryexp ::= prefixexp { `.' NAME | `[' exp `]' | `:' NAME funcargs | funcargs }
 asexp ::= simpleexp [`::' typeannotation]
-simpleexp ::= NUMBER | STRING | NIL | true | false | ... | constructor | FUNCTION body | primaryexp
+simpleexp ::= NUMBER | STRING | NIL | true | false | ... | constructor | FUNCTION body | primaryexp | ifelseexp
 funcargs ::=  `(' [explist] `)' | tableconstructor | String
 
 compoundop :: `+=' | `-=' | `*=' | `/=' | `%=' | `^=' | `..='

--- a/docs/_pages/grammar.md
+++ b/docs/_pages/grammar.md
@@ -37,7 +37,7 @@ prefixexp ::= NAME | '(' expr ')'
 primaryexp ::= prefixexp { `.' NAME | `[' exp `]' | `:' NAME funcargs | funcargs }
 asexp ::= simpleexp [`::' typeannotation]
 simpleexp ::= NUMBER | STRING | NIL | true | false | ... | constructor | FUNCTION body | primaryexp
-args ::=  `(' [explist] `)' | tableconstructor | String
+funcargs ::=  `(' [explist] `)' | tableconstructor | String
 
 compoundop :: `+=' | `-=' | `*=' | `/=' | `%=' | `^=' | `..='
 binop ::= `+' | `-' | `*' | `/' | `^' | `%' | `..' | `<' | `<=' | `>' | `>=' | `==' | `~=' | and | or

--- a/docs/_pages/grammar.md
+++ b/docs/_pages/grammar.md
@@ -1,0 +1,60 @@
+---
+permalink: /grammar
+title: Grammar
+toc: true
+---
+
+```
+chunk ::= {stat [`;']} [laststat [`;']]
+block ::= chunk
+stat ::= varlist `=' explist |
+    functioncall |
+    do block end |
+    while exp do block end |
+    repeat block until exp |
+    if exp then block {elseif exp then block} [else block] end |
+    for binding `=' exp `,' exp [`,' exp] do block end |
+    for namelist in explist do block end |
+    function funcname funcbody |
+    local function Name funcbody |
+    local namelist [`=' explist]
+
+laststat ::= return [explist] | break
+
+funcname ::= Name {`.' Name} [`:' Name]
+funcbody ::= `(' [parlist] `)' [`:' ReturnType] block end
+parlist ::= bindinglist [`,' `...'] | `...'
+explist ::= {exp `,'} exp
+bindinglist ::= (binding | `...') [`,' bindinglist]
+
+subexpr ::= (asexp | unop subexpr) { binop subexpr }
+prefixexp ::= NAME | '(' expr ')'
+primaryexp ::= prefixexp { `.' NAME | `[' exp `]' | `:' NAME funcargs | funcargs }
+asexp ::= simpleexp [`::' typeannotation]
+simpleexp ::= NUMBER | STRING | NIL | true | false | ... | constructor | FUNCTION body | primaryexp
+args ::=  `(' [explist] `)' | tableconstructor | String
+
+tableconstructor ::= `{' [fieldlist] `}'
+fieldlist ::= field {fieldsep field} [fieldsep]
+field ::= `[' exp `]' `=' exp | Name `=' exp | exp
+fieldsep ::= `,' | `;'
+
+typeannotation ::=
+      nil |
+      Name[`.' Name] [`<' namelist `>'] |
+     `{' [PropList] `}' |
+      `(' [TypeList] `)' `->` ReturnType
+      `typeof` typeannotation
+
+typeannotation ::= nil | Name[`.' Name] [ `<' typeannotation [`,' ...] `>' ] | `typeof' `(' expr `)' | `{' [PropList] `}' | [`<' varlist `>'] `(' [TypeList] `)' `->` ReturnType
+
+TypeList ::= TypeAnnotation [`,' TypeList] | ...TypeAnnotation
+ReturnType ::= TypeAnnotation | `(' TypeList `)'
+TableIndexer ::= `[' TypeAnnotation `]' `:' TypeAnnotation
+TableProp ::= Name `:' TypeAnnotation
+TablePropOrIndexer ::= TableProp | TableIndexer
+PropList ::= TablePropOrIndexer {fieldsep TablePropOrIndexer} [fieldsep]
+TableTypeAnnotation ::= `{' PropList `}'
+FunctionTypeAnnotation ::= [`<' varlist `>'] `(' [TypeList] `)' `->` ReturnType
+
+```

--- a/docs/_pages/grammar.md
+++ b/docs/_pages/grammar.md
@@ -17,19 +17,20 @@ stat ::= varlist `=' explist |
     for binding `=' exp `,' exp [`,' exp] do block end |
     for bindinglist in explist do block end |
     function funcname funcbody |
-    local function Name funcbody |
+    local function NAME funcbody |
     local bindinglist [`=' explist] |
-    [export] type Name [`<' GenericTypeList `>'] `=' TypeAnnotation
+    [export] type NAME [`<' GenericTypeList `>'] `=' TypeAnnotation
 
 laststat ::= return [explist] | break | continue
 
-funcname ::= Name {`.' Name} [`:' Name]
+funcname ::= NAME {`.' NAME} [`:' NAME]
 funcbody ::= `(' [parlist] `)' [`:' ReturnType] block end
 parlist ::= bindinglist [`,' `...'] | `...'
-explist ::= {exp `,'} exp
-namelist ::= Name {`,' Name}
 
-binding ::= Name [`:' TypeAnnotation]
+explist ::= {exp `,'} exp
+namelist ::= NAME {`,' NAME}
+
+binding ::= NAME [`:' TypeAnnotation]
 bindinglist ::= (binding | `...') [`,' bindinglist]
 
 subexpr ::= (asexp | unop subexpr) { binop subexpr }
@@ -37,21 +38,21 @@ ifelseexp ::= if exp then exp {elseif exp then exp} else exp
 prefixexp ::= NAME | '(' expr ')'
 primaryexp ::= prefixexp { `.' NAME | `[' exp `]' | `:' NAME funcargs | funcargs }
 asexp ::= simpleexp [`::' TypeAnnotation]
-simpleexp ::= NUMBER | STRING | NIL | true | false | ... | constructor | FUNCTION body | primaryexp | ifelseexp
-funcargs ::=  `(' [explist] `)' | tableconstructor | String
+simpleexp ::= NUMBER | STRING | nil | true | false | ... | tableconstructor | function body | primaryexp | ifelseexp
+funcargs ::=  `(' [explist] `)' | tableconstructor | STRING
+
+tableconstructor ::= `{' [fieldlist] `}'
+fieldlist ::= field {fieldsep field} [fieldsep]
+field ::= `[' exp `]' `=' exp | NAME `=' exp | exp
+fieldsep ::= `,' | `;'
 
 compoundop :: `+=' | `-=' | `*=' | `/=' | `%=' | `^=' | `..='
 binop ::= `+' | `-' | `*' | `/' | `^' | `%' | `..' | `<' | `<=' | `>' | `>=' | `==' | `~=' | and | or
 unop ::= `-' | not | `#´
 
-tableconstructor ::= `{' [fieldlist] `}'
-fieldlist ::= field {fieldsep field} [fieldsep]
-field ::= `[' exp `]' `=' exp | Name `=' exp | exp
-fieldsep ::= `,' | `;'
-
 SimpleTypeAnnotation ::=
     nil |
-    Name[`.' Name] [ `<' TypeAnnotation [`,' ...] `>' ] |
+    NAME[`.' NAME] [ `<' TypeAnnotation [`,' ...] `>' ] |
     `typeof' `(' expr `)' |
     `{' [PropList] `}' |
     FunctionTypeAnnotation
@@ -65,7 +66,7 @@ GenericTypeList ::= NAME [`...'] {`,' NAME}
 TypeList ::= TypeAnnotation [`,' TypeList] | ...TypeAnnotation
 ReturnType ::= TypeAnnotation | `(' TypeList `)'
 TableIndexer ::= `[' TypeAnnotation `]' `:' TypeAnnotation
-TableProp ::= Name `:' TypeAnnotation
+TableProp ::= NAME `:' TypeAnnotation
 TablePropOrIndexer ::= TableProp | TableIndexer
 PropList ::= TablePropOrIndexer {fieldsep TablePropOrIndexer} [fieldsep]
 TableTypeAnnotation ::= `{' PropList `}'

--- a/docs/_pages/grammar.md
+++ b/docs/_pages/grammar.md
@@ -28,6 +28,8 @@ funcbody ::= `(' [parlist] `)' [`:' ReturnType] block end
 parlist ::= bindinglist [`,' `...'] | `...'
 explist ::= {exp `,'} exp
 namelist ::= Name {`,' Name}
+
+binding ::= Name [`:' typeannotation]
 bindinglist ::= (binding | `...') [`,' bindinglist]
 
 subexpr ::= (asexp | unop subexpr) { binop subexpr }

--- a/docs/_pages/grammar.md
+++ b/docs/_pages/grammar.md
@@ -15,10 +15,10 @@ stat ::= varlist `=' explist |
     repeat block until exp |
     if exp then block {elseif exp then block} [else block] end |
     for binding `=' exp `,' exp [`,' exp] do block end |
-    for namelist in explist do block end |
+    for bindinglist in explist do block end |
     function funcname funcbody |
     local function Name funcbody |
-    local namelist [`=' explist] |
+    local bindinglist [`=' explist] |
     [export] type Name [`<' GenericTypeList `>'] `=' typeannotation
 
 laststat ::= return [explist] | break | continue

--- a/docs/_pages/grammar.md
+++ b/docs/_pages/grammar.md
@@ -7,6 +7,8 @@ toc: true
 This is the complete syntax grammar for Luau in EBNF. More information about the terminal nodes String and Number
 is available in the [syntax section](syntax).
 
+> Note: this grammar is currently missing type pack syntax for generic arguments
+
 ```ebnf
 chunk ::= {stat [`;']} [laststat [`;']]
 block ::= chunk

--- a/docs/_pages/grammar.md
+++ b/docs/_pages/grammar.md
@@ -4,6 +4,9 @@ title: Grammar
 toc: true
 ---
 
+This is the complete syntax grammar for Luau in EBNF. More information about the terminal nodes Name, String and Number
+is available in the [syntax section](syntax).
+
 ```
 chunk ::= {stat [`;']} [laststat [`;']]
 block ::= chunk


### PR DESCRIPTION
This PR adds grammar documentation to the webpage (closes #148)

I got the initial definitions (available in the initial commit) from the comments in https://github.com/Roblox/luau/blob/master/Ast/src/Parser.cpp.

Subsequent commits deal with including definitions which were missing, fixing incorrect definitions, and tidying up the definitions. I've tried to break it up into small commits so you can see the changes I made against the initial definitions in the Parser.cpp file - you may want the comments updated in Parser.cpp in a different PR.

A few things of note:
- `bindinglist` is a strange one, it has the option to allow 3 dots depending on what we are parsing, which isn't something I can express in EBNF (to my knowledge). I was kinda confused what the 3 dots were about, I *think* its for the `...` vararg in a parameter list? but thats also described in `parlist`, so I'm not entirely sure. I took the `bindinglist` definition from the comments in Parser.cpp, but it is also used in local declarations and for loops, so it doesn't really fit right now.
- Bit confused on what to do with `functioncall`, it seems to be a subpart of `primaryexp`, but primaryexp also contains normally indexing. I wasn't sure whether to break it down like in Lua5.1/5.4, as I didn't want to deviate from how it works internally.
- Theres a few inconsistencies around the place, `exp` or `expr`? `STRING` or `String` for terminal nodes? all lower case vs. PascalCase for definitions (PascalCase seems to only be used for type-related definitions?). I've normalised (most) of them to be consistent, but maybe you want it a bit different.

I've worked my way through Parser.cpp to come up with the document, but I'm bound to have missed something. Let me know if there's a mistake somewhere!