### PR TITLE
Respect useLineBreaks for union/intersect toString

### DIFF
--- a/Analysis/src/ToString.cpp
+++ b/Analysis/src/ToString.cpp
@@ -744,8 +744,10 @@ struct TypeVarStringifier
         bool first = true;
         for (std::string& ss : results)
         {
-            if (!first)
-                state.emit(" | ");
+            if (!first) {
+                state.newline();
+                state.emit("| ");
+            }
             state.emit(ss);
             first = false;
         }
@@ -797,8 +799,10 @@ struct TypeVarStringifier
         bool first = true;
         for (std::string& ss : results)
         {
-            if (!first)
-                state.emit(" & ");
+            if (!first) {
+                state.newline();
+                state.emit("& ");
+            }
             state.emit(ss);
             first = false;
         }

--- a/Analysis/src/ToString.cpp
+++ b/Analysis/src/ToString.cpp
@@ -744,7 +744,8 @@ struct TypeVarStringifier
         bool first = true;
         for (std::string& ss : results)
         {
-            if (!first) {
+            if (!first)
+            {
                 state.newline();
                 state.emit("| ");
             }
@@ -799,7 +800,8 @@ struct TypeVarStringifier
         bool first = true;
         for (std::string& ss : results)
         {
-            if (!first) {
+            if (!first)
+            {
                 state.newline();
                 state.emit("& ");
             }

--- a/tests/ToString.test.cpp
+++ b/tests/ToString.test.cpp
@@ -136,8 +136,8 @@ TEST_CASE_FIXTURE(Fixture, "intersections_respects_use_line_breaks")
     opts.useLineBreaks = true;
 
     //clang-format off
-    CHECK_EQ("((number) -> number)"
-             "\n& ((string) -> string)",
+    CHECK_EQ("((number) -> number)\n"
+             "& ((string) -> string)",
         toString(requireType("a"), opts));
     //clang-format on
 }
@@ -152,9 +152,9 @@ TEST_CASE_FIXTURE(Fixture, "unions_respects_use_line_breaks")
     opts.useLineBreaks = true;
 
     //clang-format off
-    CHECK_EQ("boolean"
-             "\n| number"
-             "\n| string",
+    CHECK_EQ("boolean\n"
+             "| number\n"
+             "| string",
         toString(requireType("a"), opts));
     //clang-format on
 }

--- a/tests/ToString.test.cpp
+++ b/tests/ToString.test.cpp
@@ -126,6 +126,39 @@ TEST_CASE_FIXTURE(Fixture, "functions_are_always_parenthesized_in_unions_or_inte
     CHECK_EQ(toString(&itv), "((number, string) -> (string, number)) & ((string, number) -> (number, string))");
 }
 
+TEST_CASE_FIXTURE(Fixture, "intersections_respects_use_line_breaks")
+{
+    CheckResult result = check(R"(
+        local a: ((string) -> string) & ((number) -> number)
+    )");
+
+    ToStringOptions opts;
+    opts.useLineBreaks = true;
+
+    //clang-format off
+    CHECK_EQ("((number) -> number)"
+             "\n& ((string) -> string)",
+        toString(requireType("a"), opts));
+    //clang-format on
+}
+
+TEST_CASE_FIXTURE(Fixture, "unions_respects_use_line_breaks")
+{
+    CheckResult result = check(R"(
+        local a: string | number | boolean
+    )");
+
+    ToStringOptions opts;
+    opts.useLineBreaks = true;
+
+    //clang-format off
+    CHECK_EQ("boolean"
+             "\n| number"
+             "\n| string",
+        toString(requireType("a"), opts));
+    //clang-format on
+}
+
 TEST_CASE_FIXTURE(Fixture, "quit_stringifying_table_type_when_length_is_exceeded")
 {
     TableTypeVar ttv{};


### PR DESCRIPTION
This change makes `Luau::toString()` on a union or interesection type respect the `useLineBreaks` option in ToStringOption.

This mostly comes up in large function type intersections. For example for the type of `game:GetService`:
```lua
((self: ServiceProvider, service: "ABTestService") -> ABTestService) & ((self: ServiceProvider, service: "AdService") -> AdService) & ((self: ServiceProvider, service: "AnalyticsService") -> AnalyticsService) & ((self: ServiceProvider, service: "AnimationClipProvider") -> AnimationClipProvider) & ((self: ServiceProvider, service: "AnimationFromVideoCreatorService") -> AnimationFromVideoCreatorService) & ((self: ServiceProvider, service: "AnimationFromVideoCreatorStudioService") -> AnimationFromVideoCreatorStudioService)... <TRUNCATED>
```

Is now formatted as
```lua
((self: ServiceProvider, service: "ABTestService") -> ABTestService)
& ((self: ServiceProvider, service: "AdService") -> AdService)
& ((self: ServiceProvider, service: "AnalyticsService") -> AnalyticsService)
& ((self: ServiceProvider, service: "AnimationClipProvider") -> AnimationClipProvider)
& ((self: ServiceProvider, service: "AnimationFromVideoCreatorService") -> AnimationFromVideoCreatorService)
& ((self: ServiceProvider, service: "AnimationFromVideoCreatorStudioService") -> AnimationFromVideoCreatorStudioService)... <TRUNCATED>
```

Which makes this much nicer to read.
The equivalent is done for union operations.

<details>
<summary>Example when used in VSCode hover string</summary>

![image](https://user-images.githubusercontent.com/19635171/168839415-120ef78d-e70b-465c-809d-1d4cf6e4e537.png)

![image](https://user-images.githubusercontent.com/19635171/168838918-c6d2d1a5-0cfc-441a-98c4-2abb765f40e4.png)

</details>

I realise that I think this `toString` operation is used internally for Studio's hover string. So I understand if this is undesirable behaviour / conflicts with studio internally (given that its the introduction of a lot more vertical space).