### PR TITLE
Update prototyping.yml

### DIFF
--- a/.github/workflows/prototyping.yml
+++ b/.github/workflows/prototyping.yml
@@ -1,25 +1,10 @@
 name: prototyping
 
 on:
-  push:
-    branches:
-      - 'master'
-      - 'prototyping-*'
-    paths:
-      - '.github/workflows/**'
-      - 'prototyping/**'
-      - 'Analysis/**'
-      - 'Ast/**'
-      - 'CLI/Ast.cpp'
-      - 'CLI/FileUtils.*'
   pull_request:
     paths:
-      - '.github/workflows/**'
+      - '.github/workflows/prototyping.yml'
       - 'prototyping/**'
-      - 'Analysis/**'
-      - 'Ast/**'
-      - 'CLI/Ast.cpp'
-      - 'CLI/FileUtils.*'
 
 jobs:
   linux:


### PR DESCRIPTION
This limits the scope of prototyping action to PRs to prototyping branch to minimize the GHA cost / latency, as cabal install sometimes takes forever