### PR TITLE
Fix lint.md formatting

### DIFF
--- a/docs/_pages/lint.md
+++ b/docs/_pages/lint.md
@@ -326,7 +326,6 @@ Luau uses comments that start from `!` to control certain aspects of analysis, f
 --!nostrict
 -- Unknown comment directive 'nostrict'; did you mean 'nonstrict'?"
 ```
-```
 
 ## IntegerParsing (27)
 


### PR DESCRIPTION
This pull requests fixes a mistake in `lint.md` file that causes incorrect formatting of the text:

![image](https://user-images.githubusercontent.com/69454747/184346070-887abf00-dacf-4d97-a7bf-d9d1f5fd0ebc.png)