### PR TITLE
Revert "Mark singleton types RFC as implemented (#370)"

### DIFF
--- a/rfcs/STATUS.md
+++ b/rfcs/STATUS.md
@@ -23,6 +23,12 @@ This document tracks unimplemented RFCs.
 
 **Status**: Implemented but depends on new transaction log implementation that is not fully live yet.
 
+## Singleton types
+
+[RFC: Singleton types](https://github.com/Roblox/luau/blob/master/rfcs/syntax-singleton-types.md)
+
+**Status**: Implemented but not fully rolled out yet.
+
 ## Nil-forgiving operator
 
 [RFC: nil-forgiving postfix operator !](https://github.com/Roblox/luau/blob/master/rfcs/syntax-nil-forgiving-operator.md)

--- a/rfcs/syntax-singleton-types.md
+++ b/rfcs/syntax-singleton-types.md
@@ -2,8 +2,6 @@
 
 > Note: this RFC was adapted from an internal proposal that predates RFC process
 
-**Status**: Implemented
-
 ## Summary
 
 Introduce a new kind of type variable, called singleton types. They are just like normal types but has the capability to represent a constant runtime value as a type.


### PR DESCRIPTION
This reverts commit 731e197757ead8908e558cfc63f9d518f53940d5.

We had to revert singleton type support on Roblox due to bad interaction with refinements