### PR TITLE
Fix spelling error of 'ROBLOX'

### DIFF
--- a/VM/src/lvmutils.cpp
+++ b/VM/src/lvmutils.cpp
@@ -53,7 +53,7 @@ const float* luaV_tovector(const TValue* obj)
 static void callTMres(lua_State* L, StkId res, const TValue* f, const TValue* p1, const TValue* p2)
 {
     ptrdiff_t result = savestack(L, res);
-    // ROBLOX: using stack room beyond top is technically safe here, but for very complicated reasons:
+    // using stack room beyond top is technically safe here, but for very complicated reasons:
     // * The stack guarantees 1 + EXTRA_STACK room beyond stack_last (see luaD_reallocstack) will be allocated
     // * we cannot move luaD_checkstack above because the arguments are *sometimes* pointers to the lua
     // stack and checkstack may invalidate those pointers
@@ -74,7 +74,7 @@ static void callTMres(lua_State* L, StkId res, const TValue* f, const TValue* p1
 
 static void callTM(lua_State* L, const TValue* f, const TValue* p1, const TValue* p2, const TValue* p3)
 {
-    // ROBLOX: using stack room beyond top is technically safe here, but for very complicated reasons:
+    // using stack room beyond top is technically safe here, but for very complicated reasons:
     // * The stack guarantees 1 + EXTRA_STACK room beyond stack_last (see luaD_reallocstack) will be allocated
     // * we cannot move luaD_checkstack above because the arguments are *sometimes* pointers to the lua
     // stack and checkstack may invalidate those pointers

--- a/VM/src/lvmutils.cpp
+++ b/VM/src/lvmutils.cpp
@@ -53,7 +53,7 @@ const float* luaV_tovector(const TValue* obj)
 static void callTMres(lua_State* L, StkId res, const TValue* f, const TValue* p1, const TValue* p2)
 {
     ptrdiff_t result = savestack(L, res);
-    // RBOLOX: using stack room beyond top is technically safe here, but for very complicated reasons:
+    // ROBLOX: using stack room beyond top is technically safe here, but for very complicated reasons:
     // * The stack guarantees 1 + EXTRA_STACK room beyond stack_last (see luaD_reallocstack) will be allocated
     // * we cannot move luaD_checkstack above because the arguments are *sometimes* pointers to the lua
     // stack and checkstack may invalidate those pointers
@@ -74,7 +74,7 @@ static void callTMres(lua_State* L, StkId res, const TValue* f, const TValue* p1
 
 static void callTM(lua_State* L, const TValue* f, const TValue* p1, const TValue* p2, const TValue* p3)
 {
-    // RBOLOX: using stack room beyond top is technically safe here, but for very complicated reasons:
+    // ROBLOX: using stack room beyond top is technically safe here, but for very complicated reasons:
     // * The stack guarantees 1 + EXTRA_STACK room beyond stack_last (see luaD_reallocstack) will be allocated
     // * we cannot move luaD_checkstack above because the arguments are *sometimes* pointers to the lua
     // stack and checkstack may invalidate those pointers


### PR DESCRIPTION
Self explanatory! 👍 