### PR TITLE
Store AstExprFunction in astTypes for stats

### DIFF
--- a/Analysis/src/TypeInfer.cpp
+++ b/Analysis/src/TypeInfer.cpp
@@ -3640,6 +3640,9 @@ void TypeChecker::checkFunctionBody(const ScopePtr& scope, TypeId ty, const AstE
                 reportError(getEndLocation(function), FunctionExitsWithoutReturning{funTy->retTypes});
             }
         }
+
+        if (!currentModule->astTypes.find(&function))
+            currentModule->astTypes[&function] = ty;
     }
     else
         ice("Checking non functional type");


### PR DESCRIPTION
Currently, for `AstStatFunction` and `AstStatLocalFunction`, the expr relating to them is not stored in `module.astTypes`.
This PR adds them in.

This is useful to me because I want to be able to look up a FunctionTypeVar from a given StatFunction/StatLocalFunction, without having to do excessive lookups using the function name (even more involved when function name is an index expression).