### PR TITLE
Update compatibility.md to split coroutine.close from lua_resetthread

### DIFF
--- a/docs/_pages/compatibility.md
+++ b/docs/_pages/compatibility.md
@@ -107,8 +107,7 @@ Floor division is less harmful, but it's used rarely enough that `math.floor(a/b
 | const variables | ❌ | while there's some demand for const variables, we'd never adopt this syntax |
 | new implementation for math.random | ✔️ | our RNG is based on PCG, unlike Lua 5.4 which uses Xoroshiro |
 | optional `init` argument to `string.gmatch` | 🤷‍♀️ | no strong use cases |
-| new function `lua_resetthread`| 🤷‍ | not useful without to-be-closed variables |
-| new function `coroutine.close`| ✔️ ||
+| new functions `lua_resetthread` and `coroutine.close` | ✔️ ||
 | coercions string-to-number moved to the string library | 😞 | we love this, but it breaks compatibility |
 | new format `%p` in `string.format` | 🤷‍♀️ | no strong use cases |
 | `utf8` library accepts codepoints up to 2^31 | 🤷‍♀️ | no strong use cases |

--- a/docs/_pages/compatibility.md
+++ b/docs/_pages/compatibility.md
@@ -107,7 +107,8 @@ Floor division is less harmful, but it's used rarely enough that `math.floor(a/b
 | const variables | ❌ | while there's some demand for const variables, we'd never adopt this syntax |
 | new implementation for math.random | ✔️ | our RNG is based on PCG, unlike Lua 5.4 which uses Xoroshiro |
 | optional `init` argument to `string.gmatch` | 🤷‍♀️ | no strong use cases |
-| new functions `lua_resetthread` and `coroutine.close` | 🤷‍ | not useful without to-be-closed variables |
+| new function `lua_resetthread`| 🤷‍ | not useful without to-be-closed variables |
+| new function `coroutine.close`| ✔️ ||
 | coercions string-to-number moved to the string library | 😞 | we love this, but it breaks compatibility |
 | new format `%p` in `string.format` | 🤷‍♀️ | no strong use cases |
 | `utf8` library accepts codepoints up to 2^31 | 🤷‍♀️ | no strong use cases |


### PR DESCRIPTION
Considering how coroutine.close was added recently, it would make sense to rework this document to split `lua_resetthread` and `coroutine.close` because of this, to mark one as ticked and the other as not currently available.