### PR TITLE
Fix broken link in typecheck.md

### DIFF
--- a/docs/_pages/typecheck.md
+++ b/docs/_pages/typecheck.md
@@ -48,7 +48,7 @@ local b2: B = a1 -- not ok
 
 ## Primitive types
 
-Lua VM supports 8 primitive types: `nil`, `string`, `number`, `boolean`, `table`, `function`, `thread`, and `userdata`. Of these, `table` and `function` are not represented by name, but have their dedicated syntax as covered in this [syntax document](syntax), and `userdata` is represented by [concrete types](#Roblox-types); other types can be specified by their name.
+Lua VM supports 8 primitive types: `nil`, `string`, `number`, `boolean`, `table`, `function`, `thread`, and `userdata`. Of these, `table` and `function` are not represented by name, but have their dedicated syntax as covered in this [syntax document](syntax), and `userdata` is represented by [concrete types](#roblox-types); other types can be specified by their name.
 
 Additionally, we also have `any` which is a special built-in type. It effectively disables all type checking, and thus should be used as last resort.
 


### PR DESCRIPTION
Current link redirects to 
https://luau-lang.org/typecheck#Roblox-types (notice the fragment) 
which is effectively the same as https://luau-lang.org/typecheck
What the link *wants* to redirect to is 
https://luau-lang.org/typecheck#roblox-types (notice the change in fragment) 
which is the Roblox types segment of the document

User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:102.0) Gecko/20100101 Firefox/102.0
(in case this ever worked in the past and is a problem on this browser specifically) 