### PR TITLE
Fix non-C locale issues in REPL

### DIFF
--- a/CLI/Repl.cpp
+++ b/CLI/Repl.cpp
@@ -21,6 +21,8 @@
 #include <fcntl.h>
 #endif
 
+#include <locale.h>
+
 LUAU_FASTFLAG(DebugLuauTimeTracing)
 
 enum class CliMode

--- a/CLI/Repl.cpp
+++ b/CLI/Repl.cpp
@@ -435,6 +435,9 @@ static void runReplImpl(lua_State* L)
 {
     ic_set_default_completer(completeRepl, L);
 
+    // Reset the locale to C
+    setlocale(LC_ALL, "C");
+
     // Make brace matching easier to see
     ic_style_def("ic-bracematch", "teal");
 


### PR DESCRIPTION
This fixes #473 by resetting the locale to `C` after calling `ic_set_default_completer` (which eventually calls `setlocale(LC_ALL,"")`) in `runReplImpl`.