### PR TITLE
Mark singleton types and unsealed table literals RFCs as implemented

### DIFF
--- a/rfcs/STATUS.md
+++ b/rfcs/STATUS.md
@@ -17,14 +17,7 @@ This document tracks unimplemented RFCs.
 
 ## Sealed/unsealed typing changes
 
-[RFC: Unsealed table literals](https://github.com/Roblox/luau/blob/master/rfcs/unsealed-table-literals.md) |
 [RFC: Only strip optional properties from unsealed tables during subtyping](https://github.com/Roblox/luau/blob/master/rfcs/unsealed-table-subtyping-strips-optional-properties.md)
-
-**Status**: Implemented but not fully rolled out yet.
-
-## Singleton types
-
-[RFC: Singleton types](https://github.com/Roblox/luau/blob/master/rfcs/syntax-singleton-types.md)
 
 **Status**: Implemented but not fully rolled out yet.
 

--- a/rfcs/STATUS.md
+++ b/rfcs/STATUS.md
@@ -18,7 +18,6 @@ This document tracks unimplemented RFCs.
 ## Sealed/unsealed typing changes
 
 [RFC: Only strip optional properties from unsealed tables during subtyping](https://github.com/Roblox/luau/blob/master/rfcs/unsealed-table-subtyping-strips-optional-properties.md)
-[RFC: Unsealed table assignment creates an optional property](https://github.com/Roblox/luau/blob/master/rfcs/unsealed-table-assign-optional-property.md)
 
 **Status**: Implemented but not fully rolled out yet.
 

--- a/rfcs/STATUS.md
+++ b/rfcs/STATUS.md
@@ -18,6 +18,7 @@ This document tracks unimplemented RFCs.
 ## Sealed/unsealed typing changes
 
 [RFC: Only strip optional properties from unsealed tables during subtyping](https://github.com/Roblox/luau/blob/master/rfcs/unsealed-table-subtyping-strips-optional-properties.md)
+[RFC: Unsealed table assignment creates an optional property](https://github.com/Roblox/luau/blob/master/rfcs/unsealed-table-assign-optional-property.md)
 
 **Status**: Implemented but not fully rolled out yet.
 

--- a/rfcs/STATUS.md
+++ b/rfcs/STATUS.md
@@ -40,3 +40,9 @@ This document tracks unimplemented RFCs.
 [RFC: Generalized iteration](https://github.com/Roblox/luau/blob/master/rfcs/generalized-iteration.md)
 
 **Status**: Needs implementation
+
+## Lower Bounds Calculation
+
+[RFC: Lower bounds calculation](https://github.com/Roblox/luau/blob/master/rfcs/lower-bounds-calculation.md)
+
+**Status**: Needs implementation

--- a/rfcs/function-bit32-countlz-countrz.md
+++ b/rfcs/function-bit32-countlz-countrz.md
@@ -1,10 +1,10 @@
 # bit32.countlz/countrz
 
+**Status**: Implemented
+
 ## Summary
 
 Add bit32.countlz (count left zeroes) and bit32.countrz (count right zeroes) to accelerate bit scanning
-
-**Status**: Implemented
 
 ## Motivation
 

--- a/rfcs/function-coroutine-close.md
+++ b/rfcs/function-coroutine-close.md
@@ -1,10 +1,10 @@
 # coroutine.close
 
+**Status**: Implemented
+
 ## Summary
 
 Add `coroutine.close` function from Lua 5.4 that takes a suspended coroutine and makes it "dead" (non-runnable).
-
-**Status**: Implemented
 
 ## Motivation
 

--- a/rfcs/syntax-safe-navigation-operator.md
+++ b/rfcs/syntax-safe-navigation-operator.md
@@ -1,5 +1,7 @@
 # Safe navigation postfix operator (?)
 
+**Note**: We have unresolved issues with interaction between this feature and Roblox instance hierarchy. This may affect the viability of this proposal.
+
 ## Summary
 
 Introduce syntax to navigate through `nil` values, or short-circuit with `nil` if it was encountered.

--- a/rfcs/syntax-singleton-types.md
+++ b/rfcs/syntax-singleton-types.md
@@ -2,6 +2,8 @@
 
 > Note: this RFC was adapted from an internal proposal that predates RFC process
 
+**Status**: Implemented
+
 ## Summary
 
 Introduce a new kind of type variable, called singleton types. They are just like normal types but has the capability to represent a constant runtime value as a type.

--- a/rfcs/syntax-type-ascription-bidi.md
+++ b/rfcs/syntax-type-ascription-bidi.md
@@ -1,10 +1,10 @@
 # Relaxing type assertions
 
+**Status**: Implemented
+
 ## Summary
 
 The way `::` works today is really strange.  The best solution we can come up with is to allow `::` to convert between any two related types.
-
-**Status**: Implemented
 
 ## Motivation
 

--- a/rfcs/unsealed-table-assign-optional-property.md
+++ b/rfcs/unsealed-table-assign-optional-property.md
@@ -1,5 +1,7 @@
 # Unsealed table assignment creates an optional property
 
+**Status**: Implemented
+
 ## Summary
 
 In Luau, tables have a state, which can, among others, be "unsealed".

--- a/rfcs/unsealed-table-literals.md
+++ b/rfcs/unsealed-table-literals.md
@@ -1,5 +1,7 @@
 # Unsealed table literals
 
+**Status**: Implemented
+
 ## Summary
 
 Currently the only way to create an unsealed table is as an empty table literal `{}`.


### PR DESCRIPTION
This also cleans up formatting of status notes in a few RFCs and adds some missed RFCs to status page