### PR TITLE
Update title and fix a dead link.

### DIFF
--- a/docs/_posts/2022-08-29-luau-recap-august-2022.md
+++ b/docs/_posts/2022-08-29-luau-recap-august-2022.md
@@ -1,11 +1,11 @@
 ---
 layout: single
-title:  "Luau Recap: August 2022"
+title:  "Luau Recap: July & August 2022"
 ---
 
 Luau is our new language that you can read more about at [https://luau-lang.org](https://luau-lang.org).
 
-[Cross-posted to the [Roblox Developer Forum](https://devforum.roblox.com/t/luau-recap-august-2022/).]
+[Cross-posted to the [Roblox Developer Forum](https://devforum.roblox.com/t/luau-recap-july-august-2022/).]
 
 ## Tables now support `__len` metamethod
 


### PR DESCRIPTION
Originally it was titled "Luau Recap: August 2022" but it got renamed to "Luau Recap: July & August 2022" and we just didn't fix the link here too. Also backports the title change to here too for consistency.