### PR TITLE
Switch coverage build to checkout@v2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,22 +66,24 @@ jobs:
 
   coverage:
     runs-on: ubuntu-latest
-    env:
-      NODE_COVERALLS_DEBUG: 1
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: install
       run: |
         sudo apt install llvm
     - name: make coverage
       run: |
         CXX=clang++-10 make -j2 config=coverage coverage
+    - name: debug coverage
+      run: |
+        git status
+        git log -5
+        echo SHA: $GITHUB_SHA
     - name: upload coverage
       uses: coverallsapp/github-action@master
       with:
         path-to-lcov: ./coverage.info
         github-token: ${{ secrets.GITHUB_TOKEN }}
-      continue-on-error: false
     - uses: actions/upload-artifact@v2
       with:
         name: coverage


### PR DESCRIPTION
Attempt to fix coverage builds by using checkout@v2 instead of v1 which might fix the detached HEAD issue.

On the off chance it doesn't, add extra logging around git specifically.

See https://github.com/lemurheavy/coveralls-public/issues/1595 + https://github.com/coverallsapp/github-action/issues/55