### PR TITLE
Add lua_tolightuserdata, optimized lua_topointer

### DIFF
--- a/VM/include/lua.h
+++ b/VM/include/lua.h
@@ -148,6 +148,7 @@ LUA_API const char* lua_tostringatom(lua_State* L, int idx, int* atom);
 LUA_API const char* lua_namecallatom(lua_State* L, int* atom);
 LUA_API int lua_objlen(lua_State* L, int idx);
 LUA_API lua_CFunction lua_tocfunction(lua_State* L, int idx);
+LUA_API void* lua_tolightuserdata(lua_State* L, int idx);
 LUA_API void* lua_touserdata(lua_State* L, int idx);
 LUA_API void* lua_touserdatatagged(lua_State* L, int idx, int tag);
 LUA_API int lua_userdatatag(lua_State* L, int idx);

--- a/VM/src/lapi.cpp
+++ b/VM/src/lapi.cpp
@@ -478,6 +478,12 @@ lua_CFunction lua_tocfunction(lua_State* L, int idx)
     return (!iscfunction(o)) ? NULL : cast_to(lua_CFunction, clvalue(o)->c.f);
 }
 
+void* lua_tolightuserdata(lua_State* L, int idx)
+{
+    StkId o = index2addr(L, idx);
+    return (!ttislightuserdata(o)) ? NULL : pvalue(o);
+}
+
 void* lua_touserdata(lua_State* L, int idx)
 {
     StkId o = index2addr(L, idx);
@@ -524,8 +530,9 @@ const void* lua_topointer(lua_State* L, int idx)
     case LUA_TTHREAD:
         return thvalue(o);
     case LUA_TUSERDATA:
+        return uvalue(o)->data;
     case LUA_TLIGHTUSERDATA:
-        return lua_touserdata(L, idx);
+        return pvalue(o);
     default:
         return NULL;
     }

--- a/VM/src/lapi.cpp
+++ b/VM/src/lapi.cpp
@@ -487,15 +487,13 @@ void* lua_tolightuserdata(lua_State* L, int idx)
 void* lua_touserdata(lua_State* L, int idx)
 {
     StkId o = index2addr(L, idx);
-    switch (ttype(o))
-    {
-    case LUA_TUSERDATA:
+    // fast-path: check userdata first since it is most likely the expected result
+    if (ttisuserdata(o))
         return uvalue(o)->data;
-    case LUA_TLIGHTUSERDATA:
+    else if (ttislightuserdata(o))
         return pvalue(o);
-    default:
+    else
         return NULL;
-    }
 }
 
 void* lua_touserdatatagged(lua_State* L, int idx, int tag)

--- a/tests/Conformance.test.cpp
+++ b/tests/Conformance.test.cpp
@@ -1066,6 +1066,7 @@ TEST_CASE("UserdataApi")
     int lud;
     lua_pushlightuserdata(L, &lud);
 
+    CHECK(lua_tolightuserdata(L, -1) == &lud);
     CHECK(lua_touserdata(L, -1) == &lud);
     CHECK(lua_topointer(L, -1) == &lud);
 
@@ -1073,6 +1074,7 @@ TEST_CASE("UserdataApi")
     int* ud1 = (int*)lua_newuserdata(L, 4);
     *ud1 = 42;
 
+    CHECK(lua_tolightuserdata(L, -1) == nullptr);
     CHECK(lua_touserdata(L, -1) == ud1);
     CHECK(lua_topointer(L, -1) == ud1);
 


### PR DESCRIPTION
This change adds lua_tolightuserdata to the public API. Rationale:

First, it's faster than lua_touserdata when working purely with lightuserdata values. In our codebase we use lightuserdata for opaque 64-bit object handles (handles to objects managed by C++ code). With lua_touserlightdata we are seeing up to 8% performance improvement in Lua to C++ calls that use these handles. I believe this is a common use-case for lightuserdata.

Secondly, since the API already has lua_pushlightuserdata and lua_islightuserdata, it would make sense to have lua_tolightuserdata for completeness.

I also optimized lua_topointer a bit by reducing branching in userdata case.