### PR TITLE
RFC: Prohibit use of interpolated strings in function calls without parentheses

### DIFF
--- a/rfcs/syntax-string-interpolation.md
+++ b/rfcs/syntax-string-interpolation.md
@@ -87,12 +87,14 @@ print(`Welcome to \
 --  Luau!
 ```
 
-This expression can also come after a `prefixexp`:
+We currently *prohibit* using interpolated strings in function calls without parentheses, this is illegal:
 
 ```
 local name = "world"
 print`Hello {name}`
 ```
+
+> Note: This restriction is likely temporary while we work through string interpolation DSLs, an ability to pass individual components of interpolated strings to a function.
 
 The restriction on `{{` exists solely for the people coming from languages e.g. C#, Rust, or Python which uses `{{` to escape and get the character `{` at runtime. We're also rejecting this at parse time too, since the proper way to escape it is `\{`, so:
 


### PR DESCRIPTION
We've had this restriction in the original RFC, but decided to remove it afterwards. This change puts the restriction back - we need to work through some implications of future support for string-based DSLs together with interpolated strings which may or may not change the behavior here, for example to allow something like

```
local fragment = xml `
  <img src="{self.url}" />
`
```