### PR TITLE
Add `ToStringOptions.hideFunctionSelfArgument`

### DIFF
--- a/Analysis/include/Luau/ToString.h
+++ b/Analysis/include/Luau/ToString.h
@@ -28,6 +28,7 @@ struct ToStringOptions
     bool functionTypeArguments = false;           // If true, output function type argument names when they are available
     bool hideTableKind = false;                   // If true, all tables will be surrounded with plain '{}'
     bool hideNamedFunctionTypeParameters = false; // If true, type parameters of functions will be hidden at top-level.
+    bool hideFunctionSelfArgument = false;        // If true, `self: X` will be omitted from the function signature if the function has self
     bool indent = false;
     size_t maxTableLength = size_t(FInt::LuauTableTypeMaximumStringifierLength); // Only applied to TableTypeVars
     size_t maxTypeLength = size_t(FInt::LuauTypeMaximumStringifierLength);

--- a/Analysis/src/ToString.cpp
+++ b/Analysis/src/ToString.cpp
@@ -1230,6 +1230,14 @@ std::string toStringNamedFunction(const std::string& funcName, const FunctionTyp
         size_t idx = 0;
         while (argPackIter != end(ftv.argTypes))
         {
+            // ftv takes a self parameter as the first argument, skip it if specified in option
+            if (idx == 0 && ftv.hasSelf && opts.hideFunctionSelfArgument)
+            {
+                ++argPackIter;
+                ++idx;
+                continue;
+            }
+
             if (!first)
                 state.emit(", ");
             first = false;

--- a/tests/ToString.test.cpp
+++ b/tests/ToString.test.cpp
@@ -617,4 +617,40 @@ TEST_CASE_FIXTURE(Fixture, "toStringNamedFunction_overrides_param_names")
     CHECK_EQ("test<a>(first: a, second: string, ...: number): a", toStringNamedFunction("test", *ftv, opts));
 }
 
+TEST_CASE_FIXTURE(Fixture, "toStringNamedFunction_include_self_param")
+{
+    ScopedFastFlag flag{"LuauDocFuncParameters", true};
+    CheckResult result = check(R"(
+        local foo = {}
+        function foo:method(arg: string): ()
+        end
+    )");
+
+    TypeId parentTy = requireType("foo");
+    auto ttv = get<TableTypeVar>(follow(parentTy));
+    auto ftv = get<FunctionTypeVar>(ttv->props.at("method").type);
+
+    CHECK_EQ("foo:method<a>(self: a, arg: string): ()", toStringNamedFunction("foo:method", *ftv));
+}
+
+
+TEST_CASE_FIXTURE(Fixture, "toStringNamedFunction_hide_self_param")
+{
+    ScopedFastFlag flag{"LuauDocFuncParameters", true};
+    CheckResult result = check(R"(
+        local foo = {}
+        function foo:method(arg: string): ()
+        end
+    )");
+
+    TypeId parentTy = requireType("foo");
+    auto ttv = get<TableTypeVar>(follow(parentTy));
+    auto ftv = get<FunctionTypeVar>(ttv->props.at("method").type);
+
+    ToStringOptions opts;
+    opts.hideFunctionSelfArgument = true;
+    CHECK_EQ("foo:method<a>(arg: string): ()", toStringNamedFunction("foo:method", *ftv, opts));
+}
+
+
 TEST_SUITE_END();


### PR DESCRIPTION
Adds an option to hide the `self: type` argument as the first argument in the string representation of a named function type var if the ftv hasSelf.

Also added in a test for the original output (i.e., if the option was disabled)

I didn't apply this option in the normal `Luau::toString()` function, just the `Luau::toStringNamedFunction()` one (for my usecase, that is enough + I felt like a named function would include the method colon `:` to signify self). If this is unintuitive, I can also add it to the general `Luau::toString()` function.

