### PR TITLE
Add lua_setuserdatatag to update userdata tags

### DIFF
--- a/VM/include/lua.h
+++ b/VM/include/lua.h
@@ -64,14 +64,14 @@ enum lua_Type
     LUA_TNIL = 0,     /* must be 0 due to lua_isnoneornil */
     LUA_TBOOLEAN = 1, /* must be 1 due to l_isfalse */
 
-    
+
     LUA_TLIGHTUSERDATA,
     LUA_TNUMBER,
     LUA_TVECTOR,
 
     LUA_TSTRING, /* all types above this must be value types, all types below this must be GC types - see iscollectable */
 
-    
+
     LUA_TTABLE,
     LUA_TFUNCTION,
     LUA_TUSERDATA,
@@ -300,6 +300,7 @@ LUA_API uintptr_t lua_encodepointer(lua_State* L, uintptr_t p);
 
 LUA_API double lua_clock();
 
+LUA_API void lua_setuserdatatag(lua_State* L, int idx, int tag);
 LUA_API void lua_setuserdatadtor(lua_State* L, int tag, void (*dtor)(lua_State*, void*));
 
 LUA_API void lua_clonefunction(lua_State* L, int idx);

--- a/VM/src/lapi.cpp
+++ b/VM/src/lapi.cpp
@@ -1305,6 +1305,14 @@ void lua_unref(lua_State* L, int ref)
     return;
 }
 
+void lua_setuserdatatag(lua_State* L, int idx, int tag)
+{
+    api_check(L, unsigned(tag) < LUA_UTAG_LIMIT);
+    StkId o = index2addr(L, idx);
+    api_check(L, ttisuserdata(o));
+    uvalue(o)->tag = uint8_t(tag);
+}
+
 void lua_setuserdatadtor(lua_State* L, int tag, void (*dtor)(lua_State*, void*))
 {
     api_check(L, unsigned(tag) < LUA_UTAG_LIMIT);

--- a/tests/Conformance.test.cpp
+++ b/tests/Conformance.test.cpp
@@ -1152,6 +1152,10 @@ TEST_CASE("UserdataApi")
     CHECK(lua_touserdatatagged(L, -1, 41) == nullptr);
     CHECK(lua_userdatatag(L, -1) == 42);
 
+    lua_setuserdatatag(L, -1, 43);
+    CHECK(lua_userdatatag(L, -1) == 43);
+    lua_setuserdatatag(L, -1, 42);
+
     // user data with inline dtor
     void* ud3 = lua_newuserdatadtor(L, 4, [](void* data) {
         dtorhits += *(int*)data;


### PR DESCRIPTION
It could be useful to update userdata tags, for example if change underlying type.

I plan to use this in Rust in [mlua](https://github.com/khvzak/mlua) in order to mark userdata as destructed (and avoid running destructors).
