### PR TITLE
Allow vec4 constructor to work with 3-4 arguments

### DIFF
--- a/VM/src/lbuiltins.cpp
+++ b/VM/src/lbuiltins.cpp
@@ -1018,18 +1018,20 @@ static int luauF_tunpack(lua_State* L, StkId res, TValue* arg0, int nresults, St
 
 static int luauF_vector(lua_State* L, StkId res, TValue* arg0, int nresults, StkId args, int nparams)
 {
-#if LUA_VECTOR_SIZE == 4
-    if (nparams >= 4 && nresults <= 1 && ttisnumber(arg0) && ttisnumber(args) && ttisnumber(args + 1) && ttisnumber(args + 2))
-#else
     if (nparams >= 3 && nresults <= 1 && ttisnumber(arg0) && ttisnumber(args) && ttisnumber(args + 1))
-#endif
     {
         double x = nvalue(arg0);
         double y = nvalue(args);
         double z = nvalue(args + 1);
 
 #if LUA_VECTOR_SIZE == 4
-        double w = nvalue(args + 2);
+        double w = 0.0;
+        if (nparams >= 4)
+        {
+            if (!ttisnumber(args + 2))
+                return -1;
+            w = nvalue(args + 2);
+        }
         setvvalue(res, float(x), float(y), float(z), float(w));
 #else
         setvvalue(res, float(x), float(y), float(z), 0.0f);


### PR DESCRIPTION
A common use case for 4-wide vectors is to store 3D positions, offsets, etc. in the X/Y/Z components. Typically this is handled so that the 4th argument to the vector constructor is optional and the fourth component is padded with zero when necessary. However, currently vector fastcall constructor only works with 4 components so there's a big performance penalty unless the user always provides four arguments.

With this change the fastcall constructor works with 3 or 4 arguments when compiled with 4-wide vectors.

I wrote a simple benchmark to test this. The benchmark creates a large amount of vectors in a unrolled loop.

vector() called with three arguments
no fastcall: 438ms
with fastcall, original: 510ms
with fastcall, patched: 170ms

vector() called with four arguments
no fastcall: 498ms
with fastcall, original: 197ms
with fastcall, patched: 196ms

Constructing 4-wide vectors from 3 components is 3 times faster with this patch. There is practically no change to the results when four arguments are provided 

This patch has no effect unless 4-wide vectors are enabled.