### PR TITLE
Change upvalue size from 48 to 32 bytes

### DIFF
--- a/VM/src/lfunc.h
+++ b/VM/src/lfunc.h
@@ -14,6 +14,5 @@ LUAI_FUNC UpVal* luaF_findupval(lua_State* L, StkId level);
 LUAI_FUNC void luaF_close(lua_State* L, StkId level);
 LUAI_FUNC void luaF_freeproto(lua_State* L, Proto* f, struct lua_Page* page);
 LUAI_FUNC void luaF_freeclosure(lua_State* L, Closure* c, struct lua_Page* page);
-LUAI_FUNC void luaF_unlinkupval(UpVal* uv);
 LUAI_FUNC void luaF_freeupval(lua_State* L, UpVal* uv, struct lua_Page* page);
 LUAI_FUNC const LocVar* luaF_getlocal(const Proto* func, int local_number, int pc);

--- a/VM/src/lgc.h
+++ b/VM/src/lgc.h
@@ -136,7 +136,6 @@ LUAI_FUNC void luaC_freeall(lua_State* L);
 LUAI_FUNC size_t luaC_step(lua_State* L, bool assist);
 LUAI_FUNC void luaC_fullgc(lua_State* L);
 LUAI_FUNC void luaC_initobj(lua_State* L, GCObject* o, uint8_t tt);
-LUAI_FUNC void luaC_initupval(lua_State* L, UpVal* uv);
 LUAI_FUNC void luaC_barrierupval(lua_State* L, GCObject* v);
 LUAI_FUNC void luaC_barrierf(lua_State* L, GCObject* o, GCObject* v);
 LUAI_FUNC void luaC_barriertable(lua_State* L, Table* t, GCObject* v);

--- a/VM/src/lobject.h
+++ b/VM/src/lobject.h
@@ -323,14 +323,10 @@ typedef struct UpVal
         TValue value; // the value (when closed)
         struct
         {
-            // global double linked list (when open)
-            struct UpVal* prev;
-            struct UpVal* next;
-
-            // thread double linked list (when open)
+            // State into which stack this upvalue points at
+            lua_State* thread;
+            // Link to next upvalue in sorted order
             struct UpVal* threadnext;
-            // note: this is the location of a pointer to this upvalue in the previous element that can be either an UpVal or a lua_State
-            struct UpVal** threadprev;
         } l;
     } u;
 } UpVal;

--- a/VM/src/lstate.cpp
+++ b/VM/src/lstate.cpp
@@ -70,6 +70,7 @@ static void preinit_state(lua_State* L, global_State* g)
     L->stacksize = 0;
     L->gt = NULL;
     L->openupval = NULL;
+    L->gclistprev = NULL;
     L->size_ci = 0;
     L->nCcalls = L->baseCcalls = 0;
     L->status = 0;
@@ -119,8 +120,6 @@ lua_State* luaE_newthread(lua_State* L)
 
 void luaE_freethread(lua_State* L, lua_State* L1, lua_Page* page)
 {
-    luaF_close(L1, L1->stack); // close all upvalues for this thread
-    LUAU_ASSERT(L1->openupval == NULL);
     global_State* g = L->global;
     if (g->cb.userthread)
         g->cb.userthread(NULL, L1);
@@ -175,8 +174,6 @@ lua_State* lua_newstate(lua_Alloc f, void* ud)
     g->frealloc = f;
     g->ud = ud;
     g->mainthread = L;
-    g->uvhead.u.l.prev = &g->uvhead;
-    g->uvhead.u.l.next = &g->uvhead;
     g->GCthreshold = 0; // mark it as unfinished state
     g->registryfree = 0;
     g->errorjmp = NULL;
@@ -194,6 +191,7 @@ lua_State* lua_newstate(lua_Alloc f, void* ud)
     g->gray = NULL;
     g->grayagain = NULL;
     g->weak = NULL;
+    g->whitethreads = NULL;
     g->strbufgc = NULL;
     g->totalbytes = sizeof(LG);
     g->gcgoal = LUAI_GCGOAL;

--- a/VM/src/lstate.h
+++ b/VM/src/lstate.h
@@ -166,6 +166,7 @@ typedef struct global_State
     GCObject* gray;      // list of gray objects
     GCObject* grayagain; // list of objects to be traversed atomically
     GCObject* weak;     // list of weak tables (to be cleared)
+    GCObject* whitethreads; // list of white threads which might have a black upvalue which need closing
 
     TString* strbufgc; // list of all string buffer objects
 
@@ -185,7 +186,6 @@ typedef struct global_State
 
 
     struct lua_State* mainthread;
-    UpVal uvhead;                                    // head of double-linked list of all open upvalues
     struct Table* mt[LUA_T_COUNT];                   // metatables for basic types
     TString* ttname[LUA_T_COUNT];       // names for basic types
     TString* tmname[TM_N];             // array with tag-method names
@@ -252,6 +252,7 @@ struct lua_State
     Table* gt;           // table of globals
     UpVal* openupval;    // list of open upvalues in this stack
     GCObject* gclist;
+    GCObject** gclistprev; // Only used when on white list.
 
     TString* namecall; // when invoked from Luau using NAMECALL, what method do we need to invoke?
 

--- a/bench/gc/test_GC_upvalues_dead.lua
+++ b/bench/gc/test_GC_upvalues_dead.lua
@@ -1,0 +1,17 @@
+local bench = script and require(script.Parent.bench_support) or require("bench_support")
+
+function test()
+
+    local ts0 = os.clock()
+    for i=1,1000000 do
+        local up = 1
+        local function f()
+            up = 2
+        end
+    end
+    local ts1 = os.clock()
+
+    return ts1-ts0
+end
+
+bench.runCode(test, "Upvalues: dead")

--- a/bench/gc/test_GC_upvalues_gray.lua
+++ b/bench/gc/test_GC_upvalues_gray.lua
@@ -1,0 +1,23 @@
+local bench = script and require(script.Parent.bench_support) or require("bench_support")
+
+function test()
+
+    local function makeup()
+        local up = 1
+        local function f()
+            up = 2
+        end
+        coroutine.yield()
+    end
+
+    local ts0 = os.clock()
+    for i=1,100000 do
+        local co = coroutine.create(makeup)
+        coroutine.resume(co)
+    end
+    local ts1 = os.clock()
+
+    return ts1-ts0
+end
+
+bench.runCode(test, "Upvalues: gray")


### PR DESCRIPTION
# Motivation

Currently the size of the `UpVal` struct will be 48 bytes on 64 bit systems. This is caused by the two doubly linked lists an open upvalue is inserted into. This needs 32 byte for the pointers and can be improved to 16 bytes by making some changes.

# Description

To reduce the size from 32 byte to 16 the open upvalues are removed from the global open upvalue list. This list is only used in the atomic phase to mark all the values from gray upvalues. However, this can also be achieved by traversing all threads and for every thread through all the upvalues. This is done in a optimized way by this implementation and details will follow.

But first we take a look at the second linked list an open upvalue is in. This thread local list contains all open upvalues for the thread sorted from the top of the stack. However, this does not really need to be a doubly linked list. A single linked list is sufficient as upvalues are only inserted from the top and the topmost one is the first to be closed. Currently this is a doubly linked list to allow an upvalue to be removed from the list when it is deleted. However, this does not need to happen in the destructor.

Instead of the doubly linked list this implementation use a single linked list and a pointer to the thread the open upvalue belongs to. Furthermore, open upvalues can now be either white or black, never gray. This actually violates the GC invariant. However, we ensure that the invariant holds in the end.

Now, when an open upvalue is marked it will put the thread in a white-thread-with-black-upvalue-list if the thread is white. When the thread is later found and marked it is removed from this list. After the atomic phase all threads in this list are iterated over and black upvalues are closed. This allows to delete all upvalues with a trivial destructor as they are never in a live list. The value such open upvalues refer to are guaranteed black since they are marked through the upvalue and upvalue store barriers and in case the thread mutates the value the thread is actually not white.
Since in the end all values from a living thread (aka threads not in the white-thread-with-black-upvalue-list) are marked it is not an issue when an open upvalue refers to a white value in the stack written by the mutator.

Finally, to ensure that no of the upvalues of a live thread need to be removed from the linked list all are marked black when the thread is marked.

# Advantages

- Decreases the size of `UpVal` on 64 bit systems from 48 bytes to 32 bytes.
- Dead open upvalues on dead thread do not need to be visited which is currently the case.
- Trivial destructor for upvalues and removal of the closing of upvalues from the `lua_State` destructor. (Trivial destructors are preferable as they allow to remove an object without touching the dead object. This can be useful when putting a bitmap into the page header with bits for new & marked as it allows to only touch those bitmasks and not the objects.)

# Disadvantages

- All upvalues of a live thread are marked as live by the thread. Currently there might be dead upvalues which are then deleted. However, this is of questionable usefulness.
- All threads in the white-thread-with-black-upvalue-list are visited in the atomic phase. However, this should have the same cost as iterating though all open upvalues in the current implementation.

# Benchmarks

Following are some benchmarks with the current vs suggested implementation.

Note that these benchmarks did show large variations on different runs on my setup!

<details>
<summary>Benchmarks</summary>

Output of `python3 bench/bench.py --vm luau-base --compare luau --extra-loops 1 --folder bench/gc`:

| Test                                | Min         | Average     | StdDev%    | Driver     | Speedup    | Significance   | P(T<=t) |
| ----------------------------------- | ----------- | ----------- | ---------- | ---------- | ---------- | -------------- | ------- |
| BinaryTree                          |   30.216ms  |   34.107ms  |    1.625%  | luau-base  |            |                |         |
| BinaryTree                          |   31.341ms  |   36.295ms  |    4.949%  | luau       |   -6.027%  | likely worse   |      2% |
| GC: Boehm tree                      | 1984.451ms  | 2164.497ms  |    2.697%  | luau-base  |            |                |         |
| GC: Boehm tree                      | 2007.325ms  | 2128.197ms  |    2.742%  | luau       |    1.706%  | likely same    |     34% |
| GC: tree pruning (eager fill)       |   80.885ms  |   90.690ms  |    2.269%  | luau-base  |            |                |         |
| GC: tree pruning (eager fill)       |   77.140ms  |   87.441ms  |    2.319%  | luau       |    3.716%  | likely better  |      3% |
| GC: tree pruning (eager fill, gen)  |   84.967ms  |  102.744ms  |    2.702%  | luau-base  |            |                |         |
| GC: tree pruning (eager fill, gen)  |   83.761ms  |   97.934ms  |    2.367%  | luau       |    4.912%  | likely better  |      1% |
| GC: tree pruning (lazy fill)        |   79.194ms  |   91.138ms  |    2.099%  | luau-base  |            |                |         |
| GC: tree pruning (lazy fill)        |   82.538ms  |   91.860ms  |    2.465%  | luau       |   -0.785%  | likely same    |     62% |
| GC: hashtable keys and values       |   57.859ms  |   63.467ms  |    1.599%  | luau-base  |            |                |         |
| GC: hashtable keys and values       |   52.005ms  |   63.042ms  |    1.914%  | luau       |    0.674%  | likely same    |     59% |
| Upvalues: dead                      |   59.051ms  |   64.824ms  |    1.690%  | luau-base  |            |                |         |
| Upvalues: dead                      |   53.701ms  |   59.201ms  |    1.410%  | luau       |    9.498%  | likely better  |      0% |
| Upvalues: gray                      |   33.224ms  |   36.692ms  |    1.220%  | luau-base  |            |                |         |
| Upvalues: gray                      |   30.136ms  |   33.440ms  |    1.812%  | luau       |    9.725%  | likely better  |      0% |
| mandel                              |   79.056ms  |   91.937ms  |    2.588%  | luau-base  |            |                |         |
| mandel                              |   82.554ms  |   96.405ms  |    2.728%  | luau       |   -4.634%  | likely worse   |      1% |
| LargeTableCtor: array               |    7.018ms  |    7.776ms  |    1.479%  | luau-base  |            |                |         |
| LargeTableCtor: array               |    7.181ms  |    7.909ms  |    1.705%  | luau       |   -1.671%  | likely same    |     14% |
| LargeTableCtor: hash                |   11.037ms  |   13.365ms  |    3.763%  | luau-base  |            |                |         |
| LargeTableCtor: hash                |   12.555ms  |   13.185ms  |    1.209%  | luau       |    1.366%  | likely same    |     49% |
| Pcall: pcall yield                  |   40.021ms  |   46.948ms  |    2.037%  | luau-base  |            |                |         |
| Pcall: pcall yield                  |   41.319ms  |   45.848ms  |    1.374%  | luau       |    2.400%  | likely same    |      6% |
| 3d-raytrace                         |   13.373ms  |   14.914ms  |    2.309%  | luau-base  |            |                |         |
| 3d-raytrace                         |   12.989ms  |   14.547ms  |    1.854%  | luau       |    2.520%  | likely same    |      9% |
| TableCreate: nil                    |   29.400ms  |   32.672ms  |    1.763%  | luau-base  |            |                |         |
| TableCreate: nil                    |   28.664ms  |   31.532ms  |    1.846%  | luau       |    3.613%  | likely better  |      1% |
| TableCreate: number                 |   35.743ms  |   38.502ms  |    1.346%  | luau-base  |            |                |         |
| TableCreate: number                 |   33.039ms  |   38.049ms  |    1.786%  | luau       |    1.192%  | likely same    |     29% |
| TableCreate: zerofill               |  124.501ms  |  134.746ms  |    1.299%  | luau-base  |            |                |         |
| TableCreate: zerofill               |  120.485ms  |  132.865ms  |    1.269%  | luau       |    1.416%  | likely same    |     12% |
| TableMarshal: {n=select,...}        |   19.525ms  |   22.587ms  |    1.616%  | luau-base  |            |                |         |
| TableMarshal: {n=select,...}        |   18.772ms  |   21.633ms  |    1.486%  | luau       |    4.409%  | likely better  |      0% |
| TableMarshal: table.pack            |   15.978ms  |   18.128ms  |    2.068%  | luau-base  |            |                |         |
| TableMarshal: table.pack            |   15.249ms  |   17.807ms  |    2.084%  | luau       |    1.803%  | likely same    |     22% |
| TableMarshal: {...}                 |   11.406ms  |   13.120ms  |    1.429%  | luau-base  |            |                |         |
| TableMarshal: {...}                 |   11.588ms  |   13.409ms  |    1.768%  | luau       |   -2.157%  | likely same    |      6% |
| Total                               | 2796.903ms  | 3082.856ms  |       ---  | luau-base  |            |                |         |
| Total                               | 2802.343ms  | 3030.599ms  |       ---  | luau       |    1.724%  |                |         |

'luau' change is 1.699% positive on average


Output of `python3 bench/bench.py --vm luau-base --compare luau --extra-loops 10`:

| Test                   | Min         | Average     | StdDev%    | Driver     | Speedup    | Significance   | P(T<=t) |
| ---------------------- | ----------- | ----------- | ---------- | ---------- | ---------- | -------------- | ------- |
| base64                 |   28.618ms  |   34.330ms  |    0.871%  | luau-base  |            |                |         |
| base64                 |   29.097ms  |   33.792ms  |    0.833%  | luau       |    1.593%  | likely better  |      1% |
| chess                  |  130.647ms  |  147.318ms  |    0.702%  | luau-base  |            |                |         |
| chess                  |  125.681ms  |  144.201ms  |    0.771%  | luau       |    2.162%  | likely better  |      0% |
| life                   |   97.753ms  |  109.337ms  |    0.610%  | luau-base  |            |                |         |
| life                   |   87.368ms  |  100.052ms  |    0.690%  | luau       |    9.280%  | likely better  |      0% |
| qsort                  |   82.126ms  |   97.804ms  |    1.053%  | luau-base  |            |                |         |
| qsort                  |   76.813ms  |   95.627ms  |    1.849%  | luau       |    2.276%  | likely better  |      4% |
| sha256                 |   25.308ms  |   29.036ms  |    0.610%  | luau-base  |            |                |         |
| sha256                 |   23.985ms  |   28.140ms  |    0.935%  | luau       |    3.182%  | likely better  |      0% |
| ack                    |   53.159ms  |   61.760ms  |    0.654%  | luau-base  |            |                |         |
| ack                    |   53.791ms  |   60.395ms  |    0.637%  | luau       |    2.260%  | likely better  |      0% |
| binary-trees           |   30.521ms  |   35.391ms  |    0.641%  | luau-base  |            |                |         |
| binary-trees           |   30.257ms  |   34.551ms  |    0.638%  | luau       |    2.431%  | likely better  |      0% |
| fannkuchen-redux       |   11.654ms  |   13.746ms  |    0.902%  | luau-base  |            |                |         |
| fannkuchen-redux       |   11.396ms  |   13.676ms  |    0.654%  | luau       |    0.513%  | likely same    |     37% |
| fixpoint-fact          |   55.719ms  |   65.007ms  |    0.588%  | luau-base  |            |                |         |
| fixpoint-fact          |   57.571ms  |   64.589ms  |    0.490%  | luau       |    0.646%  | likely same    |     10% |
| heapsort               |   22.390ms  |   26.041ms  |    0.600%  | luau-base  |            |                |         |
| heapsort               |   22.289ms  |   26.163ms  |    0.643%  | luau       |   -0.463%  | likely same    |     30% |
| mandel                 |   73.551ms  |   82.656ms  |    0.480%  | luau-base  |            |                |         |
| mandel                 |   75.405ms  |   84.108ms  |    0.545%  | luau       |   -1.727%  | likely worse   |      0% |
| n-body                 |   27.983ms  |   32.354ms  |    0.596%  | luau-base  |            |                |         |
| n-body                 |   26.898ms  |   32.463ms  |    0.698%  | luau       |   -0.334%  | likely same    |     47% |
| qt                     |   62.664ms  |   74.106ms  |    1.057%  | luau-base  |            |                |         |
| qt                     |   63.549ms  |   72.662ms  |    0.682%  | luau       |    1.986%  | likely better  |      0% |
| queen                  |    1.622ms  |    1.962ms  |    0.883%  | luau-base  |            |                |         |
| queen                  |    1.630ms  |    1.965ms  |    0.909%  | luau       |   -0.174%  | likely same    |     79% |
| scimark                |   74.973ms  |   83.245ms  |    0.530%  | luau-base  |            |                |         |
| scimark                |   75.792ms  |   85.079ms  |    0.460%  | luau       |   -2.156%  | likely worse   |      0% |
| spectral-norm          |   14.519ms  |   17.339ms  |    0.715%  | luau-base  |            |                |         |
| spectral-norm          |   14.416ms  |   17.063ms  |    0.697%  | luau       |    1.617%  | likely better  |      0% |
| sieve                  |   97.572ms  |  112.653ms  |    0.932%  | luau-base  |            |                |         |
| sieve                  |  100.176ms  |  113.292ms  |    1.138%  | luau       |   -0.564%  | likely same    |     45% |
| 3d-cube                |    7.465ms  |    9.050ms  |    0.645%  | luau-base  |            |                |         |
| 3d-cube                |    7.325ms  |    8.811ms  |    0.611%  | luau       |    2.714%  | likely better  |      0% |
| 3d-morph               |    8.291ms  |    9.838ms  |    0.569%  | luau-base  |            |                |         |
| 3d-morph               |    8.369ms  |    9.854ms  |    0.416%  | luau       |   -0.159%  | likely same    |     66% |
| 3d-raytrace            |    9.137ms  |   10.639ms  |    0.425%  | luau-base  |            |                |         |
| 3d-raytrace            |    8.884ms  |   10.699ms  |    0.717%  | luau       |   -0.559%  | likely same    |     19% |
| controlflow-recursive  |    4.360ms  |    5.113ms  |    0.752%  | luau-base  |            |                |         |
| controlflow-recursive  |    4.275ms  |    5.060ms  |    0.666%  | luau       |    1.049%  | likely better  |      4% |
| crypto-aes             |   14.489ms  |   16.835ms  |    0.642%  | luau-base  |            |                |         |
| crypto-aes             |   14.440ms  |   17.190ms  |    0.451%  | luau       |   -2.064%  | likely worse   |      0% |
| fannkuch               |   22.369ms  |   25.767ms  |    0.553%  | luau-base  |            |                |         |
| fannkuch               |   22.084ms  |   25.398ms  |    0.588%  | luau       |    1.452%  | likely better  |      0% |
| math-cordic            |   14.646ms  |   17.092ms  |    0.719%  | luau-base  |            |                |         |
| math-cordic            |   14.922ms  |   17.312ms  |    0.610%  | luau       |   -1.269%  | likely worse   |      1% |
| math-partial-sums      |    4.517ms  |    5.221ms  |    0.551%  | luau-base  |            |                |         |
| math-partial-sums      |    4.577ms  |    5.260ms  |    0.559%  | luau       |   -0.741%  | likely same    |      6% |
| n-body-oop             |   47.531ms  |   54.330ms  |    0.552%  | luau-base  |            |                |         |
| n-body-oop             |   48.432ms  |   55.078ms  |    0.568%  | luau       |   -1.358%  | likely worse   |      0% |
| tictactoe              |  130.463ms  |  145.940ms  |    0.465%  | luau-base  |            |                |         |
| tictactoe              |  133.632ms  |  146.080ms  |    0.465%  | luau       |   -0.095%  | likely same    |     77% |
| trig                   |   21.122ms  |   25.126ms  |    0.660%  | luau-base  |            |                |         |
| trig                   |   21.231ms  |   25.043ms  |    0.550%  | luau       |    0.331%  | likely same    |     45% |
| Total                  | 1175.167ms  | 1349.035ms  |       ---  | luau-base  |            |                |         |
| Total                  | 1164.283ms  | 1333.603ms  |       ---  | luau       |    1.157%  |                |         |

'luau' change is 0.756% positive on average

</details>