### PR TITLE
RFC: Explicitly support escape sequence in string interpolation literals

### DIFF
--- a/rfcs/syntax-string-interpolation.md
+++ b/rfcs/syntax-string-interpolation.md
@@ -139,6 +139,13 @@ local foo: `foo`
 local bar: `bar{baz}`
 ```
 
+String interpolation syntax will also support escape sequences. Except `\u{...}`, there is no ambiguity with other escape sequences. If `\u{...}` occurs within a string interpolation literal, it takes priority.
+
+```lua
+local foo = `foo\tbar` -- "foo	bar"
+local bar = `\u{0041} \u{42}` -- "A B"
+```
+
 ## Drawbacks
 
 If we want to use backticks for other purposes, it may introduce some potential ambiguity. One option to solve that is to only ever produce string interpolation tokens from the context of an expression. This is messy but doable because the parser and the lexer are already implemented to work in tandem. The other option is to pick a different delimiter syntax to keep backticks available for use in the future.


### PR DESCRIPTION
This was implicitly assumed to be supported, but we should really just say so explicitly. If we didn't, there'd be two ways to interpret it: string interpolations are raw strings and escape sequences don't exist for the most part (false), or string interpolations are like strings and escape sequences do exist (true).

Also talks about the ambiguity with `\u{` and that it is defined to take priority and does not terminate the interpolation chunk and starts a new expression, instead it must be a well-formed escape sequence `\u{...}`. It is very unlikely there'd be another escape sequence that also has this same ambiguity problem, so we don't need to worry about this.