### PR TITLE
Improve Grammar documentation

### DIFF
--- a/docs/_pages/grammar.md
+++ b/docs/_pages/grammar.md
@@ -71,11 +71,13 @@ Type =
     SimpleType ['|' Type] |
     SimpleType ['&' Type]
 
-GenericTypePack = NAME '...' ['=' (TypePack | '...' Type | NAME '...')]
-GenericTypeList = NAME ['=' Type] [',' GenericTypeList] | GenericTypePack {',' GenericTypePack}
+GenericTypePackParameter = NAME '...' ['=' (TypePack | VariadicTypePack | GenericTypePack)]
+GenericTypeParameterList = NAME ['=' Type] [',' GenericTypeParameterList] | GenericTypePackParameter {',' GenericTypePackParameter}
 TypeList = Type [',' TypeList] | '...' Type
-TypeParams = (Type | TypePack | '...' Type | NAME '...') [',' TypeParams]
+TypeParams = (Type | TypePack | VariadicTypePack | GenericTypePack) [',' TypeParams]
 TypePack = '(' [TypeList] ')'
+GenericTypePack = NAME '...'
+VariadicTypePack = '...' Type
 ReturnType = Type | TypePack
 TableIndexer = '[' Type ']' ':' Type
 TableProp = NAME ':' Type

--- a/docs/_pages/grammar.md
+++ b/docs/_pages/grammar.md
@@ -58,13 +58,13 @@ unop = '-' | 'not' | '#'
 
 SimpleType =
     'nil' |
-    STRING |
-    'true' |
-    'false' |
+    SingletonType |
     NAME ['.' NAME] [ '<' [TypeParams] '>' ] |
     'typeof' '(' exp ')' |
     TableType |
     FunctionType
+
+SingletonType = STRING | 'true' | 'false'
 
 Type =
     SimpleType ['?'] |

--- a/docs/_pages/grammar.md
+++ b/docs/_pages/grammar.md
@@ -73,7 +73,7 @@ Type =
     SimpleType ['|' Type] |
     SimpleType ['&' Type]
 
-GenericTypeList = NAME ['...'] {',' NAME ['...']}
+GenericTypeList = NAME [',' GenericTypeList] | NAME '...' {',' NAME '...'}
 TypeList = Type [',' TypeList] | '...' Type
 ReturnType = Type | '(' TypeList ')'
 TableIndexer = '[' Type ']' ':' Type

--- a/docs/_pages/grammar.md
+++ b/docs/_pages/grammar.md
@@ -73,7 +73,8 @@ Type =
     SimpleType ['|' Type] |
     SimpleType ['&' Type]
 
-GenericTypeList = NAME [',' GenericTypeList] | NAME '...' {',' NAME '...'}
+GenericTypePack = NAME '...' ['=' '(' TypeList ')']
+GenericTypeList = NAME ['=' Type] [',' GenericTypeList] | GenericTypePack {',' GenericTypePack}
 TypeList = Type [',' TypeList] | '...' Type
 ReturnType = Type | '(' TypeList ')'
 TableIndexer = '[' Type ']' ':' Type

--- a/docs/_pages/grammar.md
+++ b/docs/_pages/grammar.md
@@ -71,7 +71,7 @@ Type =
     SimpleType ['|' Type] |
     SimpleType ['&' Type]
 
-GenericTypePack = NAME '...' ['=' '(' TypeList ')']
+GenericTypePack = NAME '...' ['=' (TypePack | '...' Type | NAME '...')]
 GenericTypeList = NAME ['=' Type] [',' GenericTypeList] | GenericTypePack {',' GenericTypePack}
 TypeList = Type [',' TypeList] | '...' Type
 TypeParams = (Type | TypePack | '...' Type | NAME '...') [',' TypeParams]

--- a/docs/_pages/grammar.md
+++ b/docs/_pages/grammar.md
@@ -29,7 +29,7 @@ stat = varlist '=' explist |
 laststat = 'return' [explist] | 'break' | 'continue'
 
 funcname = NAME {'.' NAME} [':' NAME]
-funcbody = '(' [parlist] ')' [':' ReturnType] block 'end'
+funcbody = ['<' GenericTypeList '>'] '(' [parlist] ')' [':' ReturnType] block 'end'
 parlist = bindinglist [',' '...'] | '...'
 
 explist = {exp ','} exp

--- a/docs/_pages/grammar.md
+++ b/docs/_pages/grammar.md
@@ -7,8 +7,6 @@ classes: wide
 This is the complete syntax grammar for Luau in EBNF. More information about the terminal nodes String and Number
 is available in the [syntax section](syntax).
 
-> Note: this grammar is currently missing type pack syntax for generic arguments
-
 ```ebnf
 chunk = block
 block = {stat [';']} [laststat [';']]
@@ -63,7 +61,7 @@ SimpleType =
     STRING |
     'true' |
     'false' |
-    NAME ['.' NAME] [ '<' TypeList '>' ] |
+    NAME ['.' NAME] [ '<' [TypeParams] '>' ] |
     'typeof' '(' exp ')' |
     TableType |
     FunctionType
@@ -76,7 +74,9 @@ Type =
 GenericTypePack = NAME '...' ['=' '(' TypeList ')']
 GenericTypeList = NAME ['=' Type] [',' GenericTypeList] | GenericTypePack {',' GenericTypePack}
 TypeList = Type [',' TypeList] | '...' Type
-ReturnType = Type | '(' TypeList ')'
+TypeParams = (Type | TypePack | '...' Type | NAME '...') [',' TypeParams]
+TypePack = '(' [TypeList] ')'
+ReturnType = Type | TypePack
 TableIndexer = '[' Type ']' ':' Type
 TableProp = NAME ':' Type
 TablePropOrIndexer = TableProp | TableIndexer

--- a/docs/_pages/grammar.md
+++ b/docs/_pages/grammar.md
@@ -60,6 +60,9 @@ unop = '-' | 'not' | '#'
 
 SimpleType =
     'nil' |
+    STRING |
+    'true' |
+    'false' |
     NAME ['.' NAME] [ '<' TypeList '>' ] |
     'typeof' '(' exp ')' |
     TableType |

--- a/docs/_pages/grammar.md
+++ b/docs/_pages/grammar.md
@@ -22,12 +22,12 @@ stat = varlist '=' explist |
     'function' funcname funcbody |
     'local' 'function' NAME funcbody |
     'local' bindinglist ['=' explist] |
-    ['export'] 'type' NAME ['<' GenericTypeList '>'] '=' Type
+    ['export'] 'type' NAME ['<' GenericTypeParameterList '>'] '=' Type
 
 laststat = 'return' [explist] | 'break' | 'continue'
 
 funcname = NAME {'.' NAME} [':' NAME]
-funcbody = ['<' GenericTypeList '>'] '(' [parlist] ')' [':' ReturnType] block 'end'
+funcbody = ['<' GenericTypeParameterList '>'] '(' [parlist] ')' [':' ReturnType] block 'end'
 parlist = bindinglist [',' '...'] | '...'
 
 explist = {exp ','} exp


### PR DESCRIPTION
- Adds grammar for singleton types (string/boolean)
- Fixes the correctness of generic type declarations:
       Previously, the definition allowed `type Foo<T..., U> = ...`, but this is incorrect since generic types must be before generic type packs. This corrects the definition
- Adds grammar for default types for generic type declarations
- Fixes the grammar for function definitions: now allows generic type declarations `function foo<T>(param) ... end`
- Improves generic type argument grammar (adding type packs + generic/variadic type packs): e.g. `Foo<string, (number, string), ...number>`