### PR TITLE
Switch to -j3 for build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,26 @@ jobs:
     - uses: actions/checkout@v1
     - name: make test
       run: |
+        make -j2 config=sanitize werror=1 test
+    - name: make test w/flags
+      run: |
+        make -j2 config=sanitize werror=1 flags=true test
+    - name: make cli
+      run: |
+         make -j2 config=sanitize werror=1 luau luau-analyze # match config with tests to improve build time
+         ./luau tests/conformance/assert.lua
+         ./luau-analyze tests/conformance/assert.lua
+
+  unix3:
+    strategy:
+      matrix:
+        os: [ubuntu, macos]
+    name: ${{matrix.os}}-3
+    runs-on: ${{matrix.os}}-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: make test
+      run: |
         make -j3 config=sanitize werror=1 test
     - name: make test w/flags
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,13 +29,13 @@ jobs:
     - uses: actions/checkout@v1
     - name: make test
       run: |
-        make -j2 config=sanitize werror=1 test
+        make -j3 config=sanitize werror=1 test
     - name: make test w/flags
       run: |
-        make -j2 config=sanitize werror=1 flags=true test
+        make -j3 config=sanitize werror=1 flags=true test
     - name: make cli
       run: |
-         make -j2 config=sanitize werror=1 luau luau-analyze # match config with tests to improve build time
+         make -j3 config=sanitize werror=1 luau luau-analyze # match config with tests to improve build time
          ./luau tests/conformance/assert.lua
          ./luau-analyze tests/conformance/assert.lua
 


### PR DESCRIPTION
GHA uses 3-core machines for macOS so this tests if we're going to get better build times with an extra core.