### PR TITLE
Add %* format specifier

### DIFF
--- a/Analysis/src/Linter.cpp
+++ b/Analysis/src/Linter.cpp
@@ -1433,7 +1433,7 @@ private:
     const char* checkStringFormat(const char* data, size_t size)
     {
         const char* flags = "-+ #0";
-        const char* options = "cdiouxXeEfgGqs";
+        const char* options = "cdiouxXeEfgGqs*";
 
         for (size_t i = 0; i < size; ++i)
         {

--- a/Analysis/src/TypeVar.cpp
+++ b/Analysis/src/TypeVar.cpp
@@ -1058,7 +1058,7 @@ ConstrainedTypeVarIterator end(const ConstrainedTypeVar* ctv)
 
 static std::vector<TypeId> parseFormatString(TypeChecker& typechecker, const char* data, size_t size)
 {
-    const char* options = "cdiouxXeEfgGqs";
+    const char* options = "cdiouxXeEfgGqs*";
 
     std::vector<TypeId> result;
 

--- a/Analysis/src/TypeVar.cpp
+++ b/Analysis/src/TypeVar.cpp
@@ -1081,7 +1081,7 @@ static std::vector<TypeId> parseFormatString(TypeChecker& typechecker, const cha
             if (data[i] == 'q' || data[i] == 's')
                 result.push_back(typechecker.stringType);
             else if (data[i] == '*')
-                result.push_back(typechecker.anyType);
+                result.push_back(typechecker.unknownType);
             else if (strchr(options, data[i]))
                 result.push_back(typechecker.numberType);
             else

--- a/Analysis/src/TypeVar.cpp
+++ b/Analysis/src/TypeVar.cpp
@@ -1072,7 +1072,7 @@ static std::vector<TypeId> parseFormatString(TypeChecker& typechecker, const cha
                 continue;
 
             // we just ignore all characters (including flags/precision) up until first alphabetic character
-            while (i < size && !(data[i] > 0 && (isalpha(data[i])) || data[i] == '*'))
+            while (i < size && !(data[i] > 0 && (isalpha(data[i]) || data[i] == '*')))
                 i++;
 
             if (i == size)

--- a/Analysis/src/TypeVar.cpp
+++ b/Analysis/src/TypeVar.cpp
@@ -1072,7 +1072,7 @@ static std::vector<TypeId> parseFormatString(TypeChecker& typechecker, const cha
                 continue;
 
             // we just ignore all characters (including flags/precision) up until first alphabetic character
-            while (i < size && !(data[i] > 0 && isalpha(data[i])))
+            while (i < size && !(data[i] > 0 && (isalpha(data[i])) || data[i] == '*'))
                 i++;
 
             if (i == size)
@@ -1080,6 +1080,8 @@ static std::vector<TypeId> parseFormatString(TypeChecker& typechecker, const cha
 
             if (data[i] == 'q' || data[i] == 's')
                 result.push_back(typechecker.stringType);
+            else if (data[i] == '*')
+                result.push_back(typechecker.errorRecoveryType(typechecker.anyType));
             else if (strchr(options, data[i]))
                 result.push_back(typechecker.numberType);
             else

--- a/Analysis/src/TypeVar.cpp
+++ b/Analysis/src/TypeVar.cpp
@@ -1081,7 +1081,7 @@ static std::vector<TypeId> parseFormatString(TypeChecker& typechecker, const cha
             if (data[i] == 'q' || data[i] == 's')
                 result.push_back(typechecker.stringType);
             else if (data[i] == '*')
-                result.push_back(typechecker.errorRecoveryType(typechecker.anyType));
+                result.push_back(typechecker.anyType);
             else if (strchr(options, data[i]))
                 result.push_back(typechecker.numberType);
             else

--- a/VM/src/lstrlib.cpp
+++ b/VM/src/lstrlib.cpp
@@ -8,6 +8,8 @@
 #include <string.h>
 #include <stdio.h>
 
+LUAU_FASTFLAGVARIABLE(LuauTostringFormatSpecifier, false);
+
 /* macro to `unsign' a character */
 #define uchar(c) ((unsigned char)(c))
 
@@ -1031,6 +1033,26 @@ static int str_format(lua_State* L)
                     snprintf(buff, sizeof(buff), form, s);
                     break;
                 }
+            }
+            case '*':
+            {
+                if (!FFlag::LuauTostringFormatSpecifier)
+                {
+                    luaL_error(L, "invalid option '%%*' to 'format'");
+                    break;
+                }
+
+                if (formatItemSize != 1)
+                {
+                    luaL_error(L, "'%%*' does not take a form");
+                }
+
+                size_t length;
+                const char* string = luaL_tolstring(L, arg, &length);
+
+                luaL_addlstring(&b, string, length);
+
+                continue; /* skip the `addsize' at the end */
             }
             default:
             { /* also treat cases `pnLlh' */

--- a/tests/Conformance.test.cpp
+++ b/tests/Conformance.test.cpp
@@ -291,6 +291,8 @@ TEST_CASE("Clear")
 
 TEST_CASE("Strings")
 {
+    ScopedFastFlag sff{"LuauTostringFormatSpecifier", true};
+
     runConformance("strings.lua");
 }
 

--- a/tests/TypeInfer.builtins.test.cpp
+++ b/tests/TypeInfer.builtins.test.cpp
@@ -566,6 +566,19 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "string_format_tostring_specifier")
     LUAU_REQUIRE_NO_ERRORS(result);
 }
 
+TEST_CASE_FIXTURE(BuiltinsFixture, "string_format_tostring_specifier_type_constraint")
+{
+    CheckResult result = check(R"(
+        local function f(x): string
+            local _ = string.format("%*", x)
+            return x
+        end
+    )");
+
+    LUAU_REQUIRE_NO_ERRORS(result);
+    CHECK_EQ("(string) -> string", toString(requireType("f")));
+}
+
 TEST_CASE_FIXTURE(BuiltinsFixture, "xpcall")
 {
     CheckResult result = check(R"(

--- a/tests/TypeInfer.builtins.test.cpp
+++ b/tests/TypeInfer.builtins.test.cpp
@@ -556,6 +556,16 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "string_format_correctly_ordered_types")
     CHECK_EQ(tm->givenType, typeChecker.numberType);
 }
 
+TEST_CASE_FIXTURE(BuiltinsFixture, "string_format_tostring_specifier")
+{
+    CheckResult result = check(R"(
+        --!strict
+        string.format("%* %* %* %*", "string", 1, true, function() end)
+    )");
+
+    LUAU_REQUIRE_NO_ERRORS(result);
+}
+
 TEST_CASE_FIXTURE(BuiltinsFixture, "xpcall")
 {
     CheckResult result = check(R"(

--- a/tests/conformance/strings.lua
+++ b/tests/conformance/strings.lua
@@ -130,6 +130,26 @@ assert(string.format('"-%20s.20s"', string.rep("%", 2000)) ==
 -- longest number that can be formated
 assert(string.len(string.format('%99.99f', -1e308)) >= 100)
 
+local function return_one_thing()
+	return "hi"
+end
+local function return_two_nils()
+	return nil, nil
+end
+
+assert(string.format("%*", return_one_thing()) == "hi")
+assert(string.format("%* %*", return_two_nils()) == "nil nil")
+assert(pcall(function()
+	string.format("%* %* %*", return_two_nils())
+end) == false)
+
+assert(string.format("%*", "a\0b\0c") == "a\0b\0c")
+assert(string.format("%*", string.rep("doge", 3000)) == string.rep("doge", 3000))
+
+assert(pcall(function()
+	string.format("%#*", "bad form")
+end) == false)
+
 assert(loadstring("return 1\n--comentário sem EOL no final")() == 1)
 
 


### PR DESCRIPTION
Split off from #614, which will let string interpolation be stabilized faster as it will be a purely compile time update.