### PR TITLE
Prevent overflow in lua_newuserdatadtor

### DIFF
--- a/VM/src/lapi.cpp
+++ b/VM/src/lapi.cpp
@@ -1209,7 +1209,10 @@ void* lua_newuserdatadtor(lua_State* L, size_t sz, void (*dtor)(void*))
 {
     luaC_checkGC(L);
     luaC_checkthreadsleep(L);
-    Udata* u = luaU_newudata(L, sz + sizeof(dtor), UTAG_IDTOR);
+    size_t as = sz + sizeof(dtor);
+    if (as < sizeof(dtor))
+        as = SIZE_MAX; // Will cause a memory error in luaU_newudata.
+    Udata* u = luaU_newudata(L, as, UTAG_IDTOR);
     memcpy(&u->data + sz, &dtor, sizeof(dtor));
     setuvalue(L, L->top, u);
     api_incr_top(L);


### PR DESCRIPTION
In case a large userdata size is passed to `lua_newuserdatadtor` it might overflow the size resulting in `luaU_newudata` actually allocating the object without a memory error. This will then result in overwriting part of the `metatable` pointer of the userdata.

This PR fixes this issue by checking for the overflow and in such cases pass a size value which will cause a memory error in `luaU_newudata`.