### PR TITLE
Fix Json Encoding for AstArray<T>

### DIFF
--- a/Analysis/src/JsonEncoder.cpp
+++ b/Analysis/src/JsonEncoder.cpp
@@ -262,7 +262,7 @@ struct AstJsonEncoder : public AstVisitor
             if (comma)
                 writeRaw(",");
             else
-                comma = false;
+                comma = true;
 
             write(a);
         }


### PR DESCRIPTION
Fix JsonEncoder so that AstArray elems are given commas separating them.

Old output excerpt (not valid JSON):
```json
{
        "type": "AstExprFunction",
        "location": "0,611 - 0,786",
        "generics": [],
        "genericPacks": [],
        "args": [
            "p1"
            "s1"
            "B1"
        ],
```

New output excerpt (valid JSON):
```json
{
        "type": "AstExprFunction",
        "location": "0,611 - 0,786",
        "generics": [],
        "genericPacks": [],
        "args": [
            "p1",
            "s1",
            "B1"
        ],
```