### PR TITLE
Add lua_State* argument to lua_newuserdatadtor destructors

### DIFF
--- a/VM/include/lua.h
+++ b/VM/include/lua.h
@@ -177,7 +177,7 @@ LUA_API int lua_pushthread(lua_State* L);
 
 LUA_API void lua_pushlightuserdata(lua_State* L, void* p);
 LUA_API void* lua_newuserdatatagged(lua_State* L, size_t sz, int tag);
-LUA_API void* lua_newuserdatadtor(lua_State* L, size_t sz, void (*dtor)(void*));
+LUA_API void* lua_newuserdatadtor(lua_State* L, size_t sz, void (*dtor)(lua_State*, void*));
 
 /*
 ** get functions (Lua -> stack)

--- a/VM/src/lapi.cpp
+++ b/VM/src/lapi.cpp
@@ -1213,7 +1213,7 @@ void* lua_newuserdatatagged(lua_State* L, size_t sz, int tag)
     return u->data;
 }
 
-void* lua_newuserdatadtor(lua_State* L, size_t sz, void (*dtor)(void*))
+void* lua_newuserdatadtor(lua_State* L, size_t sz, void (*dtor)(lua_State*, void*))
 {
     luaC_checkGC(L);
     luaC_checkthreadsleep(L);

--- a/VM/src/ludata.cpp
+++ b/VM/src/ludata.cpp
@@ -31,10 +31,10 @@ void luaU_freeudata(lua_State* L, Udata* u, lua_Page* page)
     }
     else if (u->tag == UTAG_IDTOR)
     {
-        void (*dtor)(void*) = nullptr;
+        void (*dtor)(lua_State*, void*) = nullptr;
         memcpy(&dtor, &u->data + u->len - sizeof(dtor), sizeof(dtor));
         if (dtor)
-            dtor(u->data);
+            dtor(L, u->data);
     }
 
 

--- a/VM/src/ludata.cpp
+++ b/VM/src/ludata.cpp
@@ -22,21 +22,15 @@ Udata* luaU_newudata(lua_State* L, size_t s, int tag)
 
 void luaU_freeudata(lua_State* L, Udata* u, lua_Page* page)
 {
+    void (*dtor)(lua_State*, void*) = nullptr;
+ 
     if (u->tag < LUA_UTAG_LIMIT)
-    {
-        void (*dtor)(lua_State*, void*) = nullptr;
         dtor = L->global->udatagc[u->tag];
-        if (dtor)
-            dtor(L, u->data);
-    }
     else if (u->tag == UTAG_IDTOR)
-    {
-        void (*dtor)(lua_State*, void*) = nullptr;
         memcpy(&dtor, &u->data + u->len - sizeof(dtor), sizeof(dtor));
-        if (dtor)
-            dtor(L, u->data);
-    }
 
-
+    if (dtor)
+        dtor(L, u->data);
+ 
     luaM_freegco(L, u, sizeudata(u->len), u->memcat, page);
 }

--- a/tests/Conformance.test.cpp
+++ b/tests/Conformance.test.cpp
@@ -668,10 +668,10 @@ TEST_CASE("Reference")
     lua_State* L = globalState.get();
 
     // note, we push two userdata objects but only pin one of them (the first one)
-    lua_newuserdatadtor(L, 0, [](void*) {
+    lua_newuserdatadtor(L, 0, [](lua_State*, void*) {
         dtorhits++;
     });
-    lua_newuserdatadtor(L, 0, [](void*) {
+    lua_newuserdatadtor(L, 0, [](lua_State*, void*) {
         dtorhits++;
     });
 
@@ -1092,11 +1092,11 @@ TEST_CASE("UserdataApi")
     CHECK(lua_userdatatag(L, -1) == 42);
 
     // user data with inline dtor
-    void* ud3 = lua_newuserdatadtor(L, 4, [](void* data) {
+    void* ud3 = lua_newuserdatadtor(L, 4, [](lua_State*, void* data) {
         dtorhits += *(int*)data;
     });
 
-    void* ud4 = lua_newuserdatadtor(L, 1, [](void* data) {
+    void* ud4 = lua_newuserdatadtor(L, 1, [](lua_State*, void* data) {
         dtorhits += *(char*)data;
     });
 


### PR DESCRIPTION
Currently lua_State* argument is missing from destructors registered with lua_newuserdatadtor:
```
lua_newuserdatadtor(lua_State* L, size_t sz, void (*dtor)(void*));
lua_setuserdatadtor(lua_State* L, int tag, void (*dtor)(lua_State*, void*))
```

This change adds the missing argument.

Typical use-case is cleaning up some Lua state specific data when the destructor is run. This also makes the API more consistent.

The only downside is that the ABI changes.