### PR TITLE
Add names to built in definition parameters

### DIFF
--- a/Analysis/src/BuiltinDefinitions.cpp
+++ b/Analysis/src/BuiltinDefinitions.cpp
@@ -221,7 +221,7 @@ void registerBuiltinTypes(TypeChecker& typeChecker)
 
     TypeId tableMetaMT = arena.addType(MetatableTypeVar{tabTy, genericMT});
 
-    addGlobalBinding(typeChecker, "getmetatable", makeFunction(arena, std::nullopt, {genericMT}, {}, {tableMetaMT}, {"tbl"}, {genericMT}), "@luau");
+    addGlobalBinding(typeChecker, "getmetatable", makeFunction(arena, std::nullopt, {genericMT}, {}, {tableMetaMT}, {"t"}, {genericMT}), "@luau");
 
     // clang-format off
     // setmetatable<T: {}, MT>(T, MT) -> { @metatable MT, T }

--- a/Analysis/src/BuiltinDefinitions.cpp
+++ b/Analysis/src/BuiltinDefinitions.cpp
@@ -221,7 +221,7 @@ void registerBuiltinTypes(TypeChecker& typeChecker)
 
     TypeId tableMetaMT = arena.addType(MetatableTypeVar{tabTy, genericMT});
 
-    addGlobalBinding(typeChecker, "getmetatable", makeFunction(arena, std::nullopt, {genericMT}, {}, {tableMetaMT}, {genericMT}), "@luau");
+    addGlobalBinding(typeChecker, "getmetatable", makeFunction(arena, std::nullopt, {genericMT}, {}, {tableMetaMT}, {"tbl"}, {genericMT}), "@luau");
 
     // clang-format off
     // setmetatable<T: {}, MT>(T, MT) -> { @metatable MT, T }

--- a/Analysis/src/EmbeddedBuiltinDefinitions.cpp
+++ b/Analysis/src/EmbeddedBuiltinDefinitions.cpp
@@ -13,17 +13,17 @@ declare bit32: {
     band: (...number) -> number,
     bor: (...number) -> number,
     bxor: (...number) -> number,
-    btest: (number, ...number) -> boolean,
-    rrotate: (number, number) -> number,
-    lrotate: (number, number) -> number,
-    lshift: (number, number) -> number,
-    arshift: (number, number) -> number,
-    rshift: (number, number) -> number,
-    bnot: (number) -> number,
-    extract: (number, number, number?) -> number,
-    replace: (number, number, number, number?) -> number,
-    countlz: (number) -> number,
-    countrz: (number) -> number,
+    btest: (n: number, ...number) -> boolean,
+    rrotate: (n: number, i: number) -> number,
+    lrotate: (n: number, i: number) -> number,
+    lshift: (n: number, i: number) -> number,
+    arshift: (n: number, i: number) -> number,
+    rshift: (n: number, i: number) -> number,
+    bnot: (n: number) -> number,
+    extract: (n: number, position: number, width: number?) -> number,
+    replace: (n: number, r: number, position: number, width: number?) -> number,
+    countlz: (n: number) -> number,
+    countrz: (n: number) -> number,
 }
 
 declare math: {
@@ -94,9 +94,9 @@ type DateTypeResult = {
 }
 
 declare os: {
-    time: (DateTypeArg?) -> number,
-    date: (string?, number?) -> DateTypeResult | string,
-    difftime: (DateTypeResult | number, DateTypeResult | number) -> number,
+    time: (time: DateTypeArg?) -> number,
+    date: (format: string?, time: number?) -> DateTypeResult | string,
+    difftime: (a: DateTypeResult | number, b: DateTypeResult | number) -> number,
     clock: () -> number,
 }
 
@@ -145,52 +145,52 @@ declare function loadstring<A...>(src: string, chunkname: string?): (((A...) -> 
 declare function newproxy(mt: boolean?): any
 
 declare coroutine: {
-    create: <A..., R...>((A...) -> R...) -> thread,
-    resume: <A..., R...>(thread, A...) -> (boolean, R...),
+    create: <A..., R...>(f: (A...) -> R...) -> thread,
+    resume: <A..., R...>(co: thread, A...) -> (boolean, R...),
     running: () -> thread,
-    status: (thread) -> "dead" | "running" | "normal" | "suspended",
+    status: (co: thread) -> "dead" | "running" | "normal" | "suspended",
     -- FIXME: This technically returns a function, but we can't represent this yet.
-    wrap: <A..., R...>((A...) -> R...) -> any,
+    wrap: <A..., R...>(f: (A...) -> R...) -> any,
     yield: <A..., R...>(A...) -> R...,
     isyieldable: () -> boolean,
-    close: (thread) -> (boolean, any)
+    close: (co: thread) -> (boolean, any)
 }
 
 declare table: {
-    concat: <V>({V}, string?, number?, number?) -> string,
-    insert: (<V>({V}, V) -> ()) & (<V>({V}, number, V) -> ()),
-    maxn: <V>({V}) -> number,
-    remove: <V>({V}, number?) -> V?,
-    sort: <V>({V}, ((V, V) -> boolean)?) -> (),
-    create: <V>(number, V?) -> {V},
-    find: <V>({V}, V, number?) -> number?,
+    concat: <V>(tbl: {V}, sep: string?, from: number?, to: number?) -> string,
+    insert: (<V>(tbl: {V}, value: V) -> ()) & (<V>(tbl: {V}, index: number, value: V) -> ()),
+    maxn: <V>(tbl: {V}) -> number,
+    remove: <V>(tbl: {V}, index: number?) -> V?,
+    sort: <V>(tbl: {V}, f: ((V, V) -> boolean)?) -> (),
+    create: <V>(size: number, value: V?) -> {V},
+    find: <V>(tbl: {V}, value: V, startIndex: number?) -> number?,
 
-    unpack: <V>({V}, number?, number?) -> ...V,
+    unpack: <V>(tbl: {V}, from: number?, to: number?) -> ...V,
     pack: <V>(...V) -> { n: number, [number]: V },
 
-    getn: <V>({V}) -> number,
-    foreach: <K, V>({[K]: V}, (K, V) -> ()) -> (),
-    foreachi: <V>({V}, (number, V) -> ()) -> (),
+    getn: <V>(tbl: {V}) -> number,
+    foreach: <K, V>(tbl: {[K]: V}, f: (key: K, value: V) -> ()) -> (),
+    foreachi: <V>(tbl: {V}, (index: number, value: V) -> ()) -> (),
 
-    move: <V>({V}, number, number, number, {V}?) -> {V},
-    clear: <K, V>({[K]: V}) -> (),
+    move: <V>(tbl: {V}, from: number, to: number, startIndex: number, newTbl: {V}?) -> {V},
+    clear: <K, V>(tbl: {[K]: V}) -> (),
 
-    isfrozen: <K, V>({[K]: V}) -> boolean,
+    isfrozen: <K, V>(tbl: {[K]: V}) -> boolean,
 }
 
 declare debug: {
-    info: (<R...>(thread, number, string) -> R...) & (<R...>(number, string) -> R...) & (<A..., R1..., R2...>((A...) -> R1..., string) -> R2...),
-    traceback: ((string?, number?) -> string) & ((thread, string?, number?) -> string),
+    info: (<R...>(co: thread, level: number, s: string) -> R...) & (<R...>(level: number, s: string) -> R...) & (<A..., R1..., R2...>(f: (A...) -> R1..., s: string) -> R2...),
+    traceback: ((msg: string?, level: number?) -> string) & ((co: thread, message: string?, level: number?) -> string),
 }
 
 declare utf8: {
     char: (...number) -> string,
     charpattern: string,
-    codes: (string) -> ((string, number) -> (number, number), string, number),
+    codes: (str: string) -> ((string, number) -> (number, number), string, number),
     -- FIXME
-    codepoint: (string, number?, number?) -> (number, ...number),
-    len: (string, number?, number?) -> (number?, number?),
-    offset: (string, number?, number?) -> number,
+    codepoint: (str: string, startOffset: number?, endOffset: number?) -> (number, ...number),
+    len: (str: string, startOffset: number?, endOffset: number?) -> (number?, number?),
+    offset: (str: string, codepoint: number?, bytePosition: number?) -> number,
     nfdnormalize: (string) -> string,
     nfcnormalize: (string) -> string,
     graphemes: (string, number?, number?) -> (() -> (number, number)),

--- a/Analysis/src/EmbeddedBuiltinDefinitions.cpp
+++ b/Analysis/src/EmbeddedBuiltinDefinitions.cpp
@@ -170,7 +170,7 @@ declare table: {
 
     getn: <V>(tbl: {V}) -> number,
     foreach: <K, V>(tbl: {[K]: V}, f: (key: K, value: V) -> ()) -> (),
-    foreachi: <V>(tbl: {V}, (index: number, value: V) -> ()) -> (),
+    foreachi: <V>(tbl: {V}, f: (index: number, value: V) -> ()) -> (),
 
     move: <V>(tbl: {V}, from: number, to: number, startIndex: number, newTbl: {V}?) -> {V},
     clear: <K, V>(tbl: {[K]: V}) -> (),

--- a/Analysis/src/EmbeddedBuiltinDefinitions.cpp
+++ b/Analysis/src/EmbeddedBuiltinDefinitions.cpp
@@ -20,8 +20,8 @@ declare bit32: {
     arshift: (n: number, i: number) -> number,
     rshift: (n: number, i: number) -> number,
     bnot: (n: number) -> number,
-    extract: (n: number, position: number, width: number?) -> number,
-    replace: (n: number, r: number, position: number, width: number?) -> number,
+    extract: (n: number, f: number, w: number?) -> number,
+    replace: (n: number, r: number, f: number, w: number?) -> number,
     countlz: (n: number) -> number,
     countrz: (n: number) -> number,
 }
@@ -94,8 +94,8 @@ type DateTypeResult = {
 }
 
 declare os: {
-    time: (time: DateTypeArg?) -> number,
-    date: (format: string?, time: number?) -> DateTypeResult | string,
+    time: (t: DateTypeArg?) -> number,
+    date: (s: string?, t: number?) -> DateTypeResult | string,
     difftime: (a: DateTypeResult | number, b: DateTypeResult | number) -> number,
     clock: () -> number,
 }
@@ -115,25 +115,25 @@ declare function type<T>(value: T): string
 declare function typeof<T>(value: T): string
 
 -- `assert` has a magic function attached that will give more detailed type information
-declare function assert<T>(value: T, errorMessage: string?): T
+declare function assert<T>(value: T, message: string?): T
 
 declare function tostring<T>(value: T): string
 declare function tonumber<T>(value: T, radix: number?): number?
 
 declare function rawequal<T1, T2>(a: T1, b: T2): boolean
-declare function rawget<K, V>(tab: {[K]: V}, k: K): V
-declare function rawset<K, V>(tab: {[K]: V}, k: K, v: V): {[K]: V}
+declare function rawget<K, V>(t: {[K]: V}, k: K): V
+declare function rawset<K, V>(t: {[K]: V}, k: K, v: V): {[K]: V}
 
 declare function setfenv<T..., R...>(target: number | (T...) -> R..., env: {[string]: any}): ((T...) -> R...)?
 
-declare function ipairs<V>(tab: {V}): (({V}, number) -> (number, V), {V}, number)
+declare function ipairs<V>(t: {V}): (({V}, number) -> (number, V), {V}, number)
 
 declare function pcall<A..., R...>(f: (A...) -> R..., ...: A...): (boolean, R...)
 
 -- FIXME: The actual type of `xpcall` is:
 -- <E, A..., R1..., R2...>(f: (A...) -> R1..., err: (E) -> R2..., A...) -> (true, R1...) | (false, R2...)
 -- Since we can't represent the return value, we use (boolean, R1...).
-declare function xpcall<E, A..., R1..., R2...>(f: (A...) -> R1..., err: (E) -> R2..., ...: A...): (boolean, R1...)
+declare function xpcall<E, A..., R1..., R2...>(f: (A...) -> R1..., e: (E) -> R2..., ...: A...): (boolean, R1...)
 
 -- `select` has a magic function attached to provide more detailed type information
 declare function select<A...>(i: string | number, ...: A...): ...any
@@ -157,30 +157,30 @@ declare coroutine: {
 }
 
 declare table: {
-    concat: <V>(tbl: {V}, sep: string?, from: number?, to: number?) -> string,
-    insert: (<V>(tbl: {V}, value: V) -> ()) & (<V>(tbl: {V}, index: number, value: V) -> ()),
-    maxn: <V>(tbl: {V}) -> number,
-    remove: <V>(tbl: {V}, index: number?) -> V?,
-    sort: <V>(tbl: {V}, f: ((V, V) -> boolean)?) -> (),
-    create: <V>(size: number, value: V?) -> {V},
-    find: <V>(tbl: {V}, value: V, startIndex: number?) -> number?,
+    concat: <V>(t: {V}, sep: string?, f: number?, t: number?) -> string,
+    insert: (<V>(t: {V}, value: V) -> ()) & (<V>(t: {V}, i: number, v: V) -> ()),
+    maxn: <V>(t: {V}) -> number,
+    remove: <V>(t: {V}, i: number?) -> V?,
+    sort: <V>(t: {V}, f: ((V, V) -> boolean)?) -> (),
+    create: <V>(n: number, v: V?) -> {V},
+    find: <V>(t: {V}, v: V, i: number?) -> number?,
 
-    unpack: <V>(tbl: {V}, from: number?, to: number?) -> ...V,
+    unpack: <V>(a: {V}, f: number?, t: number?) -> ...V,
     pack: <V>(...V) -> { n: number, [number]: V },
 
-    getn: <V>(tbl: {V}) -> number,
-    foreach: <K, V>(tbl: {[K]: V}, f: (key: K, value: V) -> ()) -> (),
-    foreachi: <V>(tbl: {V}, f: (index: number, value: V) -> ()) -> (),
+    getn: <V>(t: {V}) -> number,
+    foreach: <K, V>(t: {[K]: V}, f: (key: K, value: V) -> ()) -> (),
+    foreachi: <V>(t: {V}, f: (index: number, value: V) -> ()) -> (),
 
-    move: <V>(tbl: {V}, from: number, to: number, startIndex: number, newTbl: {V}?) -> {V},
-    clear: <K, V>(tbl: {[K]: V}) -> (),
+    move: <V>(a: {V}, f: number, t: number, d: number, tt: {V}?) -> {V},
+    clear: <K, V>(t: {[K]: V}) -> (),
 
-    isfrozen: <K, V>(tbl: {[K]: V}) -> boolean,
+    isfrozen: <K, V>(t: {[K]: V}) -> boolean,
 }
 
 declare debug: {
     info: (<R...>(co: thread, level: number, s: string) -> R...) & (<R...>(level: number, s: string) -> R...) & (<A..., R1..., R2...>(f: (A...) -> R1..., s: string) -> R2...),
-    traceback: ((msg: string?, level: number?) -> string) & ((co: thread, message: string?, level: number?) -> string),
+    traceback: ((msg: string?, level: number?) -> string) & ((co: thread, msg: string?, level: number?) -> string),
 }
 
 declare utf8: {
@@ -188,16 +188,16 @@ declare utf8: {
     charpattern: string,
     codes: (str: string) -> ((string, number) -> (number, number), string, number),
     -- FIXME
-    codepoint: (str: string, startOffset: number?, endOffset: number?) -> (number, ...number),
-    len: (str: string, startOffset: number?, endOffset: number?) -> (number?, number?),
-    offset: (str: string, codepoint: number?, bytePosition: number?) -> number,
+    codepoint: (s: string, i: number?, j: number?) -> (number, ...number),
+    len: (s: string, i: number?, j: number?) -> (number?, number?),
+    offset: (s: string, n: number?, i: number?) -> number,
     nfdnormalize: (string) -> string,
     nfcnormalize: (string) -> string,
     graphemes: (string, number?, number?) -> (() -> (number, number)),
 }
 
 -- Cannot use `typeof` here because it will produce a polytype when we expect a monotype.
-declare function unpack<V>(tab: {V}, i: number?, j: number?): ...V
+declare function unpack<V>(a: {V}, f: number?, t: number?): ...V
 
 )BUILTIN_SRC";
 
@@ -211,9 +211,9 @@ std::string getBuiltinDefinitionSource()
         result += "declare function rawlen<K, V>(obj: {[K]: V} | string): number\n";
 
     if (FFlag::LuauUnknownAndNeverType)
-        result += "declare function error<T>(message: T, level: number?): never\n";
+        result += "declare function error<T>(obj: T, level: number?): never\n";
     else
-        result += "declare function error<T>(message: T, level: number?)\n";
+        result += "declare function error<T>(obj: T, level: number?)\n";
 
     return result;
 }

--- a/Analysis/src/TypeVar.cpp
+++ b/Analysis/src/TypeVar.cpp
@@ -766,14 +766,14 @@ TypeId SingletonTypes::makeStringMetatable()
     const TypePackId stringVariadicList = arena->addTypePack(TypePackVar{VariadicTypePack{stringType}});
     const TypePackId numberVariadicList = arena->addTypePack(TypePackVar{VariadicTypePack{numberType}});
 
-    const TypeId stringToStringType = makeFunction(*arena, std::nullopt, {}, {}, {stringType}, {}, {stringType});
+    const TypeId stringToStringType = makeFunction(*arena, std::nullopt, {}, {}, {stringType}, {"str"}, {stringType});
 
     const TypeId replArgType = arena->addType(
         UnionTypeVar{{stringType, arena->addType(TableTypeVar({}, TableIndexer(stringType, stringType), TypeLevel{}, TableState::Generic)),
             makeFunction(*arena, std::nullopt, {}, {}, {stringType}, {}, {stringType})}});
-    const TypeId gsubFunc = makeFunction(*arena, stringType, {}, {}, {stringType, replArgType, optionalNumber}, {}, {stringType, numberType});
+    const TypeId gsubFunc = makeFunction(*arena, stringType, {}, {}, {stringType, replArgType, optionalNumber}, {"pattern", "replace", "maxs"}, {stringType, numberType});
     const TypeId gmatchFunc =
-        makeFunction(*arena, stringType, {}, {}, {stringType}, {}, {arena->addType(FunctionTypeVar{emptyPack, stringVariadicList})});
+        makeFunction(*arena, stringType, {}, {}, {stringType}, {"pattern"}, {arena->addType(FunctionTypeVar{emptyPack, stringVariadicList})});
     attachMagicFunction(gmatchFunc, magicFunctionGmatch);
 
     const TypeId matchFunc = arena->addType(FunctionTypeVar{arena->addTypePack({stringType, stringType, optionalNumber}),
@@ -794,17 +794,17 @@ TypeId SingletonTypes::makeStringMetatable()
         {"len", {makeFunction(*arena, stringType, {}, {}, {}, {}, {numberType})}},
         {"lower", {stringToStringType}},
         {"match", {matchFunc}},
-        {"rep", {makeFunction(*arena, stringType, {}, {}, {numberType}, {}, {stringType})}},
+        {"rep", {makeFunction(*arena, stringType, {}, {}, {numberType}, {"n"}, {stringType})}},
         {"reverse", {stringToStringType}},
-        {"sub", {makeFunction(*arena, stringType, {}, {}, {numberType, optionalNumber}, {}, {stringType})}},
+        {"sub", {makeFunction(*arena, stringType, {}, {}, {numberType, optionalNumber}, {"from", "to"}, {stringType})}},
         {"upper", {stringToStringType}},
-        {"split", {makeFunction(*arena, stringType, {}, {}, {optionalString}, {},
+        {"split", {makeFunction(*arena, stringType, {}, {}, {optionalString}, {"sep"},
                       {arena->addType(TableTypeVar{{}, TableIndexer{numberType, stringType}, TypeLevel{}, TableState::Sealed})})}},
         {"pack", {arena->addType(FunctionTypeVar{
                      arena->addTypePack(TypePack{{stringType}, anyTypePack}),
                      oneStringPack,
                  })}},
-        {"packsize", {makeFunction(*arena, stringType, {}, {}, {}, {}, {numberType})}},
+        {"packsize", {makeFunction(*arena, stringType, {}, {}, {}, {"format"}, {numberType})}},
         {"unpack", {arena->addType(FunctionTypeVar{
                        arena->addTypePack(TypePack{{stringType, stringType, optionalNumber}}),
                        anyTypePack,

--- a/Analysis/src/TypeVar.cpp
+++ b/Analysis/src/TypeVar.cpp
@@ -766,14 +766,14 @@ TypeId SingletonTypes::makeStringMetatable()
     const TypePackId stringVariadicList = arena->addTypePack(TypePackVar{VariadicTypePack{stringType}});
     const TypePackId numberVariadicList = arena->addTypePack(TypePackVar{VariadicTypePack{numberType}});
 
-    const TypeId stringToStringType = makeFunction(*arena, std::nullopt, {}, {}, {stringType}, {"str"}, {stringType});
+    const TypeId stringToStringType = makeFunction(*arena, std::nullopt, {}, {}, {stringType}, {"s"}, {stringType});
 
     const TypeId replArgType = arena->addType(
         UnionTypeVar{{stringType, arena->addType(TableTypeVar({}, TableIndexer(stringType, stringType), TypeLevel{}, TableState::Generic)),
             makeFunction(*arena, std::nullopt, {}, {}, {stringType}, {}, {stringType})}});
-    const TypeId gsubFunc = makeFunction(*arena, stringType, {}, {}, {stringType, replArgType, optionalNumber}, {"pattern", "replace", "maxs"}, {stringType, numberType});
+    const TypeId gsubFunc = makeFunction(*arena, stringType, {}, {}, {stringType, replArgType, optionalNumber}, {"p", "f", "maxs"}, {stringType, numberType});
     const TypeId gmatchFunc =
-        makeFunction(*arena, stringType, {}, {}, {stringType}, {"pattern"}, {arena->addType(FunctionTypeVar{emptyPack, stringVariadicList})});
+        makeFunction(*arena, stringType, {}, {}, {stringType}, {"p"}, {arena->addType(FunctionTypeVar{emptyPack, stringVariadicList})});
     attachMagicFunction(gmatchFunc, magicFunctionGmatch);
 
     const TypeId matchFunc = arena->addType(FunctionTypeVar{arena->addTypePack({stringType, stringType, optionalNumber}),
@@ -796,7 +796,7 @@ TypeId SingletonTypes::makeStringMetatable()
         {"match", {matchFunc}},
         {"rep", {makeFunction(*arena, stringType, {}, {}, {numberType}, {"n"}, {stringType})}},
         {"reverse", {stringToStringType}},
-        {"sub", {makeFunction(*arena, stringType, {}, {}, {numberType, optionalNumber}, {"from", "to"}, {stringType})}},
+        {"sub", {makeFunction(*arena, stringType, {}, {}, {numberType, optionalNumber}, {"f", "t"}, {stringType})}},
         {"upper", {stringToStringType}},
         {"split", {makeFunction(*arena, stringType, {}, {}, {optionalString}, {"sep"},
                       {arena->addType(TableTypeVar{{}, TableIndexer{numberType, stringType}, TypeLevel{}, TableState::Sealed})})}},
@@ -804,7 +804,7 @@ TypeId SingletonTypes::makeStringMetatable()
                      arena->addTypePack(TypePack{{stringType}, anyTypePack}),
                      oneStringPack,
                  })}},
-        {"packsize", {makeFunction(*arena, stringType, {}, {}, {}, {"format"}, {numberType})}},
+        {"packsize", {makeFunction(*arena, stringType, {}, {}, {}, {"f"}, {numberType})}},
         {"unpack", {arena->addType(FunctionTypeVar{
                        arena->addTypePack(TypePack{{stringType, stringType, optionalNumber}}),
                        anyTypePack,


### PR DESCRIPTION
Adds names to the parameters in the embedded built in definitions.

Currently, most definitions have no named parameters, and for complex functions this is not helpful, especially for autocompletion / hover information.

Before:
![image](https://user-images.githubusercontent.com/19635171/180606149-06bcc39d-b752-4223-a038-631ee40ea8ac.png)

After:
![image](https://user-images.githubusercontent.com/19635171/180606177-106e0945-62d7-4b22-be18-596a7d9bd068.png)

Not fully certain about some of the names. I tried to take them from https://luau-lang.org/library but some names are not very descriptive there. The main aim here is to open up discussion and come up with better names which make these functions easier to understand
