### PR TITLE
RFC: Update the rules on string interpolation in light of feedback

### DIFF
--- a/rfcs/syntax-string-interpolation.md
+++ b/rfcs/syntax-string-interpolation.md
@@ -87,7 +87,7 @@ print(`Welcome to \
 --  Luau!
 ```
 
-This expression will not be allowed to come after a `prefixexp`. I believe this is fully additive, so a future RFC may allow this. So for now, we explicitly reject the following:
+This expression can also come after a `prefixexp`:
 
 ```
 local name = "world"

--- a/rfcs/syntax-string-interpolation.md
+++ b/rfcs/syntax-string-interpolation.md
@@ -132,6 +132,13 @@ print(string.format("%* %* %*", return_two_nils()))
 --> error: value #3 is missing, got 2
 ```
 
+It must be said that we are not allowing this style of string literals in type annotations at this time, regardless of zero or many interpolating expressions, so the following two type annotations below are illegal syntax:
+
+```lua
+local foo: `foo`
+local bar: `bar{baz}`
+```
+
 ## Drawbacks
 
 If we want to use backticks for other purposes, it may introduce some potential ambiguity. One option to solve that is to only ever produce string interpolation tokens from the context of an expression. This is messy but doable because the parser and the lexer are already implemented to work in tandem. The other option is to pick a different delimiter syntax to keep backticks available for use in the future.

--- a/rfcs/syntax-string-interpolation.md
+++ b/rfcs/syntax-string-interpolation.md
@@ -31,7 +31,6 @@ Because we care about backward compatibility, we need some new syntax in order t
 
 1. A string chunk (`` `...{ ``, `}...{`, and `` }...` ``) where `...` is a range of 0 to many characters.
    * `\` escapes `` ` ``, `{`, and itself `\`.
-   * Restriction: the string interpolation literal must have at least one value to interpolate. We do not need 3 ways to express a single line string literal.
    * The pairs must be on the same line (unless a `\` escapes the newline) but expressions needn't be on the same line.
 2. An expression between the braces. This is the value that will be interpolated into the string.
    * Restriction: we explicitly reject `{{` as it is considered an attempt to escape and get a single `{` character at runtime.
@@ -62,7 +61,6 @@ local set2 = Set.new({0, 5, 4})
 print(`{set1} ∪ {set2} = {Set.union(set1, set2)}`)
 --> {0, 1, 3} ∪ {0, 5, 4} = {0, 1, 3, 4, 5}
 
--- For illustrative purposes. These are illegal specifically because they don't interpolate anything.
 print(`Some example escaping the braces \{like so}`)
 print(`backslash \ that escapes the space is not a part of the string...`)
 print(`backslash \\ will escape the second backslash...`)


### PR DESCRIPTION
We make four adjustments in this RFC:

1. `{{` is not allowed. This is likely a valid but poor attempt at escaping coming from C#, Rust, or Python.
2. We now allow `` `this` `` with zero interpolating expressions.
3. We now allow `` f `this` `` also.
4. Explicitly say that `` `this` `` and `` `this {that}` `` are not valid type annotation syntax.