### PR TITLE
Enhancement: Changed data output to be different for each os

### DIFF
--- a/.github/workflows/benchmark-dev.yml
+++ b/.github/workflows/benchmark-dev.yml
@@ -75,7 +75,7 @@ jobs:
           name: ${{ matrix.bench.title }} (Windows ${{matrix.arch}})
           tool: "benchmarkluau"
           output-file-path: ./${{ matrix.bench.script }}-output.txt
-          external-data-json-path: ./gh-pages/dev/bench/data.json
+          external-data-json-path: ./gh-pages/dev/bench/data-${{ matrix.os }}.json
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Push benchmark results
@@ -85,7 +85,7 @@ jobs:
           cd gh-pages
           git config user.name github-actions
           git config user.email github@users.noreply.github.com
-          git add ./dev/bench/data.json
+          git add ./dev/bench/data-${{ matrix.os }}.json
           git commit -m "Add benchmarks results for ${{ github.sha }}"
           git push
           cd ..
@@ -156,7 +156,7 @@ jobs:
           name: ${{ matrix.bench.title }}
           tool: "benchmarkluau"
           output-file-path: ./${{ matrix.bench.script }}-output.txt
-          external-data-json-path: ./gh-pages/dev/bench/data.json
+          external-data-json-path: ./gh-pages/dev/bench/data-${{ matrix.os }}.json
           github-token: ${{ secrets.BENCH_GITHUB_TOKEN }}
 
       - name: Store ${{ matrix.bench.title }} result (CacheGrind)
@@ -166,7 +166,7 @@ jobs:
           name: ${{ matrix.bench.title }} (CacheGrind)
           tool: "roblox"
           output-file-path: ./${{ matrix.bench.script }}-output.txt
-          external-data-json-path: ./gh-pages/dev/bench/data.json
+          external-data-json-path: ./gh-pages/dev/bench/data-${{ matrix.os }}.json
           github-token: ${{ secrets.BENCH_GITHUB_TOKEN }}
 
       - name: Push benchmark results
@@ -176,7 +176,7 @@ jobs:
           cd gh-pages
           git config user.name github-actions
           git config user.email github@users.noreply.github.com
-          git add ./dev/bench/data.json
+          git add ./dev/bench/data-${{ matrix.os }}.json
           git commit -m "Add benchmarks results for ${{ github.sha }}"
           git push
           cd ..
@@ -244,7 +244,7 @@ jobs:
 
           gh-pages-branch: "main"
           output-file-path: ./${{ matrix.bench.script }}-output.txt
-          external-data-json-path: ./gh-pages/dev/bench/data.json
+          external-data-json-path: ./gh-pages/dev/bench/data-${{ matrix.os }}.json
           github-token: ${{ secrets.BENCH_GITHUB_TOKEN }}
 
       - name: Store ${{ matrix.bench.title }} result (CacheGrind)
@@ -254,7 +254,7 @@ jobs:
           tool: "roblox"
           gh-pages-branch: "main"
           output-file-path: ./${{ matrix.bench.script }}-output.txt
-          external-data-json-path: ./gh-pages/dev/bench/data.json
+          external-data-json-path: ./gh-pages/dev/bench/data-${{ matrix.os }}.json
           github-token: ${{ secrets.BENCH_GITHUB_TOKEN }}
 
       - name: Push benchmark results
@@ -264,7 +264,7 @@ jobs:
           cd gh-pages
           git config user.name github-actions
           git config user.email github@users.noreply.github.com
-          git add ./dev/bench/data.json
+          git add ./dev/bench/data-${{ matrix.os }}.json
           git commit -m "Add benchmarks results for ${{ github.sha }}"
           git push
           cd ..


### PR DESCRIPTION
Each job will now send data [to a different file depending on what OS it belongs to](https://github.com/luau-lang/benchmark-data/tree/main/dev/bench)
- macos: `data-macos-latest.json`
- ubuntu: `data-ubuntu-latest.json`
- windows: `data-windows-latest.json`

This allows us to filter our workflow results by OS as can be seen [in this example.](https://allanjeremy.github.io/luau-benchmark-results/dev/bench/)

--
@zeux , would appreciate a review on the same