### PR TITLE
Add ephemeron table support

### DIFF
--- a/VM/src/lgc.h
+++ b/VM/src/lgc.h
@@ -52,18 +52,21 @@
 ** bit 1 - object is white (type 1)
 ** bit 2 - object is black
 ** bit 3 - object is fixed (should not be collected)
+** bit 4 - object is an ephemeron key and needs special handling when marked from white to grey or black (only used in the atomic gc phase)
 */
 
 #define WHITE0BIT 0
 #define WHITE1BIT 1
 #define BLACKBIT 2
 #define FIXEDBIT 3
+#define EPHEMERONKEYBIT 4
 #define WHITEBITS bit2mask(WHITE0BIT, WHITE1BIT)
 
 #define iswhite(x) test2bits((x)->gch.marked, WHITE0BIT, WHITE1BIT)
 #define isblack(x) testbit((x)->gch.marked, BLACKBIT)
 #define isgray(x) (!testbits((x)->gch.marked, WHITEBITS | bitmask(BLACKBIT)))
 #define isfixed(x) testbit((x)->gch.marked, FIXEDBIT)
+#define isephemeronkey(x) testbit((x)->gch.marked, EPHEMERONKEYBIT)
 
 #define otherwhite(g) (g->currentwhite ^ WHITEBITS)
 #define isdead(g, v) (((v)->gch.marked & (WHITEBITS | bitmask(FIXEDBIT))) == (otherwhite(g) & WHITEBITS))


### PR DESCRIPTION
This PR shows a possible way to implement ephemeron tables in an efficient manner. While the implementation in current versions of Lua uses a fix point search which revisits ephemeron tables in case some object were marked during the last iteration resulting in a quadratic runtime behaviour in the worst case. However, this implementation uses a different algorithmus ensuring a linear runtime behaviour.

# Implementation Details

This implementation has a notion of ephemeron keys. These are white keys in an ephemeron table. When these are found during visit of an ephemeron table in the atomic phase the table node will be linked to the ephemeron key. This allows when the key is marked to visit all the nodes and mark the values.

To understand the implementation in more detail one needs to look at the `LuaNode` table node structure. The following is a representation of the struct.
```
+----------------+--------+--------+----------------+--------+-+-------+
| Value union    | VExtra | ValTT  | Key union      | KExtra | | Link  |
+----------------+--------+--------+----------------+--------+-+-------+
                                                              ^
                                                            Key TT
```
To add such nodes to a list, only slots which can be restored can be used.
The value slots except for the type tag slot fall away, as there is not way to restore them. However, the tag slot can be used as the 4 bit type tag can be saved and then the 32 bit slot can be used for other data. The key union can be restored, as the node will be in a list starting from the object which the key pointer pointed to. Furthermore, the key extra slot is not used as we do not have a vector type, so these 32 bit can be used. The key type tag can be used for other values as it can be restored by the key object type tag.

In this implementation the node can be in one of two lists. The ephemeron list which starts at the ephemeron key and the worklist which is used during marking of the ephemeron key to avoid recursion.

When the node is in the ephemeron list the key union points to the next node instead of the object and the object points to the first node. In the userdata case the pointer in the object is stored in the metatable pointer and the last element in the list points to the metatable allowing to restore the value. In all other cases the `gclink` pointer is used as it is unused when the object is white. The last value in the list can be detected by a bit set in the extra slot of the key. Furthermore, the value type tag is saved in the extra slot of the key and the value type tag is set to nil and the key type tag to a dead key. This allows to skip cleanup for dead keys as these entries look like dead nodes in this case.

When during marking an ephemeron key is encountered the ephemeron list is added to the working list. While relinking the key union is restored, the value type tag is moved from the extra key slot to the key type tag slot and the extra key slot and value type tag slots are used to store the pointer to the next entry in the worklist.

When working throug the worklist to mark all the values the node is finally restored by moving the value type tag from the key type tag back and restoring the key type tag from the key value.

# Remarks

- This implementation violates some assumptions of the layout of taged values during the atomic phase. Since during the atomic pahse the nodes will not be revisited and the mutator is not running this should not result in actual problems.
- This adds some assumtions which might change in the future:
  - Type tag is 4 bit
  - Value has a type tag slot of 32 bit
  - Key has a extra slot of 32 bit