### PR TITLE
Revise GHA workflows for prototyping

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,12 +9,14 @@ on:
       - 'papers/**'
       - 'rfcs/**'
       - '*.md'
+      - 'prototyping/**'
   pull_request:
     paths-ignore:
       - 'docs/**'
       - 'papers/**'
       - 'rfcs/**'
       - '*.md'
+      - 'prototyping/**'
 
 jobs:
   unix:

--- a/.github/workflows/prototyping.yml
+++ b/.github/workflows/prototyping.yml
@@ -8,12 +8,18 @@ on:
     paths:
       - '.github/workflows/**'
       - 'prototyping/**'
-      - 'Analysis/src/JsonEncoder.cpp'
+      - 'Analysis/**'
+      - 'Ast/**'
+      - 'CLI/Ast.cpp'
+      - 'CLI/FileUtils.*'
   pull_request:
     paths:
       - '.github/workflows/**'
       - 'prototyping/**'
-      - 'Analysis/src/JsonEncoder.cpp'
+      - 'Analysis/**'
+      - 'Ast/**'
+      - 'CLI/Ast.cpp'
+      - 'CLI/FileUtils.*'
 
 jobs:
   linux:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ on:
       - 'papers/**'
       - 'rfcs/**'
       - '*.md'
+      - 'prototyping/**'
 
 jobs:
   build:


### PR DESCRIPTION
Changed the GHA workflows to:
- Not run `build` and `release` workflows for PRs that only affect `prototyping/`
- Run `prototyping` workflow when PRs affect `Analysis/**`, `Ast/**`, or the `luau-ast` source files