### PR TITLE
Fix JsonEncoder for AstExprTable

### DIFF
--- a/Analysis/src/JsonEncoder.cpp
+++ b/Analysis/src/JsonEncoder.cpp
@@ -403,35 +403,26 @@ struct AstJsonEncoder : public AstVisitor
     void write(const AstExprTable::Item& item)
     {
         writeRaw("{");
-        bool comma = pushComma();
+        bool c = pushComma();
         write("kind", item.kind);
         switch (item.kind)
         {
         case AstExprTable::Item::List:
-            write(item.value);
+            write("value", item.value);
             break;
         default:
-            write(item.key);
-            writeRaw(",");
-            write(item.value);
+            write("key", item.key);
+            write("value", item.value);
             break;
         }
-        popComma(comma);
+        popComma(c);
         writeRaw("}");
     }
 
     void write(class AstExprTable* node)
     {
         writeNode(node, "AstExprTable", [&]() {
-            bool comma = false;
-            for (const auto& prop : node->items)
-            {
-                if (comma)
-                    writeRaw(",");
-                else
-                    comma = true;
-                write(prop);
-            }
+            PROP(items);
         });
     }
 

--- a/tests/JsonEncoder.test.cpp
+++ b/tests/JsonEncoder.test.cpp
@@ -1,6 +1,7 @@
 // This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
 #include "Luau/Ast.h"
 #include "Luau/JsonEncoder.h"
+#include "Luau/Parser.h"
 
 #include "doctest.h"
 
@@ -48,6 +49,26 @@ TEST_CASE("encode_AstStatBlock")
     CHECK_EQ(
         (R"({"type":"AstStatBlock","location":"0,0 - 0,0","body":[{"type":"AstStatLocal","location":"0,0 - 0,0","vars":[{"type":null,"name":"a_local","location":"0,0 - 0,0"}],"values":[]}]})"),
         toJson(&block));
+}
+
+TEST_CASE("encode_tables")
+{
+    std::string src = R"(
+        local x: {
+            foo: number
+        } = {
+            foo = 123,
+        }
+    )";
+
+    Allocator allocator;
+    AstNameTable names(allocator);
+    ParseResult parseResult = Parser::parse(src.c_str(), src.length(), names, allocator);
+
+    REQUIRE(parseResult.errors.size() == 0);
+    std::string json = toJson(parseResult.root);
+
+    CHECK(json == R"({"type":"AstStatBlock","location":"0,0 - 6,4","body":[{"type":"AstStatLocal","location":"1,8 - 5,9","vars":[{"type":{"type":"AstTypeTable","location":"1,17 - 3,9","props":[{"name":"foo","location":"2,12 - 2,15","type":{"type":"AstTypeReference","location":"2,17 - 2,23","name":"number","parameters":[]}}],"indexer":false},"name":"x","location":"1,14 - 1,15"}],"values":[{"type":"AstExprTable","location":"3,12 - 5,9","items":[{"kind":"record","key":{"type":"AstExprConstantString","location":"4,12 - 4,15","value":"foo"},"value":{"type":"AstExprConstantNumber","location":"4,18 - 4,21","value":123}}]}]}]})");
 }
 
 TEST_SUITE_END();


### PR DESCRIPTION
JsonEncoder wasn't producing valid JSON for `AstExprTable`s. This PR fixes it. The new output looks like
```json
{
    "type": "AstStatBlock",
    "location": "0,0 - 6,4",
    "body": [
        {
            "type": "AstStatLocal",
            "location": "1,8 - 5,9",
            "vars": [
                {
                    "name": "x",
                    "location": "1,14 - 1,15"
                }
            ],
            "values": [
                {
                    "type": "AstExprTable",
                    "location": "3,12 - 5,9",
                    "items": [
                        {
                            "kind": "record",
                            "key": {
                                "type": "AstExprConstantString",
                                "location": "4,12 - 4,15",
                                "value": "foo"
                            },
                            "value": {
                                "type": "AstExprConstantNumber",
                                "location": "4,18 - 4,21",
                                "value": 123
                            }
                        }
                    ]
                }
            ]
        }
    ]
}
```