### PR TITLE
Use syntheticName for stringified MetatableTypeVar

### DIFF
--- a/Analysis/src/ToString.cpp
+++ b/Analysis/src/ToString.cpp
@@ -700,6 +700,12 @@ struct TypeVarStringifier
     void operator()(TypeId, const MetatableTypeVar& mtv)
     {
         state.result.invalid = true;
+        if (!state.exhaustive && mtv.syntheticName)
+        {
+            state.emit(*mtv.syntheticName);
+            return;
+        }
+
         state.emit("{ @metatable ");
         stringify(mtv.metatable);
         state.emit(",");

--- a/tests/ToString.test.cpp
+++ b/tests/ToString.test.cpp
@@ -96,6 +96,37 @@ TEST_CASE_FIXTURE(Fixture, "table_respects_use_line_break")
     //clang-format on
 }
 
+TEST_CASE_FIXTURE(Fixture, "metatable")
+{
+    TypeVar table{TypeVariant(TableTypeVar())};
+    TypeVar metatable{TypeVariant(TableTypeVar())};
+    TypeVar mtv{TypeVariant(MetatableTypeVar{&table, &metatable})};
+    CHECK_EQ("{ @metatable {  }, {  } }", toString(&mtv));
+}
+
+TEST_CASE_FIXTURE(Fixture, "named_metatable")
+{
+    TypeVar table{TypeVariant(TableTypeVar())};
+    TypeVar metatable{TypeVariant(TableTypeVar())};
+    TypeVar mtv{TypeVariant(MetatableTypeVar{&table, &metatable, "NamedMetatable"})};
+    CHECK_EQ("NamedMetatable", toString(&mtv));
+}
+
+TEST_CASE_FIXTURE(BuiltinsFixture, "named_metatable_toStringNamedFunction")
+{
+    CheckResult result = check(R"(
+        local function createTbl(): NamedMetatable
+            return setmetatable({}, {})
+        end
+        type NamedMetatable = typeof(createTbl())
+    )");
+
+    TypeId ty = requireType("createTbl");
+    const FunctionTypeVar* ftv = get<FunctionTypeVar>(follow(ty));
+    REQUIRE(ftv);
+    CHECK_EQ("createTbl(): NamedMetatable", toStringNamedFunction("createTbl", *ftv));
+}
+
 TEST_CASE_FIXTURE(BuiltinsFixture, "exhaustive_toString_of_cyclic_table")
 {
     CheckResult result = check(R"(


### PR DESCRIPTION
Fixes #550 

Let me know if you want this stuck behind a FFlag