### PR TITLE
fix feed link in footer

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -10,7 +10,7 @@ logo: /assets/images/luau-88.png
 plugins: ["jekyll-include-cache", "jekyll-feed"]
 include: ["_pages"]
 atom_feed:
-  path: feed.xml
+  path: "/feed.xml"
 
 defaults:
  # _docs


### PR DESCRIPTION
Currently, the feed link on pages such as https://luau-lang.org/news/ will lead to https://luau-lang.org/news/feed.xml because the path config is relative to the current directory. This would lead to broken RSS feed links on some pages. This pull request resolves it by adding a `/` to the path. 