### PR TITLE
Emit more information for AstLocals in JSON encoder

### DIFF
--- a/Analysis/src/JsonEncoder.cpp
+++ b/Analysis/src/JsonEncoder.cpp
@@ -150,6 +150,10 @@ struct AstJsonEncoder : public AstVisitor
     {
         writeRaw(std::to_string(i));
     }
+    void write(std::nullptr_t)
+    {
+        writeRaw("null");
+    }
     void write(std::string_view str)
     {
         writeString(str);
@@ -177,7 +181,16 @@ struct AstJsonEncoder : public AstVisitor
 
     void write(AstLocal* local)
     {
-        write(local->name);
+        writeRaw("{");
+        bool c = pushComma();
+        if (local->annotation != nullptr)
+            write("type", local->annotation);
+        else
+            write("type", nullptr);
+        write("name", local->name);
+        write("location", local->location);
+        popComma(c);
+        writeRaw("}");
     }
 
     void writeNode(AstNode* node)

--- a/tests/JsonEncoder.test.cpp
+++ b/tests/JsonEncoder.test.cpp
@@ -46,7 +46,7 @@ TEST_CASE("encode_AstStatBlock")
     AstStatBlock block{Location(), bodyArray};
 
     CHECK_EQ(
-        (R"({"type":"AstStatBlock","location":"0,0 - 0,0","body":[{"type":"AstStatLocal","location":"0,0 - 0,0","vars":["a_local"],"values":[]}]})"),
+        (R"({"type":"AstStatBlock","location":"0,0 - 0,0","body":[{"type":"AstStatLocal","location":"0,0 - 0,0","vars":[{"type":null,"name":"a_local","location":"0,0 - 0,0"}],"values":[]}]})"),
         toJson(&block));
 }
 


### PR DESCRIPTION
We don't emit type annotations right now for `AstLocal`s in the JSON encoder. This makes it really hard to surface annotations in the Agda implementation. This PR changes it to emit location and type annotations, if present.