### PR TITLE
Feat: Added retry functionality to benchmarks

### DIFF
--- a/.github/workflows/benchmark-dev.yml
+++ b/.github/workflows/benchmark-dev.yml
@@ -64,200 +64,322 @@ jobs:
           python bench/bench.py | tee ${{ matrix.bench.script }}-output.txt
 
       - name: Push benchmark results
-        if: github.event_name == 'push'
-        uses: nick-fields/retry@v2.7.0
+        id: pushBenchmarkAttempt1
+        continue-on-error: true
+        uses: ./.github/workflows/push-results
         with:
-          max_attempts: 5
-          retry_on: error
-          retry_wait_seconds: 60
-          timeout_minutes: 5
-          command:
-            uses: ./.github/workflows/push-results
-            with:
-              repository: ${{ matrix.benchResultsRepo.name }}
-              branch: ${{ matrix.benchResultsRepo.branch }}
-              token: ${{ secrets.BENCH_GITHUB_TOKEN }}
-              path: "./gh-pages"
-              bench_name: "${{ matrix.bench.title }} (Windows ${{matrix.arch}})"
-              bench_tool: "benchmarkluau"
-              bench_output_file_path: "./${{ matrix.bench.script }}-output.txt"
-              bench_external_data_json_path: "./gh-pages/dev/bench/data-${{ matrix.os }}.json"
+          repository: ${{ matrix.benchResultsRepo.name }}
+          branch: ${{ matrix.benchResultsRepo.branch }}
+          token: ${{ secrets.BENCH_GITHUB_TOKEN }}
+          path: "./gh-pages"
+          bench_name: "${{ matrix.bench.title }} (Windows ${{matrix.arch}})"
+          bench_tool: "benchmarkluau"
+          bench_output_file_path: "./${{ matrix.bench.script }}-output.txt"
+          bench_external_data_json_path: "./gh-pages/dev/bench/data-${{ matrix.os }}.json"
 
-  # unix:
-  #   name: ${{matrix.os}}
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       os: [ubuntu-latest, macos-latest]
-  #       bench:
-  #         - {
-  #             script: "run-benchmarks",
-  #             timeout: 12,
-  #             title: "Luau Benchmarks",
-  #             cachegrindTitle: "Performance",
-  #             cachegrindIterCount: 20,
-  #           }
-  #       benchResultsRepo:
-  #         - { name: "luau-lang/benchmark-data", branch: "main" }
+      - name: Push benchmark results (Attempt 2)
+        id: pushBenchmarkAttempt2
+        continue-on-error: true
+        if: steps.pushBenchmarkAttempt1.outcome == 'failure'
+        uses: ./.github/workflows/push-results
+        with:
+          repository: ${{ matrix.benchResultsRepo.name }}
+          branch: ${{ matrix.benchResultsRepo.branch }}
+          token: ${{ secrets.BENCH_GITHUB_TOKEN }}
+          path: "./gh-pages"
+          bench_name: "${{ matrix.bench.title }} (Windows ${{matrix.arch}})"
+          bench_tool: "benchmarkluau"
+          bench_output_file_path: "./${{ matrix.bench.script }}-output.txt"
+          bench_external_data_json_path: "./gh-pages/dev/bench/data-${{ matrix.os }}.json"
 
-  #   runs-on: ${{ matrix.os }}
-  #   steps:
-  #     - name: Checkout Luau repository
-  #       uses: actions/checkout@v3
+      - name: Push benchmark results (Attempt 3)
+        id: pushBenchmarkAttempt3
+        continue-on-error: true
+        if: steps.pushBenchmarkAttempt2.outcome == 'failure'
+        uses: ./.github/workflows/push-results
+        with:
+          repository: ${{ matrix.benchResultsRepo.name }}
+          branch: ${{ matrix.benchResultsRepo.branch }}
+          token: ${{ secrets.BENCH_GITHUB_TOKEN }}
+          path: "./gh-pages"
+          bench_name: "${{ matrix.bench.title }} (Windows ${{matrix.arch}})"
+          bench_tool: "benchmarkluau"
+          bench_output_file_path: "./${{ matrix.bench.script }}-output.txt"
+          bench_external_data_json_path: "./gh-pages/dev/bench/data-${{ matrix.os }}.json"
 
-  #     - name: Build Luau
-  #       run: make config=release luau luau-analyze
+  unix:
+    name: ${{matrix.os}}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        bench:
+          - {
+              script: "run-benchmarks",
+              timeout: 12,
+              title: "Luau Benchmarks",
+              cachegrindTitle: "Performance",
+              cachegrindIterCount: 20,
+            }
+        benchResultsRepo:
+          - { name: "luau-lang/benchmark-data", branch: "main" }
 
-  #     - uses: actions/setup-python@v3
-  #       with:
-  #         python-version: "3.9"
-  #         architecture: "x64"
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout Luau repository
+        uses: actions/checkout@v3
 
-  #     - name: Install python dependencies
-  #       run: |
-  #         python -m pip install requests
-  #         python -m pip install --user numpy scipy matplotlib ipython jupyter pandas sympy nose
+      - name: Build Luau
+        run: make config=release luau luau-analyze
 
-  #     - name: Run benchmark
-  #       run: |
-  #         python bench/bench.py | tee ${{ matrix.bench.script }}-output.txt
+      - uses: actions/setup-python@v3
+        with:
+          python-version: "3.9"
+          architecture: "x64"
 
-  #     - name: Install valgrind
-  #       if: matrix.os == 'ubuntu-latest'
-  #       run: |
-  #         sudo apt-get install valgrind
+      - name: Install python dependencies
+        run: |
+          python -m pip install requests
+          python -m pip install --user numpy scipy matplotlib ipython jupyter pandas sympy nose
 
-  #     - name: Run ${{ matrix.bench.title }} (Cold Cachegrind)
-  #       if: matrix.os == 'ubuntu-latest'
-  #       run: sudo bash ./scripts/run-with-cachegrind.sh python ./bench/bench.py "${{ matrix.bench.cachegrindTitle}}Cold" 1 | tee -a ${{ matrix.bench.script }}-output.txt
+      - name: Run benchmark
+        run: |
+          python bench/bench.py | tee ${{ matrix.bench.script }}-output.txt
 
-  #     - name: Run ${{ matrix.bench.title }} (Warm Cachegrind)
-  #       if: matrix.os == 'ubuntu-latest'
-  #       run: sudo bash ./scripts/run-with-cachegrind.sh python ./bench/bench.py "${{ matrix.bench.cachegrindTitle }}" ${{ matrix.bench.cachegrindIterCount }} | tee -a ${{ matrix.bench.script }}-output.txt
+      - name: Install valgrind
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get install valgrind
 
-  #     - name: Checkout Benchmark Results repository
-  #       uses: actions/checkout@v3
-  #       with:
-  #         repository: ${{ matrix.benchResultsRepo.name }}
-  #         ref: ${{ matrix.benchResultsRepo.branch }}
-  #         token: ${{ secrets.BENCH_GITHUB_TOKEN }}
-  #         path: "./gh-pages"
+      - name: Run ${{ matrix.bench.title }} (Cold Cachegrind)
+        if: matrix.os == 'ubuntu-latest'
+        run: sudo bash ./scripts/run-with-cachegrind.sh python ./bench/bench.py "${{ matrix.bench.cachegrindTitle}}Cold" 1 | tee -a ${{ matrix.bench.script }}-output.txt
 
-  #     - name: Store ${{ matrix.bench.title }} result
-  #       uses: Roblox/rhysd-github-action-benchmark@v-luau
-  #       with:
-  #         name: ${{ matrix.bench.title }}
-  #         tool: "benchmarkluau"
-  #         output-file-path: ./${{ matrix.bench.script }}-output.txt
-  #         external-data-json-path: ./gh-pages/dev/bench/data-${{ matrix.os }}.json
-  #         github-token: ${{ secrets.BENCH_GITHUB_TOKEN }}
+      - name: Run ${{ matrix.bench.title }} (Warm Cachegrind)
+        if: matrix.os == 'ubuntu-latest'
+        run: sudo bash ./scripts/run-with-cachegrind.sh python ./bench/bench.py "${{ matrix.bench.cachegrindTitle }}" ${{ matrix.bench.cachegrindIterCount }} | tee -a ${{ matrix.bench.script }}-output.txt
 
-  #     - name: Store ${{ matrix.bench.title }} result (CacheGrind)
-  #       if: matrix.os == 'ubuntu-latest'
-  #       uses: Roblox/rhysd-github-action-benchmark@v-luau
-  #       with:
-  #         name: ${{ matrix.bench.title }} (CacheGrind)
-  #         tool: "roblox"
-  #         output-file-path: ./${{ matrix.bench.script }}-output.txt
-  #         external-data-json-path: ./gh-pages/dev/bench/data-${{ matrix.os }}.json
-  #         github-token: ${{ secrets.BENCH_GITHUB_TOKEN }}
+      - name: Push benchmark results
+        id: pushBenchmarkAttempt1
+        continue-on-error: true
+        uses: ./.github/workflows/push-results
+        with:
+          repository: ${{ matrix.benchResultsRepo.name }}
+          branch: ${{ matrix.benchResultsRepo.branch }}
+          token: ${{ secrets.BENCH_GITHUB_TOKEN }}
+          path: "./gh-pages"
+          bench_name: ${{ matrix.bench.title }}
+          bench_tool: "benchmarkluau"
+          bench_output_file_path: "./${{ matrix.bench.script }}-output.txt"
+          bench_external_data_json_path: "./gh-pages/dev/bench/data-${{ matrix.os }}.json"
 
-  #     - name: Push benchmark results
-  #       if: github.event_name == 'push'
-  #       run: |
-  #         echo "Pushing benchmark results..."
-  #         cd gh-pages
-  #         git config user.name github-actions
-  #         git config user.email github@users.noreply.github.com
-  #         git add ./dev/bench/data-${{ matrix.os }}.json
-  #         git commit -m "Add benchmarks results for ${{ github.sha }}"
-  #         git push
-  #         cd ..
+      - name: Push benchmark results (Attempt 2)
+        id: pushBenchmarkAttempt2
+        continue-on-error: true
+        if: steps.pushBenchmarkAttempt1.outcome == 'failure'
+        uses: ./.github/workflows/push-results
+        with:
+          repository: ${{ matrix.benchResultsRepo.name }}
+          branch: ${{ matrix.benchResultsRepo.branch }}
+          token: ${{ secrets.BENCH_GITHUB_TOKEN }}
+          path: "./gh-pages"
+          bench_name: ${{ matrix.bench.title }}
+          bench_tool: "benchmarkluau"
+          bench_output_file_path: "./${{ matrix.bench.script }}-output.txt"
+          bench_external_data_json_path: "./gh-pages/dev/bench/data-${{ matrix.os }}.json"
 
-  # static-analysis:
-  #   name: luau-analyze
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       os: [ubuntu-latest]
-  #       bench:
-  #         - {
-  #             script: "run-analyze",
-  #             timeout: 12,
-  #             title: "Luau Analyze",
-  #             cachegrindTitle: "Performance",
-  #             cachegrindIterCount: 20,
-  #           }
-  #       benchResultsRepo:
-  #         - { name: "luau-lang/benchmark-data", branch: "main" }
-  #   runs-on: ${{ matrix.os }}
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #       with:
-  #         token: "${{ secrets.BENCH_GITHUB_TOKEN }}"
+      - name: Push benchmark results (Attempt 3)
+        id: pushBenchmarkAttempt3
+        continue-on-error: true
+        if: steps.pushBenchmarkAttempt2.outcome == 'failure'
+        uses: ./.github/workflows/push-results
+        with:
+          repository: ${{ matrix.benchResultsRepo.name }}
+          branch: ${{ matrix.benchResultsRepo.branch }}
+          token: ${{ secrets.BENCH_GITHUB_TOKEN }}
+          path: "./gh-pages"
+          bench_name: ${{ matrix.bench.title }}
+          bench_tool: "benchmarkluau"
+          bench_output_file_path: "./${{ matrix.bench.script }}-output.txt"
+          bench_external_data_json_path: "./gh-pages/dev/bench/data-${{ matrix.os }}.json"
 
-  #     - name: Build Luau
-  #       run: make config=release luau luau-analyze
+      - name: Push Cachegrind benchmark results
+        if: matrix.os == 'ubuntu-latest'
+        id: pushBenchmarkCachegrindAttempt1
+        continue-on-error: true
+        uses: ./.github/workflows/push-results
+        with:
+          repository: ${{ matrix.benchResultsRepo.name }}
+          branch: ${{ matrix.benchResultsRepo.branch }}
+          token: ${{ secrets.BENCH_GITHUB_TOKEN }}
+          path: "./gh-pages"
+          bench_name: ${{ matrix.bench.title }} (CacheGrind)
+          bench_tool: "roblox"
+          bench_output_file_path: "./${{ matrix.bench.script }}-output.txt"
+          bench_external_data_json_path: "./gh-pages/dev/bench/data-${{ matrix.os }}.json"
 
-  #     - uses: actions/setup-python@v4
-  #       with:
-  #         python-version: "3.9"
-  #         architecture: "x64"
+      - name: Push Cachegrind benchmark results (Attempt 2)
+        if: matrix.os == 'ubuntu-latest' && steps.pushBenchmarkCachegrindAttempt1.outcome == 'failure'
+        id: pushBenchmarkCachegrindAttempt2
+        continue-on-error: true
+        uses: ./.github/workflows/push-results
+        with:
+          repository: ${{ matrix.benchResultsRepo.name }}
+          branch: ${{ matrix.benchResultsRepo.branch }}
+          token: ${{ secrets.BENCH_GITHUB_TOKEN }}
+          path: "./gh-pages"
+          bench_name: ${{ matrix.bench.title }} (CacheGrind)
+          bench_tool: "roblox"
+          bench_output_file_path: "./${{ matrix.bench.script }}-output.txt"
+          bench_external_data_json_path: "./gh-pages/dev/bench/data-${{ matrix.os }}.json"
 
-  #     - name: Install python dependencies
-  #       run: |
-  #         sudo pip install requests numpy scipy matplotlib ipython jupyter pandas sympy nose
+      - name: Push Cachegrind benchmark results (Attempt 3)
+        if: matrix.os == 'ubuntu-latest' && steps.pushBenchmarkCachegrindAttempt2.outcome == 'failure'
+        id: pushBenchmarkCachegrindAttempt3
+        continue-on-error: true
+        uses: ./.github/workflows/push-results
+        with:
+          repository: ${{ matrix.benchResultsRepo.name }}
+          branch: ${{ matrix.benchResultsRepo.branch }}
+          token: ${{ secrets.BENCH_GITHUB_TOKEN }}
+          path: "./gh-pages"
+          bench_name: ${{ matrix.bench.title }} (CacheGrind)
+          bench_tool: "roblox"
+          bench_output_file_path: "./${{ matrix.bench.script }}-output.txt"
+          bench_external_data_json_path: "./gh-pages/dev/bench/data-${{ matrix.os }}.json"
 
-  #     - name: Install valgrind
-  #       run: |
-  #         sudo apt-get install valgrind
+  static-analysis:
+    name: luau-analyze
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        bench:
+          - {
+              script: "run-analyze",
+              timeout: 12,
+              title: "Luau Analyze",
+              cachegrindTitle: "Performance",
+              cachegrindIterCount: 20,
+            }
+        benchResultsRepo:
+          - { name: "luau-lang/benchmark-data", branch: "main" }
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          token: "${{ secrets.BENCH_GITHUB_TOKEN }}"
 
-  #     - name: Run Luau Analyze on static file
-  #       run: sudo python ./bench/measure_time.py ./build/release/luau-analyze bench/other/LuauPolyfillMap.lua | tee ${{ matrix.bench.script }}-output.txt
+      - name: Build Luau
+        run: make config=release luau luau-analyze
 
-  #     - name: Run ${{ matrix.bench.title }} (Cold Cachegrind)
-  #       run: sudo ./scripts/run-with-cachegrind.sh python ./bench/measure_time.py "${{ matrix.bench.cachegrindTitle}}Cold" 1 ./build/release/luau-analyze bench/other/LuauPolyfillMap.lua | tee -a ${{ matrix.bench.script }}-output.txt
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.9"
+          architecture: "x64"
 
-  #     - name: Run ${{ matrix.bench.title }} (Warm Cachegrind)
-  #       run: sudo bash ./scripts/run-with-cachegrind.sh python ./bench/measure_time.py "${{ matrix.bench.cachegrindTitle}}" 1  ./build/release/luau-analyze bench/other/LuauPolyfillMap.lua | tee -a ${{ matrix.bench.script }}-output.txt
+      - name: Install python dependencies
+        run: |
+          sudo pip install requests numpy scipy matplotlib ipython jupyter pandas sympy nose
 
-  #     - name: Checkout Benchmark Results repository
-  #       uses: actions/checkout@v3
-  #       with:
-  #         repository: ${{ matrix.benchResultsRepo.name }}
-  #         ref: ${{ matrix.benchResultsRepo.branch }}
-  #         token: ${{ secrets.BENCH_GITHUB_TOKEN }}
-  #         path: "./gh-pages"
+      - name: Install valgrind
+        run: |
+          sudo apt-get install valgrind
 
-  #     - name: Store ${{ matrix.bench.title }} result
-  #       uses: Roblox/rhysd-github-action-benchmark@v-luau
-  #       with:
-  #         name: ${{ matrix.bench.title }}
-  #         tool: "benchmarkluau"
+      - name: Run Luau Analyze on static file
+        run: sudo python ./bench/measure_time.py ./build/release/luau-analyze bench/other/LuauPolyfillMap.lua | tee ${{ matrix.bench.script }}-output.txt
 
-  #         gh-pages-branch: "main"
-  #         output-file-path: ./${{ matrix.bench.script }}-output.txt
-  #         external-data-json-path: ./gh-pages/dev/bench/data-${{ matrix.os }}.json
-  #         github-token: ${{ secrets.BENCH_GITHUB_TOKEN }}
+      - name: Run ${{ matrix.bench.title }} (Cold Cachegrind)
+        run: sudo ./scripts/run-with-cachegrind.sh python ./bench/measure_time.py "${{ matrix.bench.cachegrindTitle}}Cold" 1 ./build/release/luau-analyze bench/other/LuauPolyfillMap.lua | tee -a ${{ matrix.bench.script }}-output.txt
 
-  #     - name: Store ${{ matrix.bench.title }} result (CacheGrind)
-  #       uses: Roblox/rhysd-github-action-benchmark@v-luau
-  #       with:
-  #         name: ${{ matrix.bench.title }}
-  #         tool: "roblox"
-  #         gh-pages-branch: "main"
-  #         output-file-path: ./${{ matrix.bench.script }}-output.txt
-  #         external-data-json-path: ./gh-pages/dev/bench/data-${{ matrix.os }}.json
-  #         github-token: ${{ secrets.BENCH_GITHUB_TOKEN }}
+      - name: Run ${{ matrix.bench.title }} (Warm Cachegrind)
+        run: sudo bash ./scripts/run-with-cachegrind.sh python ./bench/measure_time.py "${{ matrix.bench.cachegrindTitle}}" 1  ./build/release/luau-analyze bench/other/LuauPolyfillMap.lua | tee -a ${{ matrix.bench.script }}-output.txt
 
-  #     - name: Push benchmark results
-  #       if: github.event_name == 'push'
-  #       run: |
-  #         echo "Pushing benchmark results..."
-  #         cd gh-pages
-  #         git config user.name github-actions
-  #         git config user.email github@users.noreply.github.com
-  #         git add ./dev/bench/data-${{ matrix.os }}.json
-  #         git commit -m "Add benchmarks results for ${{ github.sha }}"
-  #         git push
-  #         cd ..
+      - name: Push static analysis results
+        id: pushStaticAnalysisAttempt1
+        continue-on-error: true
+        uses: ./.github/workflows/push-results
+        with:
+          repository: ${{ matrix.benchResultsRepo.name }}
+          branch: ${{ matrix.benchResultsRepo.branch }}
+          token: ${{ secrets.BENCH_GITHUB_TOKEN }}
+          path: "./gh-pages"
+          bench_name: ${{ matrix.bench.title }}
+          bench_tool: "roblox"
+          bench_output_file_path: "./${{ matrix.bench.script }}-output.txt"
+          bench_external_data_json_path: "./gh-pages/dev/bench/data-${{ matrix.os }}.json"
+
+      - name: Push static analysis results (Attempt 2)
+        if: steps.pushStaticAnalysisAttempt1.outcome == 'failure'
+        id: pushStaticAnalysisAttempt2
+        continue-on-error: true
+        uses: ./.github/workflows/push-results
+        with:
+          repository: ${{ matrix.benchResultsRepo.name }}
+          branch: ${{ matrix.benchResultsRepo.branch }}
+          token: ${{ secrets.BENCH_GITHUB_TOKEN }}
+          path: "./gh-pages"
+          bench_name: ${{ matrix.bench.title }}
+          bench_tool: "roblox"
+          bench_output_file_path: "./${{ matrix.bench.script }}-output.txt"
+          bench_external_data_json_path: "./gh-pages/dev/bench/data-${{ matrix.os }}.json"
+
+      - name: Push static analysis results (Attempt 3)
+        if: steps.pushStaticAnalysisAttempt2.outcome == 'failure'
+        id: pushStaticAnalysisAttempt3
+        continue-on-error: true
+        uses: ./.github/workflows/push-results
+        with:
+          repository: ${{ matrix.benchResultsRepo.name }}
+          branch: ${{ matrix.benchResultsRepo.branch }}
+          token: ${{ secrets.BENCH_GITHUB_TOKEN }}
+          path: "./gh-pages"
+          bench_name: ${{ matrix.bench.title }}
+          bench_tool: "roblox"
+          bench_output_file_path: "./${{ matrix.bench.script }}-output.txt"
+          bench_external_data_json_path: "./gh-pages/dev/bench/data-${{ matrix.os }}.json"
+
+      - name: Push static analysis Cachegrind results
+        if: matrix.os == 'ubuntu-latest'
+        id: pushStaticAnalysisCachegrindAttempt1
+        continue-on-error: true
+        uses: ./.github/workflows/push-results
+        with:
+          repository: ${{ matrix.benchResultsRepo.name }}
+          branch: ${{ matrix.benchResultsRepo.branch }}
+          token: ${{ secrets.BENCH_GITHUB_TOKEN }}
+          path: "./gh-pages"
+          bench_name: ${{ matrix.bench.title }}
+          bench_tool: "roblox"
+          bench_output_file_path: "./${{ matrix.bench.script }}-output.txt"
+          bench_external_data_json_path: "./gh-pages/dev/bench/data-${{ matrix.os }}.json"
+
+      - name: Push static analysis Cachegrind results (Attempt 2)
+        if: matrix.os == 'ubuntu-latest' && steps.pushStaticAnalysisCachegrindAttempt1.outcome == 'failure'
+        id: pushStaticAnalysisCachegrindAttempt2
+        continue-on-error: true
+        uses: ./.github/workflows/push-results
+        with:
+          repository: ${{ matrix.benchResultsRepo.name }}
+          branch: ${{ matrix.benchResultsRepo.branch }}
+          token: ${{ secrets.BENCH_GITHUB_TOKEN }}
+          path: "./gh-pages"
+          bench_name: ${{ matrix.bench.title }}
+          bench_tool: "roblox"
+          bench_output_file_path: "./${{ matrix.bench.script }}-output.txt"
+          bench_external_data_json_path: "./gh-pages/dev/bench/data-${{ matrix.os }}.json"
+
+      - name: Push static analysis Cachegrind results (Attempt 2)
+        if: matrix.os == 'ubuntu-latest' && steps.pushStaticAnalysisCachegrindAttempt2.outcome == 'failure'
+        id: pushStaticAnalysisCachegrindAttempt3
+        continue-on-error: true
+        uses: ./.github/workflows/push-results
+        with:
+          repository: ${{ matrix.benchResultsRepo.name }}
+          branch: ${{ matrix.benchResultsRepo.branch }}
+          token: ${{ secrets.BENCH_GITHUB_TOKEN }}
+          path: "./gh-pages"
+          bench_name: ${{ matrix.bench.title }}
+          bench_tool: "roblox"
+          bench_output_file_path: "./${{ matrix.bench.script }}-output.txt"
+          bench_external_data_json_path: "./gh-pages/dev/bench/data-${{ matrix.os }}.json"

--- a/.github/workflows/benchmark-dev.yml
+++ b/.github/workflows/benchmark-dev.yml
@@ -80,6 +80,9 @@ jobs:
       - name: Print steps.pushBenchmarkAttempt1.outcome
         run: echo "steps - ${{ steps.pushBenchmarkAttempt1.outcome  }}"
 
+      - name: Did attempt 1 fail?
+        run: echo ${{ steps.pushBenchmarkAttempt1.outcome }}
+
       - name: Push benchmark results (Attempt 2)
         id: pushBenchmarkAttempt2
         continue-on-error: true

--- a/.github/workflows/benchmark-dev.yml
+++ b/.github/workflows/benchmark-dev.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - master
-      - feat/retry-benchmarks
+
     paths-ignore:
       - "docs/**"
       - "papers/**"
@@ -29,8 +29,7 @@ jobs:
               cachegrindIterCount: 20,
             }
         benchResultsRepo:
-          # - { name: "luau-lang/benchmark-data", branch: "main" }
-          - { name: "AllanJeremy/luau-benchmark-results", branch: "main" }
+          - { name: "luau-lang/benchmark-data", branch: "main" }
 
     runs-on: ${{ matrix.os }}
     steps:
@@ -122,8 +121,7 @@ jobs:
               cachegrindIterCount: 20,
             }
         benchResultsRepo:
-          # - { name: "luau-lang/benchmark-data", branch: "main" }
-          - { name: "AllanJeremy/luau-benchmark-results", branch: "main" }
+          - { name: "luau-lang/benchmark-data", branch: "main" }
 
     runs-on: ${{ matrix.os }}
     steps:
@@ -264,8 +262,7 @@ jobs:
               cachegrindIterCount: 20,
             }
         benchResultsRepo:
-          # - { name: "luau-lang/benchmark-data", branch: "main" }
-          - { name: "AllanJeremy/luau-benchmark-results", branch: "main" }
+          - { name: "luau-lang/benchmark-data", branch: "main" }
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/benchmark-dev.yml
+++ b/.github/workflows/benchmark-dev.yml
@@ -77,12 +77,6 @@ jobs:
           bench_output_file_path: "./${{ matrix.bench.script }}-output.txt"
           bench_external_data_json_path: "./gh-pages/dev/bench/data-${{ matrix.os }}.json"
 
-      - name: Print steps.pushBenchmarkAttempt1.outcome
-        run: echo "steps - ${{ steps.pushBenchmarkAttempt1.outcome  }}"
-
-      - name: Did attempt 1 fail?
-        run: echo ${{ steps.pushBenchmarkAttempt1.outcome == 'failure'}}
-
       - name: Push benchmark results (Attempt 2)
         id: pushBenchmarkAttempt2
         continue-on-error: true

--- a/.github/workflows/benchmark-dev.yml
+++ b/.github/workflows/benchmark-dev.yml
@@ -65,16 +65,23 @@ jobs:
 
       - name: Push benchmark results
         if: github.event_name == 'push'
-        uses: ./.github/workflows/push-results
+        uses: nick-fields/retry@v2.7.0
         with:
-          repository: ${{ matrix.benchResultsRepo.name }}
-          branch: ${{ matrix.benchResultsRepo.branch }}
-          token: ${{ secrets.BENCH_GITHUB_TOKEN }}
-          path: "./gh-pages"
-          bench_name: "${{ matrix.bench.title }} (Windows ${{matrix.arch}})"
-          bench_tool: "benchmarkluau"
-          bench_output_file_path: "./${{ matrix.bench.script }}-output.txt"
-          bench_external_data_json_path: "./gh-pages/dev/bench/data-${{ matrix.os }}.json"
+          max_attempts: 5
+          retry_on: error
+          retry_wait_seconds: 60
+          timeout_minutes: 5
+          command:
+            uses: ./.github/workflows/push-results
+            with:
+              repository: ${{ matrix.benchResultsRepo.name }}
+              branch: ${{ matrix.benchResultsRepo.branch }}
+              token: ${{ secrets.BENCH_GITHUB_TOKEN }}
+              path: "./gh-pages"
+              bench_name: "${{ matrix.bench.title }} (Windows ${{matrix.arch}})"
+              bench_tool: "benchmarkluau"
+              bench_output_file_path: "./${{ matrix.bench.script }}-output.txt"
+              bench_external_data_json_path: "./gh-pages/dev/bench/data-${{ matrix.os }}.json"
 
   # unix:
   #   name: ${{matrix.os}}

--- a/.github/workflows/benchmark-dev.yml
+++ b/.github/workflows/benchmark-dev.yml
@@ -81,7 +81,7 @@ jobs:
         run: echo "steps - ${{ steps.pushBenchmarkAttempt1.outcome  }}"
 
       - name: Did attempt 1 fail?
-        run: echo ${{ steps.pushBenchmarkAttempt1.outcome }}
+        run: echo ${{ steps.pushBenchmarkAttempt1.outcome == 'failure'}}
 
       - name: Push benchmark results (Attempt 2)
         id: pushBenchmarkAttempt2

--- a/.github/workflows/benchmark-dev.yml
+++ b/.github/workflows/benchmark-dev.yml
@@ -69,7 +69,7 @@ jobs:
         with:
           repository: ${{ matrix.benchResultsRepo.name }}
           branch: ${{ matrix.benchResultsRepo.branch }}
-          # token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.BENCH_GITHUB_TOKEN }}
           path: "./gh-pages"
           bench_name: "${{ matrix.bench.title }} (Windows ${{matrix.arch}})"
           bench_tool: "benchmarkluau"

--- a/.github/workflows/benchmark-dev.yml
+++ b/.github/workflows/benchmark-dev.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - feat/retry-benchmarks
     paths-ignore:
       - "docs/**"
       - "papers/**"
@@ -28,7 +29,8 @@ jobs:
               cachegrindIterCount: 20,
             }
         benchResultsRepo:
-          - { name: "luau-lang/benchmark-data", branch: "main" }
+          # - { name: "luau-lang/benchmark-data", branch: "main" }
+          - { name: "AllanJeremy/luau-benchmark-results", branch: "main" }
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/benchmark-dev.yml
+++ b/.github/workflows/benchmark-dev.yml
@@ -77,6 +77,9 @@ jobs:
           bench_output_file_path: "./${{ matrix.bench.script }}-output.txt"
           bench_external_data_json_path: "./gh-pages/dev/bench/data-${{ matrix.os }}.json"
 
+      - name: Print steps.pushBenchmarkAttempt1.outcome
+        run: echo "steps - ${{ steps.pushBenchmarkAttempt1.outcome  }}"
+
       - name: Push benchmark results (Attempt 2)
         id: pushBenchmarkAttempt2
         continue-on-error: true
@@ -92,294 +95,294 @@ jobs:
           bench_output_file_path: "./${{ matrix.bench.script }}-output.txt"
           bench_external_data_json_path: "./gh-pages/dev/bench/data-${{ matrix.os }}.json"
 
-      - name: Push benchmark results (Attempt 3)
-        id: pushBenchmarkAttempt3
-        continue-on-error: true
-        if: steps.pushBenchmarkAttempt2.outcome == 'failure'
-        uses: ./.github/workflows/push-results
-        with:
-          repository: ${{ matrix.benchResultsRepo.name }}
-          branch: ${{ matrix.benchResultsRepo.branch }}
-          token: ${{ secrets.BENCH_GITHUB_TOKEN }}
-          path: "./gh-pages"
-          bench_name: "${{ matrix.bench.title }} (Windows ${{matrix.arch}})"
-          bench_tool: "benchmarkluau"
-          bench_output_file_path: "./${{ matrix.bench.script }}-output.txt"
-          bench_external_data_json_path: "./gh-pages/dev/bench/data-${{ matrix.os }}.json"
+  #     - name: Push benchmark results (Attempt 3)
+  #       id: pushBenchmarkAttempt3
+  #       continue-on-error: true
+  #       if: steps.pushBenchmarkAttempt2.outcome == 'failure'
+  #       uses: ./.github/workflows/push-results
+  #       with:
+  #         repository: ${{ matrix.benchResultsRepo.name }}
+  #         branch: ${{ matrix.benchResultsRepo.branch }}
+  #         token: ${{ secrets.BENCH_GITHUB_TOKEN }}
+  #         path: "./gh-pages"
+  #         bench_name: "${{ matrix.bench.title }} (Windows ${{matrix.arch}})"
+  #         bench_tool: "benchmarkluau"
+  #         bench_output_file_path: "./${{ matrix.bench.script }}-output.txt"
+  #         bench_external_data_json_path: "./gh-pages/dev/bench/data-${{ matrix.os }}.json"
 
-  unix:
-    name: ${{matrix.os}}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-latest]
-        bench:
-          - {
-              script: "run-benchmarks",
-              timeout: 12,
-              title: "Luau Benchmarks",
-              cachegrindTitle: "Performance",
-              cachegrindIterCount: 20,
-            }
-        benchResultsRepo:
-          - { name: "luau-lang/benchmark-data", branch: "main" }
+  # unix:
+  #   name: ${{matrix.os}}
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       os: [ubuntu-latest, macos-latest]
+  #       bench:
+  #         - {
+  #             script: "run-benchmarks",
+  #             timeout: 12,
+  #             title: "Luau Benchmarks",
+  #             cachegrindTitle: "Performance",
+  #             cachegrindIterCount: 20,
+  #           }
+  #       benchResultsRepo:
+  #         - { name: "luau-lang/benchmark-data", branch: "main" }
 
-    runs-on: ${{ matrix.os }}
-    steps:
-      - name: Checkout Luau repository
-        uses: actions/checkout@v3
+  #   runs-on: ${{ matrix.os }}
+  #   steps:
+  #     - name: Checkout Luau repository
+  #       uses: actions/checkout@v3
 
-      - name: Build Luau
-        run: make config=release luau luau-analyze
+  #     - name: Build Luau
+  #       run: make config=release luau luau-analyze
 
-      - uses: actions/setup-python@v3
-        with:
-          python-version: "3.9"
-          architecture: "x64"
+  #     - uses: actions/setup-python@v3
+  #       with:
+  #         python-version: "3.9"
+  #         architecture: "x64"
 
-      - name: Install python dependencies
-        run: |
-          python -m pip install requests
-          python -m pip install --user numpy scipy matplotlib ipython jupyter pandas sympy nose
+  #     - name: Install python dependencies
+  #       run: |
+  #         python -m pip install requests
+  #         python -m pip install --user numpy scipy matplotlib ipython jupyter pandas sympy nose
 
-      - name: Run benchmark
-        run: |
-          python bench/bench.py | tee ${{ matrix.bench.script }}-output.txt
+  #     - name: Run benchmark
+  #       run: |
+  #         python bench/bench.py | tee ${{ matrix.bench.script }}-output.txt
 
-      - name: Install valgrind
-        if: matrix.os == 'ubuntu-latest'
-        run: |
-          sudo apt-get install valgrind
+  #     - name: Install valgrind
+  #       if: matrix.os == 'ubuntu-latest'
+  #       run: |
+  #         sudo apt-get install valgrind
 
-      - name: Run ${{ matrix.bench.title }} (Cold Cachegrind)
-        if: matrix.os == 'ubuntu-latest'
-        run: sudo bash ./scripts/run-with-cachegrind.sh python ./bench/bench.py "${{ matrix.bench.cachegrindTitle}}Cold" 1 | tee -a ${{ matrix.bench.script }}-output.txt
+  #     - name: Run ${{ matrix.bench.title }} (Cold Cachegrind)
+  #       if: matrix.os == 'ubuntu-latest'
+  #       run: sudo bash ./scripts/run-with-cachegrind.sh python ./bench/bench.py "${{ matrix.bench.cachegrindTitle}}Cold" 1 | tee -a ${{ matrix.bench.script }}-output.txt
 
-      - name: Run ${{ matrix.bench.title }} (Warm Cachegrind)
-        if: matrix.os == 'ubuntu-latest'
-        run: sudo bash ./scripts/run-with-cachegrind.sh python ./bench/bench.py "${{ matrix.bench.cachegrindTitle }}" ${{ matrix.bench.cachegrindIterCount }} | tee -a ${{ matrix.bench.script }}-output.txt
+  #     - name: Run ${{ matrix.bench.title }} (Warm Cachegrind)
+  #       if: matrix.os == 'ubuntu-latest'
+  #       run: sudo bash ./scripts/run-with-cachegrind.sh python ./bench/bench.py "${{ matrix.bench.cachegrindTitle }}" ${{ matrix.bench.cachegrindIterCount }} | tee -a ${{ matrix.bench.script }}-output.txt
 
-      - name: Push benchmark results
-        id: pushBenchmarkAttempt1
-        continue-on-error: true
-        uses: ./.github/workflows/push-results
-        with:
-          repository: ${{ matrix.benchResultsRepo.name }}
-          branch: ${{ matrix.benchResultsRepo.branch }}
-          token: ${{ secrets.BENCH_GITHUB_TOKEN }}
-          path: "./gh-pages"
-          bench_name: ${{ matrix.bench.title }}
-          bench_tool: "benchmarkluau"
-          bench_output_file_path: "./${{ matrix.bench.script }}-output.txt"
-          bench_external_data_json_path: "./gh-pages/dev/bench/data-${{ matrix.os }}.json"
+  #     - name: Push benchmark results
+  #       id: pushBenchmarkAttempt1
+  #       continue-on-error: true
+  #       uses: ./.github/workflows/push-results
+  #       with:
+  #         repository: ${{ matrix.benchResultsRepo.name }}
+  #         branch: ${{ matrix.benchResultsRepo.branch }}
+  #         token: ${{ secrets.BENCH_GITHUB_TOKEN }}
+  #         path: "./gh-pages"
+  #         bench_name: ${{ matrix.bench.title }}
+  #         bench_tool: "benchmarkluau"
+  #         bench_output_file_path: "./${{ matrix.bench.script }}-output.txt"
+  #         bench_external_data_json_path: "./gh-pages/dev/bench/data-${{ matrix.os }}.json"
 
-      - name: Push benchmark results (Attempt 2)
-        id: pushBenchmarkAttempt2
-        continue-on-error: true
-        if: steps.pushBenchmarkAttempt1.outcome == 'failure'
-        uses: ./.github/workflows/push-results
-        with:
-          repository: ${{ matrix.benchResultsRepo.name }}
-          branch: ${{ matrix.benchResultsRepo.branch }}
-          token: ${{ secrets.BENCH_GITHUB_TOKEN }}
-          path: "./gh-pages"
-          bench_name: ${{ matrix.bench.title }}
-          bench_tool: "benchmarkluau"
-          bench_output_file_path: "./${{ matrix.bench.script }}-output.txt"
-          bench_external_data_json_path: "./gh-pages/dev/bench/data-${{ matrix.os }}.json"
+  #     - name: Push benchmark results (Attempt 2)
+  #       id: pushBenchmarkAttempt2
+  #       continue-on-error: true
+  #       if: steps.pushBenchmarkAttempt1.outcome == 'failure'
+  #       uses: ./.github/workflows/push-results
+  #       with:
+  #         repository: ${{ matrix.benchResultsRepo.name }}
+  #         branch: ${{ matrix.benchResultsRepo.branch }}
+  #         token: ${{ secrets.BENCH_GITHUB_TOKEN }}
+  #         path: "./gh-pages"
+  #         bench_name: ${{ matrix.bench.title }}
+  #         bench_tool: "benchmarkluau"
+  #         bench_output_file_path: "./${{ matrix.bench.script }}-output.txt"
+  #         bench_external_data_json_path: "./gh-pages/dev/bench/data-${{ matrix.os }}.json"
 
-      - name: Push benchmark results (Attempt 3)
-        id: pushBenchmarkAttempt3
-        continue-on-error: true
-        if: steps.pushBenchmarkAttempt2.outcome == 'failure'
-        uses: ./.github/workflows/push-results
-        with:
-          repository: ${{ matrix.benchResultsRepo.name }}
-          branch: ${{ matrix.benchResultsRepo.branch }}
-          token: ${{ secrets.BENCH_GITHUB_TOKEN }}
-          path: "./gh-pages"
-          bench_name: ${{ matrix.bench.title }}
-          bench_tool: "benchmarkluau"
-          bench_output_file_path: "./${{ matrix.bench.script }}-output.txt"
-          bench_external_data_json_path: "./gh-pages/dev/bench/data-${{ matrix.os }}.json"
+  #     - name: Push benchmark results (Attempt 3)
+  #       id: pushBenchmarkAttempt3
+  #       continue-on-error: true
+  #       if: steps.pushBenchmarkAttempt2.outcome == 'failure'
+  #       uses: ./.github/workflows/push-results
+  #       with:
+  #         repository: ${{ matrix.benchResultsRepo.name }}
+  #         branch: ${{ matrix.benchResultsRepo.branch }}
+  #         token: ${{ secrets.BENCH_GITHUB_TOKEN }}
+  #         path: "./gh-pages"
+  #         bench_name: ${{ matrix.bench.title }}
+  #         bench_tool: "benchmarkluau"
+  #         bench_output_file_path: "./${{ matrix.bench.script }}-output.txt"
+  #         bench_external_data_json_path: "./gh-pages/dev/bench/data-${{ matrix.os }}.json"
 
-      - name: Push Cachegrind benchmark results
-        if: matrix.os == 'ubuntu-latest'
-        id: pushBenchmarkCachegrindAttempt1
-        continue-on-error: true
-        uses: ./.github/workflows/push-results
-        with:
-          repository: ${{ matrix.benchResultsRepo.name }}
-          branch: ${{ matrix.benchResultsRepo.branch }}
-          token: ${{ secrets.BENCH_GITHUB_TOKEN }}
-          path: "./gh-pages"
-          bench_name: ${{ matrix.bench.title }} (CacheGrind)
-          bench_tool: "roblox"
-          bench_output_file_path: "./${{ matrix.bench.script }}-output.txt"
-          bench_external_data_json_path: "./gh-pages/dev/bench/data-${{ matrix.os }}.json"
+  #     - name: Push Cachegrind benchmark results
+  #       if: matrix.os == 'ubuntu-latest'
+  #       id: pushBenchmarkCachegrindAttempt1
+  #       continue-on-error: true
+  #       uses: ./.github/workflows/push-results
+  #       with:
+  #         repository: ${{ matrix.benchResultsRepo.name }}
+  #         branch: ${{ matrix.benchResultsRepo.branch }}
+  #         token: ${{ secrets.BENCH_GITHUB_TOKEN }}
+  #         path: "./gh-pages"
+  #         bench_name: ${{ matrix.bench.title }} (CacheGrind)
+  #         bench_tool: "roblox"
+  #         bench_output_file_path: "./${{ matrix.bench.script }}-output.txt"
+  #         bench_external_data_json_path: "./gh-pages/dev/bench/data-${{ matrix.os }}.json"
 
-      - name: Push Cachegrind benchmark results (Attempt 2)
-        if: matrix.os == 'ubuntu-latest' && steps.pushBenchmarkCachegrindAttempt1.outcome == 'failure'
-        id: pushBenchmarkCachegrindAttempt2
-        continue-on-error: true
-        uses: ./.github/workflows/push-results
-        with:
-          repository: ${{ matrix.benchResultsRepo.name }}
-          branch: ${{ matrix.benchResultsRepo.branch }}
-          token: ${{ secrets.BENCH_GITHUB_TOKEN }}
-          path: "./gh-pages"
-          bench_name: ${{ matrix.bench.title }} (CacheGrind)
-          bench_tool: "roblox"
-          bench_output_file_path: "./${{ matrix.bench.script }}-output.txt"
-          bench_external_data_json_path: "./gh-pages/dev/bench/data-${{ matrix.os }}.json"
+  #     - name: Push Cachegrind benchmark results (Attempt 2)
+  #       if: matrix.os == 'ubuntu-latest' && steps.pushBenchmarkCachegrindAttempt1.outcome == 'failure'
+  #       id: pushBenchmarkCachegrindAttempt2
+  #       continue-on-error: true
+  #       uses: ./.github/workflows/push-results
+  #       with:
+  #         repository: ${{ matrix.benchResultsRepo.name }}
+  #         branch: ${{ matrix.benchResultsRepo.branch }}
+  #         token: ${{ secrets.BENCH_GITHUB_TOKEN }}
+  #         path: "./gh-pages"
+  #         bench_name: ${{ matrix.bench.title }} (CacheGrind)
+  #         bench_tool: "roblox"
+  #         bench_output_file_path: "./${{ matrix.bench.script }}-output.txt"
+  #         bench_external_data_json_path: "./gh-pages/dev/bench/data-${{ matrix.os }}.json"
 
-      - name: Push Cachegrind benchmark results (Attempt 3)
-        if: matrix.os == 'ubuntu-latest' && steps.pushBenchmarkCachegrindAttempt2.outcome == 'failure'
-        id: pushBenchmarkCachegrindAttempt3
-        continue-on-error: true
-        uses: ./.github/workflows/push-results
-        with:
-          repository: ${{ matrix.benchResultsRepo.name }}
-          branch: ${{ matrix.benchResultsRepo.branch }}
-          token: ${{ secrets.BENCH_GITHUB_TOKEN }}
-          path: "./gh-pages"
-          bench_name: ${{ matrix.bench.title }} (CacheGrind)
-          bench_tool: "roblox"
-          bench_output_file_path: "./${{ matrix.bench.script }}-output.txt"
-          bench_external_data_json_path: "./gh-pages/dev/bench/data-${{ matrix.os }}.json"
+  #     - name: Push Cachegrind benchmark results (Attempt 3)
+  #       if: matrix.os == 'ubuntu-latest' && steps.pushBenchmarkCachegrindAttempt2.outcome == 'failure'
+  #       id: pushBenchmarkCachegrindAttempt3
+  #       continue-on-error: true
+  #       uses: ./.github/workflows/push-results
+  #       with:
+  #         repository: ${{ matrix.benchResultsRepo.name }}
+  #         branch: ${{ matrix.benchResultsRepo.branch }}
+  #         token: ${{ secrets.BENCH_GITHUB_TOKEN }}
+  #         path: "./gh-pages"
+  #         bench_name: ${{ matrix.bench.title }} (CacheGrind)
+  #         bench_tool: "roblox"
+  #         bench_output_file_path: "./${{ matrix.bench.script }}-output.txt"
+  #         bench_external_data_json_path: "./gh-pages/dev/bench/data-${{ matrix.os }}.json"
 
-  static-analysis:
-    name: luau-analyze
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest]
-        bench:
-          - {
-              script: "run-analyze",
-              timeout: 12,
-              title: "Luau Analyze",
-              cachegrindTitle: "Performance",
-              cachegrindIterCount: 20,
-            }
-        benchResultsRepo:
-          - { name: "luau-lang/benchmark-data", branch: "main" }
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          token: "${{ secrets.BENCH_GITHUB_TOKEN }}"
+  # static-analysis:
+  #   name: luau-analyze
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       os: [ubuntu-latest]
+  #       bench:
+  #         - {
+  #             script: "run-analyze",
+  #             timeout: 12,
+  #             title: "Luau Analyze",
+  #             cachegrindTitle: "Performance",
+  #             cachegrindIterCount: 20,
+  #           }
+  #       benchResultsRepo:
+  #         - { name: "luau-lang/benchmark-data", branch: "main" }
+  #   runs-on: ${{ matrix.os }}
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #       with:
+  #         token: "${{ secrets.BENCH_GITHUB_TOKEN }}"
 
-      - name: Build Luau
-        run: make config=release luau luau-analyze
+  #     - name: Build Luau
+  #       run: make config=release luau luau-analyze
 
-      - uses: actions/setup-python@v4
-        with:
-          python-version: "3.9"
-          architecture: "x64"
+  #     - uses: actions/setup-python@v4
+  #       with:
+  #         python-version: "3.9"
+  #         architecture: "x64"
 
-      - name: Install python dependencies
-        run: |
-          sudo pip install requests numpy scipy matplotlib ipython jupyter pandas sympy nose
+  #     - name: Install python dependencies
+  #       run: |
+  #         sudo pip install requests numpy scipy matplotlib ipython jupyter pandas sympy nose
 
-      - name: Install valgrind
-        run: |
-          sudo apt-get install valgrind
+  #     - name: Install valgrind
+  #       run: |
+  #         sudo apt-get install valgrind
 
-      - name: Run Luau Analyze on static file
-        run: sudo python ./bench/measure_time.py ./build/release/luau-analyze bench/other/LuauPolyfillMap.lua | tee ${{ matrix.bench.script }}-output.txt
+  #     - name: Run Luau Analyze on static file
+  #       run: sudo python ./bench/measure_time.py ./build/release/luau-analyze bench/other/LuauPolyfillMap.lua | tee ${{ matrix.bench.script }}-output.txt
 
-      - name: Run ${{ matrix.bench.title }} (Cold Cachegrind)
-        run: sudo ./scripts/run-with-cachegrind.sh python ./bench/measure_time.py "${{ matrix.bench.cachegrindTitle}}Cold" 1 ./build/release/luau-analyze bench/other/LuauPolyfillMap.lua | tee -a ${{ matrix.bench.script }}-output.txt
+  #     - name: Run ${{ matrix.bench.title }} (Cold Cachegrind)
+  #       run: sudo ./scripts/run-with-cachegrind.sh python ./bench/measure_time.py "${{ matrix.bench.cachegrindTitle}}Cold" 1 ./build/release/luau-analyze bench/other/LuauPolyfillMap.lua | tee -a ${{ matrix.bench.script }}-output.txt
 
-      - name: Run ${{ matrix.bench.title }} (Warm Cachegrind)
-        run: sudo bash ./scripts/run-with-cachegrind.sh python ./bench/measure_time.py "${{ matrix.bench.cachegrindTitle}}" 1  ./build/release/luau-analyze bench/other/LuauPolyfillMap.lua | tee -a ${{ matrix.bench.script }}-output.txt
+  #     - name: Run ${{ matrix.bench.title }} (Warm Cachegrind)
+  #       run: sudo bash ./scripts/run-with-cachegrind.sh python ./bench/measure_time.py "${{ matrix.bench.cachegrindTitle}}" 1  ./build/release/luau-analyze bench/other/LuauPolyfillMap.lua | tee -a ${{ matrix.bench.script }}-output.txt
 
-      - name: Push static analysis results
-        id: pushStaticAnalysisAttempt1
-        continue-on-error: true
-        uses: ./.github/workflows/push-results
-        with:
-          repository: ${{ matrix.benchResultsRepo.name }}
-          branch: ${{ matrix.benchResultsRepo.branch }}
-          token: ${{ secrets.BENCH_GITHUB_TOKEN }}
-          path: "./gh-pages"
-          bench_name: ${{ matrix.bench.title }}
-          bench_tool: "roblox"
-          bench_output_file_path: "./${{ matrix.bench.script }}-output.txt"
-          bench_external_data_json_path: "./gh-pages/dev/bench/data-${{ matrix.os }}.json"
+  #     - name: Push static analysis results
+  #       id: pushStaticAnalysisAttempt1
+  #       continue-on-error: true
+  #       uses: ./.github/workflows/push-results
+  #       with:
+  #         repository: ${{ matrix.benchResultsRepo.name }}
+  #         branch: ${{ matrix.benchResultsRepo.branch }}
+  #         token: ${{ secrets.BENCH_GITHUB_TOKEN }}
+  #         path: "./gh-pages"
+  #         bench_name: ${{ matrix.bench.title }}
+  #         bench_tool: "roblox"
+  #         bench_output_file_path: "./${{ matrix.bench.script }}-output.txt"
+  #         bench_external_data_json_path: "./gh-pages/dev/bench/data-${{ matrix.os }}.json"
 
-      - name: Push static analysis results (Attempt 2)
-        if: steps.pushStaticAnalysisAttempt1.outcome == 'failure'
-        id: pushStaticAnalysisAttempt2
-        continue-on-error: true
-        uses: ./.github/workflows/push-results
-        with:
-          repository: ${{ matrix.benchResultsRepo.name }}
-          branch: ${{ matrix.benchResultsRepo.branch }}
-          token: ${{ secrets.BENCH_GITHUB_TOKEN }}
-          path: "./gh-pages"
-          bench_name: ${{ matrix.bench.title }}
-          bench_tool: "roblox"
-          bench_output_file_path: "./${{ matrix.bench.script }}-output.txt"
-          bench_external_data_json_path: "./gh-pages/dev/bench/data-${{ matrix.os }}.json"
+  #     - name: Push static analysis results (Attempt 2)
+  #       if: steps.pushStaticAnalysisAttempt1.outcome == 'failure'
+  #       id: pushStaticAnalysisAttempt2
+  #       continue-on-error: true
+  #       uses: ./.github/workflows/push-results
+  #       with:
+  #         repository: ${{ matrix.benchResultsRepo.name }}
+  #         branch: ${{ matrix.benchResultsRepo.branch }}
+  #         token: ${{ secrets.BENCH_GITHUB_TOKEN }}
+  #         path: "./gh-pages"
+  #         bench_name: ${{ matrix.bench.title }}
+  #         bench_tool: "roblox"
+  #         bench_output_file_path: "./${{ matrix.bench.script }}-output.txt"
+  #         bench_external_data_json_path: "./gh-pages/dev/bench/data-${{ matrix.os }}.json"
 
-      - name: Push static analysis results (Attempt 3)
-        if: steps.pushStaticAnalysisAttempt2.outcome == 'failure'
-        id: pushStaticAnalysisAttempt3
-        continue-on-error: true
-        uses: ./.github/workflows/push-results
-        with:
-          repository: ${{ matrix.benchResultsRepo.name }}
-          branch: ${{ matrix.benchResultsRepo.branch }}
-          token: ${{ secrets.BENCH_GITHUB_TOKEN }}
-          path: "./gh-pages"
-          bench_name: ${{ matrix.bench.title }}
-          bench_tool: "roblox"
-          bench_output_file_path: "./${{ matrix.bench.script }}-output.txt"
-          bench_external_data_json_path: "./gh-pages/dev/bench/data-${{ matrix.os }}.json"
+  #     - name: Push static analysis results (Attempt 3)
+  #       if: steps.pushStaticAnalysisAttempt2.outcome == 'failure'
+  #       id: pushStaticAnalysisAttempt3
+  #       continue-on-error: true
+  #       uses: ./.github/workflows/push-results
+  #       with:
+  #         repository: ${{ matrix.benchResultsRepo.name }}
+  #         branch: ${{ matrix.benchResultsRepo.branch }}
+  #         token: ${{ secrets.BENCH_GITHUB_TOKEN }}
+  #         path: "./gh-pages"
+  #         bench_name: ${{ matrix.bench.title }}
+  #         bench_tool: "roblox"
+  #         bench_output_file_path: "./${{ matrix.bench.script }}-output.txt"
+  #         bench_external_data_json_path: "./gh-pages/dev/bench/data-${{ matrix.os }}.json"
 
-      - name: Push static analysis Cachegrind results
-        if: matrix.os == 'ubuntu-latest'
-        id: pushStaticAnalysisCachegrindAttempt1
-        continue-on-error: true
-        uses: ./.github/workflows/push-results
-        with:
-          repository: ${{ matrix.benchResultsRepo.name }}
-          branch: ${{ matrix.benchResultsRepo.branch }}
-          token: ${{ secrets.BENCH_GITHUB_TOKEN }}
-          path: "./gh-pages"
-          bench_name: ${{ matrix.bench.title }}
-          bench_tool: "roblox"
-          bench_output_file_path: "./${{ matrix.bench.script }}-output.txt"
-          bench_external_data_json_path: "./gh-pages/dev/bench/data-${{ matrix.os }}.json"
+  #     - name: Push static analysis Cachegrind results
+  #       if: matrix.os == 'ubuntu-latest'
+  #       id: pushStaticAnalysisCachegrindAttempt1
+  #       continue-on-error: true
+  #       uses: ./.github/workflows/push-results
+  #       with:
+  #         repository: ${{ matrix.benchResultsRepo.name }}
+  #         branch: ${{ matrix.benchResultsRepo.branch }}
+  #         token: ${{ secrets.BENCH_GITHUB_TOKEN }}
+  #         path: "./gh-pages"
+  #         bench_name: ${{ matrix.bench.title }}
+  #         bench_tool: "roblox"
+  #         bench_output_file_path: "./${{ matrix.bench.script }}-output.txt"
+  #         bench_external_data_json_path: "./gh-pages/dev/bench/data-${{ matrix.os }}.json"
 
-      - name: Push static analysis Cachegrind results (Attempt 2)
-        if: matrix.os == 'ubuntu-latest' && steps.pushStaticAnalysisCachegrindAttempt1.outcome == 'failure'
-        id: pushStaticAnalysisCachegrindAttempt2
-        continue-on-error: true
-        uses: ./.github/workflows/push-results
-        with:
-          repository: ${{ matrix.benchResultsRepo.name }}
-          branch: ${{ matrix.benchResultsRepo.branch }}
-          token: ${{ secrets.BENCH_GITHUB_TOKEN }}
-          path: "./gh-pages"
-          bench_name: ${{ matrix.bench.title }}
-          bench_tool: "roblox"
-          bench_output_file_path: "./${{ matrix.bench.script }}-output.txt"
-          bench_external_data_json_path: "./gh-pages/dev/bench/data-${{ matrix.os }}.json"
+  #     - name: Push static analysis Cachegrind results (Attempt 2)
+  #       if: matrix.os == 'ubuntu-latest' && steps.pushStaticAnalysisCachegrindAttempt1.outcome == 'failure'
+  #       id: pushStaticAnalysisCachegrindAttempt2
+  #       continue-on-error: true
+  #       uses: ./.github/workflows/push-results
+  #       with:
+  #         repository: ${{ matrix.benchResultsRepo.name }}
+  #         branch: ${{ matrix.benchResultsRepo.branch }}
+  #         token: ${{ secrets.BENCH_GITHUB_TOKEN }}
+  #         path: "./gh-pages"
+  #         bench_name: ${{ matrix.bench.title }}
+  #         bench_tool: "roblox"
+  #         bench_output_file_path: "./${{ matrix.bench.script }}-output.txt"
+  #         bench_external_data_json_path: "./gh-pages/dev/bench/data-${{ matrix.os }}.json"
 
-      - name: Push static analysis Cachegrind results (Attempt 2)
-        if: matrix.os == 'ubuntu-latest' && steps.pushStaticAnalysisCachegrindAttempt2.outcome == 'failure'
-        id: pushStaticAnalysisCachegrindAttempt3
-        continue-on-error: true
-        uses: ./.github/workflows/push-results
-        with:
-          repository: ${{ matrix.benchResultsRepo.name }}
-          branch: ${{ matrix.benchResultsRepo.branch }}
-          token: ${{ secrets.BENCH_GITHUB_TOKEN }}
-          path: "./gh-pages"
-          bench_name: ${{ matrix.bench.title }}
-          bench_tool: "roblox"
-          bench_output_file_path: "./${{ matrix.bench.script }}-output.txt"
-          bench_external_data_json_path: "./gh-pages/dev/bench/data-${{ matrix.os }}.json"
+  #     - name: Push static analysis Cachegrind results (Attempt 2)
+  #       if: matrix.os == 'ubuntu-latest' && steps.pushStaticAnalysisCachegrindAttempt2.outcome == 'failure'
+  #       id: pushStaticAnalysisCachegrindAttempt3
+  #       continue-on-error: true
+  #       uses: ./.github/workflows/push-results
+  #       with:
+  #         repository: ${{ matrix.benchResultsRepo.name }}
+  #         branch: ${{ matrix.benchResultsRepo.branch }}
+  #         token: ${{ secrets.BENCH_GITHUB_TOKEN }}
+  #         path: "./gh-pages"
+  #         bench_name: ${{ matrix.bench.title }}
+  #         bench_tool: "roblox"
+  #         bench_output_file_path: "./${{ matrix.bench.script }}-output.txt"
+  #         bench_external_data_json_path: "./gh-pages/dev/bench/data-${{ matrix.os }}.json"

--- a/.github/workflows/benchmark-dev.yml
+++ b/.github/workflows/benchmark-dev.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest]
-        arch: [x64] #Win32,
+        arch: [Win32, x64]
         bench:
           - {
               script: "run-benchmarks",

--- a/.github/workflows/benchmark-dev.yml
+++ b/.github/workflows/benchmark-dev.yml
@@ -61,47 +61,18 @@ jobs:
         run: |
           python bench/bench.py | tee ${{ matrix.bench.script }}-output.txt
 
-      - name: Checkout Benchmark Results repository
-        uses: actions/checkout@v3
-        with:
-          repository: ${{ matrix.benchResultsRepo.name }}
-          ref: ${{ matrix.benchResultsRepo.branch }}
-          token: ${{ secrets.BENCH_GITHUB_TOKEN }}
-          path: "./gh-pages"
-
-      - name: Store ${{ matrix.bench.title }} result
-        uses: Roblox/rhysd-github-action-benchmark@v-luau
-        with:
-          name: ${{ matrix.bench.title }} (Windows ${{matrix.arch}})
-          tool: "benchmarkluau"
-          output-file-path: ./${{ matrix.bench.script }}-output.txt
-          external-data-json-path: ./gh-pages/dev/bench/data-${{ matrix.os }}.json
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Push benchmark results
-        if: github.event_name == 'push'
-        run: |
-          echo "Pushing benchmark results..."
-          cd gh-pages
-          git config user.name github-actions
-          git config user.email github@users.noreply.github.com
-          git add ./dev/bench/data-${{ matrix.os }}.json
-          git commit -m "Add benchmarks results for ${{ github.sha }}"
-          git push
-          cd ..
-
       - name: Push benchmark results
         if: github.event_name == 'push'
         uses: ./.github/workflows/push-results
-          with:
-            repository: ${{ matrix.benchResultsRepo.name }}
-            branch: ${{ matrix.benchResultsRepo.branch }}
-            token: ${{ secrets.GITHUB_TOKEN }}
-            path: "./gh-pages"
-            bench_name:  "${{ matrix.bench.title }} (Windows ${{matrix.arch}})"
-            bench_tool:  "benchmarkluau"
-            bench_output_file_path: "./${{ matrix.bench.script }}-output.txt"
-            bench_external_data_json_path: "./gh-pages/dev/bench/data-${{ matrix.os }}.json"
+        with:
+          repository: ${{ matrix.benchResultsRepo.name }}
+          branch: ${{ matrix.benchResultsRepo.branch }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          path: "./gh-pages"
+          bench_name: "${{ matrix.bench.title }} (Windows ${{matrix.arch}})"
+          bench_tool: "benchmarkluau"
+          bench_output_file_path: "./${{ matrix.bench.script }}-output.txt"
+          bench_external_data_json_path: "./gh-pages/dev/bench/data-${{ matrix.os }}.json"
 
   # unix:
   #   name: ${{matrix.os}}

--- a/.github/workflows/benchmark-dev.yml
+++ b/.github/workflows/benchmark-dev.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Push benchmark results
         id: pushBenchmarkAttempt1
-        # continue-on-error: true
+        continue-on-error: true
         uses: ./.github/workflows/push-results
         with:
           repository: ${{ matrix.benchResultsRepo.name }}

--- a/.github/workflows/benchmark-dev.yml
+++ b/.github/workflows/benchmark-dev.yml
@@ -92,294 +92,297 @@ jobs:
           bench_output_file_path: "./${{ matrix.bench.script }}-output.txt"
           bench_external_data_json_path: "./gh-pages/dev/bench/data-${{ matrix.os }}.json"
 
-  #     - name: Push benchmark results (Attempt 3)
-  #       id: pushBenchmarkAttempt3
-  #       continue-on-error: true
-  #       if: steps.pushBenchmarkAttempt2.outcome == 'failure'
-  #       uses: ./.github/workflows/push-results
-  #       with:
-  #         repository: ${{ matrix.benchResultsRepo.name }}
-  #         branch: ${{ matrix.benchResultsRepo.branch }}
-  #         token: ${{ secrets.BENCH_GITHUB_TOKEN }}
-  #         path: "./gh-pages"
-  #         bench_name: "${{ matrix.bench.title }} (Windows ${{matrix.arch}})"
-  #         bench_tool: "benchmarkluau"
-  #         bench_output_file_path: "./${{ matrix.bench.script }}-output.txt"
-  #         bench_external_data_json_path: "./gh-pages/dev/bench/data-${{ matrix.os }}.json"
+      - name: Push benchmark results (Attempt 3)
+        id: pushBenchmarkAttempt3
+        continue-on-error: true
+        if: steps.pushBenchmarkAttempt2.outcome == 'failure'
+        uses: ./.github/workflows/push-results
+        with:
+          repository: ${{ matrix.benchResultsRepo.name }}
+          branch: ${{ matrix.benchResultsRepo.branch }}
+          token: ${{ secrets.BENCH_GITHUB_TOKEN }}
+          path: "./gh-pages"
+          bench_name: "${{ matrix.bench.title }} (Windows ${{matrix.arch}})"
+          bench_tool: "benchmarkluau"
+          bench_output_file_path: "./${{ matrix.bench.script }}-output.txt"
+          bench_external_data_json_path: "./gh-pages/dev/bench/data-${{ matrix.os }}.json"
 
-  # unix:
-  #   name: ${{matrix.os}}
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       os: [ubuntu-latest, macos-latest]
-  #       bench:
-  #         - {
-  #             script: "run-benchmarks",
-  #             timeout: 12,
-  #             title: "Luau Benchmarks",
-  #             cachegrindTitle: "Performance",
-  #             cachegrindIterCount: 20,
-  #           }
-  #       benchResultsRepo:
-  #         - { name: "luau-lang/benchmark-data", branch: "main" }
+  unix:
+    name: ${{matrix.os}}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        bench:
+          - {
+              script: "run-benchmarks",
+              timeout: 12,
+              title: "Luau Benchmarks",
+              cachegrindTitle: "Performance",
+              cachegrindIterCount: 20,
+            }
+        benchResultsRepo:
+          # - { name: "luau-lang/benchmark-data", branch: "main" }
+          - { name: "AllanJeremy/luau-benchmark-results", branch: "main" }
 
-  #   runs-on: ${{ matrix.os }}
-  #   steps:
-  #     - name: Checkout Luau repository
-  #       uses: actions/checkout@v3
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout Luau repository
+        uses: actions/checkout@v3
 
-  #     - name: Build Luau
-  #       run: make config=release luau luau-analyze
+      - name: Build Luau
+        run: make config=release luau luau-analyze
 
-  #     - uses: actions/setup-python@v3
-  #       with:
-  #         python-version: "3.9"
-  #         architecture: "x64"
+      - uses: actions/setup-python@v3
+        with:
+          python-version: "3.9"
+          architecture: "x64"
 
-  #     - name: Install python dependencies
-  #       run: |
-  #         python -m pip install requests
-  #         python -m pip install --user numpy scipy matplotlib ipython jupyter pandas sympy nose
+      - name: Install python dependencies
+        run: |
+          python -m pip install requests
+          python -m pip install --user numpy scipy matplotlib ipython jupyter pandas sympy nose
 
-  #     - name: Run benchmark
-  #       run: |
-  #         python bench/bench.py | tee ${{ matrix.bench.script }}-output.txt
+      - name: Run benchmark
+        run: |
+          python bench/bench.py | tee ${{ matrix.bench.script }}-output.txt
 
-  #     - name: Install valgrind
-  #       if: matrix.os == 'ubuntu-latest'
-  #       run: |
-  #         sudo apt-get install valgrind
+      - name: Install valgrind
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get install valgrind
 
-  #     - name: Run ${{ matrix.bench.title }} (Cold Cachegrind)
-  #       if: matrix.os == 'ubuntu-latest'
-  #       run: sudo bash ./scripts/run-with-cachegrind.sh python ./bench/bench.py "${{ matrix.bench.cachegrindTitle}}Cold" 1 | tee -a ${{ matrix.bench.script }}-output.txt
+      - name: Run ${{ matrix.bench.title }} (Cold Cachegrind)
+        if: matrix.os == 'ubuntu-latest'
+        run: sudo bash ./scripts/run-with-cachegrind.sh python ./bench/bench.py "${{ matrix.bench.cachegrindTitle}}Cold" 1 | tee -a ${{ matrix.bench.script }}-output.txt
 
-  #     - name: Run ${{ matrix.bench.title }} (Warm Cachegrind)
-  #       if: matrix.os == 'ubuntu-latest'
-  #       run: sudo bash ./scripts/run-with-cachegrind.sh python ./bench/bench.py "${{ matrix.bench.cachegrindTitle }}" ${{ matrix.bench.cachegrindIterCount }} | tee -a ${{ matrix.bench.script }}-output.txt
+      - name: Run ${{ matrix.bench.title }} (Warm Cachegrind)
+        if: matrix.os == 'ubuntu-latest'
+        run: sudo bash ./scripts/run-with-cachegrind.sh python ./bench/bench.py "${{ matrix.bench.cachegrindTitle }}" ${{ matrix.bench.cachegrindIterCount }} | tee -a ${{ matrix.bench.script }}-output.txt
 
-  #     - name: Push benchmark results
-  #       id: pushBenchmarkAttempt1
-  #       continue-on-error: true
-  #       uses: ./.github/workflows/push-results
-  #       with:
-  #         repository: ${{ matrix.benchResultsRepo.name }}
-  #         branch: ${{ matrix.benchResultsRepo.branch }}
-  #         token: ${{ secrets.BENCH_GITHUB_TOKEN }}
-  #         path: "./gh-pages"
-  #         bench_name: ${{ matrix.bench.title }}
-  #         bench_tool: "benchmarkluau"
-  #         bench_output_file_path: "./${{ matrix.bench.script }}-output.txt"
-  #         bench_external_data_json_path: "./gh-pages/dev/bench/data-${{ matrix.os }}.json"
+      - name: Push benchmark results
+        id: pushBenchmarkAttempt1
+        continue-on-error: true
+        uses: ./.github/workflows/push-results
+        with:
+          repository: ${{ matrix.benchResultsRepo.name }}
+          branch: ${{ matrix.benchResultsRepo.branch }}
+          token: ${{ secrets.BENCH_GITHUB_TOKEN }}
+          path: "./gh-pages"
+          bench_name: ${{ matrix.bench.title }}
+          bench_tool: "benchmarkluau"
+          bench_output_file_path: "./${{ matrix.bench.script }}-output.txt"
+          bench_external_data_json_path: "./gh-pages/dev/bench/data-${{ matrix.os }}.json"
 
-  #     - name: Push benchmark results (Attempt 2)
-  #       id: pushBenchmarkAttempt2
-  #       continue-on-error: true
-  #       if: steps.pushBenchmarkAttempt1.outcome == 'failure'
-  #       uses: ./.github/workflows/push-results
-  #       with:
-  #         repository: ${{ matrix.benchResultsRepo.name }}
-  #         branch: ${{ matrix.benchResultsRepo.branch }}
-  #         token: ${{ secrets.BENCH_GITHUB_TOKEN }}
-  #         path: "./gh-pages"
-  #         bench_name: ${{ matrix.bench.title }}
-  #         bench_tool: "benchmarkluau"
-  #         bench_output_file_path: "./${{ matrix.bench.script }}-output.txt"
-  #         bench_external_data_json_path: "./gh-pages/dev/bench/data-${{ matrix.os }}.json"
+      - name: Push benchmark results (Attempt 2)
+        id: pushBenchmarkAttempt2
+        continue-on-error: true
+        if: steps.pushBenchmarkAttempt1.outcome == 'failure'
+        uses: ./.github/workflows/push-results
+        with:
+          repository: ${{ matrix.benchResultsRepo.name }}
+          branch: ${{ matrix.benchResultsRepo.branch }}
+          token: ${{ secrets.BENCH_GITHUB_TOKEN }}
+          path: "./gh-pages"
+          bench_name: ${{ matrix.bench.title }}
+          bench_tool: "benchmarkluau"
+          bench_output_file_path: "./${{ matrix.bench.script }}-output.txt"
+          bench_external_data_json_path: "./gh-pages/dev/bench/data-${{ matrix.os }}.json"
 
-  #     - name: Push benchmark results (Attempt 3)
-  #       id: pushBenchmarkAttempt3
-  #       continue-on-error: true
-  #       if: steps.pushBenchmarkAttempt2.outcome == 'failure'
-  #       uses: ./.github/workflows/push-results
-  #       with:
-  #         repository: ${{ matrix.benchResultsRepo.name }}
-  #         branch: ${{ matrix.benchResultsRepo.branch }}
-  #         token: ${{ secrets.BENCH_GITHUB_TOKEN }}
-  #         path: "./gh-pages"
-  #         bench_name: ${{ matrix.bench.title }}
-  #         bench_tool: "benchmarkluau"
-  #         bench_output_file_path: "./${{ matrix.bench.script }}-output.txt"
-  #         bench_external_data_json_path: "./gh-pages/dev/bench/data-${{ matrix.os }}.json"
+      - name: Push benchmark results (Attempt 3)
+        id: pushBenchmarkAttempt3
+        continue-on-error: true
+        if: steps.pushBenchmarkAttempt2.outcome == 'failure'
+        uses: ./.github/workflows/push-results
+        with:
+          repository: ${{ matrix.benchResultsRepo.name }}
+          branch: ${{ matrix.benchResultsRepo.branch }}
+          token: ${{ secrets.BENCH_GITHUB_TOKEN }}
+          path: "./gh-pages"
+          bench_name: ${{ matrix.bench.title }}
+          bench_tool: "benchmarkluau"
+          bench_output_file_path: "./${{ matrix.bench.script }}-output.txt"
+          bench_external_data_json_path: "./gh-pages/dev/bench/data-${{ matrix.os }}.json"
 
-  #     - name: Push Cachegrind benchmark results
-  #       if: matrix.os == 'ubuntu-latest'
-  #       id: pushBenchmarkCachegrindAttempt1
-  #       continue-on-error: true
-  #       uses: ./.github/workflows/push-results
-  #       with:
-  #         repository: ${{ matrix.benchResultsRepo.name }}
-  #         branch: ${{ matrix.benchResultsRepo.branch }}
-  #         token: ${{ secrets.BENCH_GITHUB_TOKEN }}
-  #         path: "./gh-pages"
-  #         bench_name: ${{ matrix.bench.title }} (CacheGrind)
-  #         bench_tool: "roblox"
-  #         bench_output_file_path: "./${{ matrix.bench.script }}-output.txt"
-  #         bench_external_data_json_path: "./gh-pages/dev/bench/data-${{ matrix.os }}.json"
+      - name: Push Cachegrind benchmark results
+        if: matrix.os == 'ubuntu-latest'
+        id: pushBenchmarkCachegrindAttempt1
+        continue-on-error: true
+        uses: ./.github/workflows/push-results
+        with:
+          repository: ${{ matrix.benchResultsRepo.name }}
+          branch: ${{ matrix.benchResultsRepo.branch }}
+          token: ${{ secrets.BENCH_GITHUB_TOKEN }}
+          path: "./gh-pages"
+          bench_name: ${{ matrix.bench.title }} (CacheGrind)
+          bench_tool: "roblox"
+          bench_output_file_path: "./${{ matrix.bench.script }}-output.txt"
+          bench_external_data_json_path: "./gh-pages/dev/bench/data-${{ matrix.os }}.json"
 
-  #     - name: Push Cachegrind benchmark results (Attempt 2)
-  #       if: matrix.os == 'ubuntu-latest' && steps.pushBenchmarkCachegrindAttempt1.outcome == 'failure'
-  #       id: pushBenchmarkCachegrindAttempt2
-  #       continue-on-error: true
-  #       uses: ./.github/workflows/push-results
-  #       with:
-  #         repository: ${{ matrix.benchResultsRepo.name }}
-  #         branch: ${{ matrix.benchResultsRepo.branch }}
-  #         token: ${{ secrets.BENCH_GITHUB_TOKEN }}
-  #         path: "./gh-pages"
-  #         bench_name: ${{ matrix.bench.title }} (CacheGrind)
-  #         bench_tool: "roblox"
-  #         bench_output_file_path: "./${{ matrix.bench.script }}-output.txt"
-  #         bench_external_data_json_path: "./gh-pages/dev/bench/data-${{ matrix.os }}.json"
+      - name: Push Cachegrind benchmark results (Attempt 2)
+        if: matrix.os == 'ubuntu-latest' && steps.pushBenchmarkCachegrindAttempt1.outcome == 'failure'
+        id: pushBenchmarkCachegrindAttempt2
+        continue-on-error: true
+        uses: ./.github/workflows/push-results
+        with:
+          repository: ${{ matrix.benchResultsRepo.name }}
+          branch: ${{ matrix.benchResultsRepo.branch }}
+          token: ${{ secrets.BENCH_GITHUB_TOKEN }}
+          path: "./gh-pages"
+          bench_name: ${{ matrix.bench.title }} (CacheGrind)
+          bench_tool: "roblox"
+          bench_output_file_path: "./${{ matrix.bench.script }}-output.txt"
+          bench_external_data_json_path: "./gh-pages/dev/bench/data-${{ matrix.os }}.json"
 
-  #     - name: Push Cachegrind benchmark results (Attempt 3)
-  #       if: matrix.os == 'ubuntu-latest' && steps.pushBenchmarkCachegrindAttempt2.outcome == 'failure'
-  #       id: pushBenchmarkCachegrindAttempt3
-  #       continue-on-error: true
-  #       uses: ./.github/workflows/push-results
-  #       with:
-  #         repository: ${{ matrix.benchResultsRepo.name }}
-  #         branch: ${{ matrix.benchResultsRepo.branch }}
-  #         token: ${{ secrets.BENCH_GITHUB_TOKEN }}
-  #         path: "./gh-pages"
-  #         bench_name: ${{ matrix.bench.title }} (CacheGrind)
-  #         bench_tool: "roblox"
-  #         bench_output_file_path: "./${{ matrix.bench.script }}-output.txt"
-  #         bench_external_data_json_path: "./gh-pages/dev/bench/data-${{ matrix.os }}.json"
+      - name: Push Cachegrind benchmark results (Attempt 3)
+        if: matrix.os == 'ubuntu-latest' && steps.pushBenchmarkCachegrindAttempt2.outcome == 'failure'
+        id: pushBenchmarkCachegrindAttempt3
+        continue-on-error: true
+        uses: ./.github/workflows/push-results
+        with:
+          repository: ${{ matrix.benchResultsRepo.name }}
+          branch: ${{ matrix.benchResultsRepo.branch }}
+          token: ${{ secrets.BENCH_GITHUB_TOKEN }}
+          path: "./gh-pages"
+          bench_name: ${{ matrix.bench.title }} (CacheGrind)
+          bench_tool: "roblox"
+          bench_output_file_path: "./${{ matrix.bench.script }}-output.txt"
+          bench_external_data_json_path: "./gh-pages/dev/bench/data-${{ matrix.os }}.json"
 
-  # static-analysis:
-  #   name: luau-analyze
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       os: [ubuntu-latest]
-  #       bench:
-  #         - {
-  #             script: "run-analyze",
-  #             timeout: 12,
-  #             title: "Luau Analyze",
-  #             cachegrindTitle: "Performance",
-  #             cachegrindIterCount: 20,
-  #           }
-  #       benchResultsRepo:
-  #         - { name: "luau-lang/benchmark-data", branch: "main" }
-  #   runs-on: ${{ matrix.os }}
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #       with:
-  #         token: "${{ secrets.BENCH_GITHUB_TOKEN }}"
+  static-analysis:
+    name: luau-analyze
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        bench:
+          - {
+              script: "run-analyze",
+              timeout: 12,
+              title: "Luau Analyze",
+              cachegrindTitle: "Performance",
+              cachegrindIterCount: 20,
+            }
+        benchResultsRepo:
+          # - { name: "luau-lang/benchmark-data", branch: "main" }
+          - { name: "AllanJeremy/luau-benchmark-results", branch: "main" }
 
-  #     - name: Build Luau
-  #       run: make config=release luau luau-analyze
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          token: "${{ secrets.BENCH_GITHUB_TOKEN }}"
 
-  #     - uses: actions/setup-python@v4
-  #       with:
-  #         python-version: "3.9"
-  #         architecture: "x64"
+      - name: Build Luau
+        run: make config=release luau luau-analyze
 
-  #     - name: Install python dependencies
-  #       run: |
-  #         sudo pip install requests numpy scipy matplotlib ipython jupyter pandas sympy nose
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.9"
+          architecture: "x64"
 
-  #     - name: Install valgrind
-  #       run: |
-  #         sudo apt-get install valgrind
+      - name: Install python dependencies
+        run: |
+          sudo pip install requests numpy scipy matplotlib ipython jupyter pandas sympy nose
 
-  #     - name: Run Luau Analyze on static file
-  #       run: sudo python ./bench/measure_time.py ./build/release/luau-analyze bench/other/LuauPolyfillMap.lua | tee ${{ matrix.bench.script }}-output.txt
+      - name: Install valgrind
+        run: |
+          sudo apt-get install valgrind
 
-  #     - name: Run ${{ matrix.bench.title }} (Cold Cachegrind)
-  #       run: sudo ./scripts/run-with-cachegrind.sh python ./bench/measure_time.py "${{ matrix.bench.cachegrindTitle}}Cold" 1 ./build/release/luau-analyze bench/other/LuauPolyfillMap.lua | tee -a ${{ matrix.bench.script }}-output.txt
+      - name: Run Luau Analyze on static file
+        run: sudo python ./bench/measure_time.py ./build/release/luau-analyze bench/other/LuauPolyfillMap.lua | tee ${{ matrix.bench.script }}-output.txt
 
-  #     - name: Run ${{ matrix.bench.title }} (Warm Cachegrind)
-  #       run: sudo bash ./scripts/run-with-cachegrind.sh python ./bench/measure_time.py "${{ matrix.bench.cachegrindTitle}}" 1  ./build/release/luau-analyze bench/other/LuauPolyfillMap.lua | tee -a ${{ matrix.bench.script }}-output.txt
+      - name: Run ${{ matrix.bench.title }} (Cold Cachegrind)
+        run: sudo ./scripts/run-with-cachegrind.sh python ./bench/measure_time.py "${{ matrix.bench.cachegrindTitle}}Cold" 1 ./build/release/luau-analyze bench/other/LuauPolyfillMap.lua | tee -a ${{ matrix.bench.script }}-output.txt
 
-  #     - name: Push static analysis results
-  #       id: pushStaticAnalysisAttempt1
-  #       continue-on-error: true
-  #       uses: ./.github/workflows/push-results
-  #       with:
-  #         repository: ${{ matrix.benchResultsRepo.name }}
-  #         branch: ${{ matrix.benchResultsRepo.branch }}
-  #         token: ${{ secrets.BENCH_GITHUB_TOKEN }}
-  #         path: "./gh-pages"
-  #         bench_name: ${{ matrix.bench.title }}
-  #         bench_tool: "roblox"
-  #         bench_output_file_path: "./${{ matrix.bench.script }}-output.txt"
-  #         bench_external_data_json_path: "./gh-pages/dev/bench/data-${{ matrix.os }}.json"
+      - name: Run ${{ matrix.bench.title }} (Warm Cachegrind)
+        run: sudo bash ./scripts/run-with-cachegrind.sh python ./bench/measure_time.py "${{ matrix.bench.cachegrindTitle}}" 1  ./build/release/luau-analyze bench/other/LuauPolyfillMap.lua | tee -a ${{ matrix.bench.script }}-output.txt
 
-  #     - name: Push static analysis results (Attempt 2)
-  #       if: steps.pushStaticAnalysisAttempt1.outcome == 'failure'
-  #       id: pushStaticAnalysisAttempt2
-  #       continue-on-error: true
-  #       uses: ./.github/workflows/push-results
-  #       with:
-  #         repository: ${{ matrix.benchResultsRepo.name }}
-  #         branch: ${{ matrix.benchResultsRepo.branch }}
-  #         token: ${{ secrets.BENCH_GITHUB_TOKEN }}
-  #         path: "./gh-pages"
-  #         bench_name: ${{ matrix.bench.title }}
-  #         bench_tool: "roblox"
-  #         bench_output_file_path: "./${{ matrix.bench.script }}-output.txt"
-  #         bench_external_data_json_path: "./gh-pages/dev/bench/data-${{ matrix.os }}.json"
+      - name: Push static analysis results
+        id: pushStaticAnalysisAttempt1
+        continue-on-error: true
+        uses: ./.github/workflows/push-results
+        with:
+          repository: ${{ matrix.benchResultsRepo.name }}
+          branch: ${{ matrix.benchResultsRepo.branch }}
+          token: ${{ secrets.BENCH_GITHUB_TOKEN }}
+          path: "./gh-pages"
+          bench_name: ${{ matrix.bench.title }}
+          bench_tool: "roblox"
+          bench_output_file_path: "./${{ matrix.bench.script }}-output.txt"
+          bench_external_data_json_path: "./gh-pages/dev/bench/data-${{ matrix.os }}.json"
 
-  #     - name: Push static analysis results (Attempt 3)
-  #       if: steps.pushStaticAnalysisAttempt2.outcome == 'failure'
-  #       id: pushStaticAnalysisAttempt3
-  #       continue-on-error: true
-  #       uses: ./.github/workflows/push-results
-  #       with:
-  #         repository: ${{ matrix.benchResultsRepo.name }}
-  #         branch: ${{ matrix.benchResultsRepo.branch }}
-  #         token: ${{ secrets.BENCH_GITHUB_TOKEN }}
-  #         path: "./gh-pages"
-  #         bench_name: ${{ matrix.bench.title }}
-  #         bench_tool: "roblox"
-  #         bench_output_file_path: "./${{ matrix.bench.script }}-output.txt"
-  #         bench_external_data_json_path: "./gh-pages/dev/bench/data-${{ matrix.os }}.json"
+      - name: Push static analysis results (Attempt 2)
+        if: steps.pushStaticAnalysisAttempt1.outcome == 'failure'
+        id: pushStaticAnalysisAttempt2
+        continue-on-error: true
+        uses: ./.github/workflows/push-results
+        with:
+          repository: ${{ matrix.benchResultsRepo.name }}
+          branch: ${{ matrix.benchResultsRepo.branch }}
+          token: ${{ secrets.BENCH_GITHUB_TOKEN }}
+          path: "./gh-pages"
+          bench_name: ${{ matrix.bench.title }}
+          bench_tool: "roblox"
+          bench_output_file_path: "./${{ matrix.bench.script }}-output.txt"
+          bench_external_data_json_path: "./gh-pages/dev/bench/data-${{ matrix.os }}.json"
 
-  #     - name: Push static analysis Cachegrind results
-  #       if: matrix.os == 'ubuntu-latest'
-  #       id: pushStaticAnalysisCachegrindAttempt1
-  #       continue-on-error: true
-  #       uses: ./.github/workflows/push-results
-  #       with:
-  #         repository: ${{ matrix.benchResultsRepo.name }}
-  #         branch: ${{ matrix.benchResultsRepo.branch }}
-  #         token: ${{ secrets.BENCH_GITHUB_TOKEN }}
-  #         path: "./gh-pages"
-  #         bench_name: ${{ matrix.bench.title }}
-  #         bench_tool: "roblox"
-  #         bench_output_file_path: "./${{ matrix.bench.script }}-output.txt"
-  #         bench_external_data_json_path: "./gh-pages/dev/bench/data-${{ matrix.os }}.json"
+      - name: Push static analysis results (Attempt 3)
+        if: steps.pushStaticAnalysisAttempt2.outcome == 'failure'
+        id: pushStaticAnalysisAttempt3
+        continue-on-error: true
+        uses: ./.github/workflows/push-results
+        with:
+          repository: ${{ matrix.benchResultsRepo.name }}
+          branch: ${{ matrix.benchResultsRepo.branch }}
+          token: ${{ secrets.BENCH_GITHUB_TOKEN }}
+          path: "./gh-pages"
+          bench_name: ${{ matrix.bench.title }}
+          bench_tool: "roblox"
+          bench_output_file_path: "./${{ matrix.bench.script }}-output.txt"
+          bench_external_data_json_path: "./gh-pages/dev/bench/data-${{ matrix.os }}.json"
 
-  #     - name: Push static analysis Cachegrind results (Attempt 2)
-  #       if: matrix.os == 'ubuntu-latest' && steps.pushStaticAnalysisCachegrindAttempt1.outcome == 'failure'
-  #       id: pushStaticAnalysisCachegrindAttempt2
-  #       continue-on-error: true
-  #       uses: ./.github/workflows/push-results
-  #       with:
-  #         repository: ${{ matrix.benchResultsRepo.name }}
-  #         branch: ${{ matrix.benchResultsRepo.branch }}
-  #         token: ${{ secrets.BENCH_GITHUB_TOKEN }}
-  #         path: "./gh-pages"
-  #         bench_name: ${{ matrix.bench.title }}
-  #         bench_tool: "roblox"
-  #         bench_output_file_path: "./${{ matrix.bench.script }}-output.txt"
-  #         bench_external_data_json_path: "./gh-pages/dev/bench/data-${{ matrix.os }}.json"
+      - name: Push static analysis Cachegrind results
+        if: matrix.os == 'ubuntu-latest'
+        id: pushStaticAnalysisCachegrindAttempt1
+        continue-on-error: true
+        uses: ./.github/workflows/push-results
+        with:
+          repository: ${{ matrix.benchResultsRepo.name }}
+          branch: ${{ matrix.benchResultsRepo.branch }}
+          token: ${{ secrets.BENCH_GITHUB_TOKEN }}
+          path: "./gh-pages"
+          bench_name: ${{ matrix.bench.title }}
+          bench_tool: "roblox"
+          bench_output_file_path: "./${{ matrix.bench.script }}-output.txt"
+          bench_external_data_json_path: "./gh-pages/dev/bench/data-${{ matrix.os }}.json"
 
-  #     - name: Push static analysis Cachegrind results (Attempt 2)
-  #       if: matrix.os == 'ubuntu-latest' && steps.pushStaticAnalysisCachegrindAttempt2.outcome == 'failure'
-  #       id: pushStaticAnalysisCachegrindAttempt3
-  #       continue-on-error: true
-  #       uses: ./.github/workflows/push-results
-  #       with:
-  #         repository: ${{ matrix.benchResultsRepo.name }}
-  #         branch: ${{ matrix.benchResultsRepo.branch }}
-  #         token: ${{ secrets.BENCH_GITHUB_TOKEN }}
-  #         path: "./gh-pages"
-  #         bench_name: ${{ matrix.bench.title }}
-  #         bench_tool: "roblox"
-  #         bench_output_file_path: "./${{ matrix.bench.script }}-output.txt"
-  #         bench_external_data_json_path: "./gh-pages/dev/bench/data-${{ matrix.os }}.json"
+      - name: Push static analysis Cachegrind results (Attempt 2)
+        if: matrix.os == 'ubuntu-latest' && steps.pushStaticAnalysisCachegrindAttempt1.outcome == 'failure'
+        id: pushStaticAnalysisCachegrindAttempt2
+        continue-on-error: true
+        uses: ./.github/workflows/push-results
+        with:
+          repository: ${{ matrix.benchResultsRepo.name }}
+          branch: ${{ matrix.benchResultsRepo.branch }}
+          token: ${{ secrets.BENCH_GITHUB_TOKEN }}
+          path: "./gh-pages"
+          bench_name: ${{ matrix.bench.title }}
+          bench_tool: "roblox"
+          bench_output_file_path: "./${{ matrix.bench.script }}-output.txt"
+          bench_external_data_json_path: "./gh-pages/dev/bench/data-${{ matrix.os }}.json"
+
+      - name: Push static analysis Cachegrind results (Attempt 2)
+        if: matrix.os == 'ubuntu-latest' && steps.pushStaticAnalysisCachegrindAttempt2.outcome == 'failure'
+        id: pushStaticAnalysisCachegrindAttempt3
+        continue-on-error: true
+        uses: ./.github/workflows/push-results
+        with:
+          repository: ${{ matrix.benchResultsRepo.name }}
+          branch: ${{ matrix.benchResultsRepo.branch }}
+          token: ${{ secrets.BENCH_GITHUB_TOKEN }}
+          path: "./gh-pages"
+          bench_name: ${{ matrix.bench.title }}
+          bench_tool: "roblox"
+          bench_output_file_path: "./${{ matrix.bench.script }}-output.txt"
+          bench_external_data_json_path: "./gh-pages/dev/bench/data-${{ matrix.os }}.json"

--- a/.github/workflows/benchmark-dev.yml
+++ b/.github/workflows/benchmark-dev.yml
@@ -90,181 +90,194 @@ jobs:
           git push
           cd ..
 
-  unix:
-    name: ${{matrix.os}}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-latest]
-        bench:
-          - {
-              script: "run-benchmarks",
-              timeout: 12,
-              title: "Luau Benchmarks",
-              cachegrindTitle: "Performance",
-              cachegrindIterCount: 20,
-            }
-        benchResultsRepo:
-          - { name: "luau-lang/benchmark-data", branch: "main" }
-
-    runs-on: ${{ matrix.os }}
-    steps:
-      - name: Checkout Luau repository
-        uses: actions/checkout@v3
-
-      - name: Build Luau
-        run: make config=release luau luau-analyze
-
-      - uses: actions/setup-python@v3
-        with:
-          python-version: "3.9"
-          architecture: "x64"
-
-      - name: Install python dependencies
-        run: |
-          python -m pip install requests
-          python -m pip install --user numpy scipy matplotlib ipython jupyter pandas sympy nose
-
-      - name: Run benchmark
-        run: |
-          python bench/bench.py | tee ${{ matrix.bench.script }}-output.txt
-
-      - name: Install valgrind
-        if: matrix.os == 'ubuntu-latest'
-        run: |
-          sudo apt-get install valgrind
-
-      - name: Run ${{ matrix.bench.title }} (Cold Cachegrind)
-        if: matrix.os == 'ubuntu-latest'
-        run: sudo bash ./scripts/run-with-cachegrind.sh python ./bench/bench.py "${{ matrix.bench.cachegrindTitle}}Cold" 1 | tee -a ${{ matrix.bench.script }}-output.txt
-
-      - name: Run ${{ matrix.bench.title }} (Warm Cachegrind)
-        if: matrix.os == 'ubuntu-latest'
-        run: sudo bash ./scripts/run-with-cachegrind.sh python ./bench/bench.py "${{ matrix.bench.cachegrindTitle }}" ${{ matrix.bench.cachegrindIterCount }} | tee -a ${{ matrix.bench.script }}-output.txt
-
-      - name: Checkout Benchmark Results repository
-        uses: actions/checkout@v3
-        with:
-          repository: ${{ matrix.benchResultsRepo.name }}
-          ref: ${{ matrix.benchResultsRepo.branch }}
-          token: ${{ secrets.BENCH_GITHUB_TOKEN }}
-          path: "./gh-pages"
-
-      - name: Store ${{ matrix.bench.title }} result
-        uses: Roblox/rhysd-github-action-benchmark@v-luau
-        with:
-          name: ${{ matrix.bench.title }}
-          tool: "benchmarkluau"
-          output-file-path: ./${{ matrix.bench.script }}-output.txt
-          external-data-json-path: ./gh-pages/dev/bench/data-${{ matrix.os }}.json
-          github-token: ${{ secrets.BENCH_GITHUB_TOKEN }}
-
-      - name: Store ${{ matrix.bench.title }} result (CacheGrind)
-        if: matrix.os == 'ubuntu-latest'
-        uses: Roblox/rhysd-github-action-benchmark@v-luau
-        with:
-          name: ${{ matrix.bench.title }} (CacheGrind)
-          tool: "roblox"
-          output-file-path: ./${{ matrix.bench.script }}-output.txt
-          external-data-json-path: ./gh-pages/dev/bench/data-${{ matrix.os }}.json
-          github-token: ${{ secrets.BENCH_GITHUB_TOKEN }}
-
       - name: Push benchmark results
         if: github.event_name == 'push'
-        run: |
-          echo "Pushing benchmark results..."
-          cd gh-pages
-          git config user.name github-actions
-          git config user.email github@users.noreply.github.com
-          git add ./dev/bench/data-${{ matrix.os }}.json
-          git commit -m "Add benchmarks results for ${{ github.sha }}"
-          git push
-          cd ..
+        uses: ./.github/workflows/push-results
+          with:
+            repository: ${{ matrix.benchResultsRepo.name }}
+            branch: ${{ matrix.benchResultsRepo.branch }}
+            token: ${{ secrets.GITHUB_TOKEN }}
+            path: "./gh-pages"
+            bench_name:  "${{ matrix.bench.title }} (Windows ${{matrix.arch}})"
+            bench_tool:  "benchmarkluau"
+            bench_output_file_path: "./${{ matrix.bench.script }}-output.txt"
+            bench_external_data_json_path: "./gh-pages/dev/bench/data-${{ matrix.os }}.json"
 
-  static-analysis:
-    name: luau-analyze
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest]
-        bench:
-          - {
-              script: "run-analyze",
-              timeout: 12,
-              title: "Luau Analyze",
-              cachegrindTitle: "Performance",
-              cachegrindIterCount: 20,
-            }
-        benchResultsRepo:
-          - { name: "luau-lang/benchmark-data", branch: "main" }
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          token: "${{ secrets.BENCH_GITHUB_TOKEN }}"
+  # unix:
+  #   name: ${{matrix.os}}
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       os: [ubuntu-latest, macos-latest]
+  #       bench:
+  #         - {
+  #             script: "run-benchmarks",
+  #             timeout: 12,
+  #             title: "Luau Benchmarks",
+  #             cachegrindTitle: "Performance",
+  #             cachegrindIterCount: 20,
+  #           }
+  #       benchResultsRepo:
+  #         - { name: "luau-lang/benchmark-data", branch: "main" }
 
-      - name: Build Luau
-        run: make config=release luau luau-analyze
+  #   runs-on: ${{ matrix.os }}
+  #   steps:
+  #     - name: Checkout Luau repository
+  #       uses: actions/checkout@v3
 
-      - uses: actions/setup-python@v4
-        with:
-          python-version: "3.9"
-          architecture: "x64"
+  #     - name: Build Luau
+  #       run: make config=release luau luau-analyze
 
-      - name: Install python dependencies
-        run: |
-          sudo pip install requests numpy scipy matplotlib ipython jupyter pandas sympy nose
+  #     - uses: actions/setup-python@v3
+  #       with:
+  #         python-version: "3.9"
+  #         architecture: "x64"
 
-      - name: Install valgrind
-        run: |
-          sudo apt-get install valgrind
+  #     - name: Install python dependencies
+  #       run: |
+  #         python -m pip install requests
+  #         python -m pip install --user numpy scipy matplotlib ipython jupyter pandas sympy nose
 
-      - name: Run Luau Analyze on static file
-        run: sudo python ./bench/measure_time.py ./build/release/luau-analyze bench/other/LuauPolyfillMap.lua | tee ${{ matrix.bench.script }}-output.txt
+  #     - name: Run benchmark
+  #       run: |
+  #         python bench/bench.py | tee ${{ matrix.bench.script }}-output.txt
 
-      - name: Run ${{ matrix.bench.title }} (Cold Cachegrind)
-        run: sudo ./scripts/run-with-cachegrind.sh python ./bench/measure_time.py "${{ matrix.bench.cachegrindTitle}}Cold" 1 ./build/release/luau-analyze bench/other/LuauPolyfillMap.lua | tee -a ${{ matrix.bench.script }}-output.txt
+  #     - name: Install valgrind
+  #       if: matrix.os == 'ubuntu-latest'
+  #       run: |
+  #         sudo apt-get install valgrind
 
-      - name: Run ${{ matrix.bench.title }} (Warm Cachegrind)
-        run: sudo bash ./scripts/run-with-cachegrind.sh python ./bench/measure_time.py "${{ matrix.bench.cachegrindTitle}}" 1  ./build/release/luau-analyze bench/other/LuauPolyfillMap.lua | tee -a ${{ matrix.bench.script }}-output.txt
+  #     - name: Run ${{ matrix.bench.title }} (Cold Cachegrind)
+  #       if: matrix.os == 'ubuntu-latest'
+  #       run: sudo bash ./scripts/run-with-cachegrind.sh python ./bench/bench.py "${{ matrix.bench.cachegrindTitle}}Cold" 1 | tee -a ${{ matrix.bench.script }}-output.txt
 
-      - name: Checkout Benchmark Results repository
-        uses: actions/checkout@v3
-        with:
-          repository: ${{ matrix.benchResultsRepo.name }}
-          ref: ${{ matrix.benchResultsRepo.branch }}
-          token: ${{ secrets.BENCH_GITHUB_TOKEN }}
-          path: "./gh-pages"
+  #     - name: Run ${{ matrix.bench.title }} (Warm Cachegrind)
+  #       if: matrix.os == 'ubuntu-latest'
+  #       run: sudo bash ./scripts/run-with-cachegrind.sh python ./bench/bench.py "${{ matrix.bench.cachegrindTitle }}" ${{ matrix.bench.cachegrindIterCount }} | tee -a ${{ matrix.bench.script }}-output.txt
 
-      - name: Store ${{ matrix.bench.title }} result
-        uses: Roblox/rhysd-github-action-benchmark@v-luau
-        with:
-          name: ${{ matrix.bench.title }}
-          tool: "benchmarkluau"
+  #     - name: Checkout Benchmark Results repository
+  #       uses: actions/checkout@v3
+  #       with:
+  #         repository: ${{ matrix.benchResultsRepo.name }}
+  #         ref: ${{ matrix.benchResultsRepo.branch }}
+  #         token: ${{ secrets.BENCH_GITHUB_TOKEN }}
+  #         path: "./gh-pages"
 
-          gh-pages-branch: "main"
-          output-file-path: ./${{ matrix.bench.script }}-output.txt
-          external-data-json-path: ./gh-pages/dev/bench/data-${{ matrix.os }}.json
-          github-token: ${{ secrets.BENCH_GITHUB_TOKEN }}
+  #     - name: Store ${{ matrix.bench.title }} result
+  #       uses: Roblox/rhysd-github-action-benchmark@v-luau
+  #       with:
+  #         name: ${{ matrix.bench.title }}
+  #         tool: "benchmarkluau"
+  #         output-file-path: ./${{ matrix.bench.script }}-output.txt
+  #         external-data-json-path: ./gh-pages/dev/bench/data-${{ matrix.os }}.json
+  #         github-token: ${{ secrets.BENCH_GITHUB_TOKEN }}
 
-      - name: Store ${{ matrix.bench.title }} result (CacheGrind)
-        uses: Roblox/rhysd-github-action-benchmark@v-luau
-        with:
-          name: ${{ matrix.bench.title }}
-          tool: "roblox"
-          gh-pages-branch: "main"
-          output-file-path: ./${{ matrix.bench.script }}-output.txt
-          external-data-json-path: ./gh-pages/dev/bench/data-${{ matrix.os }}.json
-          github-token: ${{ secrets.BENCH_GITHUB_TOKEN }}
+  #     - name: Store ${{ matrix.bench.title }} result (CacheGrind)
+  #       if: matrix.os == 'ubuntu-latest'
+  #       uses: Roblox/rhysd-github-action-benchmark@v-luau
+  #       with:
+  #         name: ${{ matrix.bench.title }} (CacheGrind)
+  #         tool: "roblox"
+  #         output-file-path: ./${{ matrix.bench.script }}-output.txt
+  #         external-data-json-path: ./gh-pages/dev/bench/data-${{ matrix.os }}.json
+  #         github-token: ${{ secrets.BENCH_GITHUB_TOKEN }}
 
-      - name: Push benchmark results
-        if: github.event_name == 'push'
-        run: |
-          echo "Pushing benchmark results..."
-          cd gh-pages
-          git config user.name github-actions
-          git config user.email github@users.noreply.github.com
-          git add ./dev/bench/data-${{ matrix.os }}.json
-          git commit -m "Add benchmarks results for ${{ github.sha }}"
-          git push
-          cd ..
+  #     - name: Push benchmark results
+  #       if: github.event_name == 'push'
+  #       run: |
+  #         echo "Pushing benchmark results..."
+  #         cd gh-pages
+  #         git config user.name github-actions
+  #         git config user.email github@users.noreply.github.com
+  #         git add ./dev/bench/data-${{ matrix.os }}.json
+  #         git commit -m "Add benchmarks results for ${{ github.sha }}"
+  #         git push
+  #         cd ..
+
+  # static-analysis:
+  #   name: luau-analyze
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       os: [ubuntu-latest]
+  #       bench:
+  #         - {
+  #             script: "run-analyze",
+  #             timeout: 12,
+  #             title: "Luau Analyze",
+  #             cachegrindTitle: "Performance",
+  #             cachegrindIterCount: 20,
+  #           }
+  #       benchResultsRepo:
+  #         - { name: "luau-lang/benchmark-data", branch: "main" }
+  #   runs-on: ${{ matrix.os }}
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #       with:
+  #         token: "${{ secrets.BENCH_GITHUB_TOKEN }}"
+
+  #     - name: Build Luau
+  #       run: make config=release luau luau-analyze
+
+  #     - uses: actions/setup-python@v4
+  #       with:
+  #         python-version: "3.9"
+  #         architecture: "x64"
+
+  #     - name: Install python dependencies
+  #       run: |
+  #         sudo pip install requests numpy scipy matplotlib ipython jupyter pandas sympy nose
+
+  #     - name: Install valgrind
+  #       run: |
+  #         sudo apt-get install valgrind
+
+  #     - name: Run Luau Analyze on static file
+  #       run: sudo python ./bench/measure_time.py ./build/release/luau-analyze bench/other/LuauPolyfillMap.lua | tee ${{ matrix.bench.script }}-output.txt
+
+  #     - name: Run ${{ matrix.bench.title }} (Cold Cachegrind)
+  #       run: sudo ./scripts/run-with-cachegrind.sh python ./bench/measure_time.py "${{ matrix.bench.cachegrindTitle}}Cold" 1 ./build/release/luau-analyze bench/other/LuauPolyfillMap.lua | tee -a ${{ matrix.bench.script }}-output.txt
+
+  #     - name: Run ${{ matrix.bench.title }} (Warm Cachegrind)
+  #       run: sudo bash ./scripts/run-with-cachegrind.sh python ./bench/measure_time.py "${{ matrix.bench.cachegrindTitle}}" 1  ./build/release/luau-analyze bench/other/LuauPolyfillMap.lua | tee -a ${{ matrix.bench.script }}-output.txt
+
+  #     - name: Checkout Benchmark Results repository
+  #       uses: actions/checkout@v3
+  #       with:
+  #         repository: ${{ matrix.benchResultsRepo.name }}
+  #         ref: ${{ matrix.benchResultsRepo.branch }}
+  #         token: ${{ secrets.BENCH_GITHUB_TOKEN }}
+  #         path: "./gh-pages"
+
+  #     - name: Store ${{ matrix.bench.title }} result
+  #       uses: Roblox/rhysd-github-action-benchmark@v-luau
+  #       with:
+  #         name: ${{ matrix.bench.title }}
+  #         tool: "benchmarkluau"
+
+  #         gh-pages-branch: "main"
+  #         output-file-path: ./${{ matrix.bench.script }}-output.txt
+  #         external-data-json-path: ./gh-pages/dev/bench/data-${{ matrix.os }}.json
+  #         github-token: ${{ secrets.BENCH_GITHUB_TOKEN }}
+
+  #     - name: Store ${{ matrix.bench.title }} result (CacheGrind)
+  #       uses: Roblox/rhysd-github-action-benchmark@v-luau
+  #       with:
+  #         name: ${{ matrix.bench.title }}
+  #         tool: "roblox"
+  #         gh-pages-branch: "main"
+  #         output-file-path: ./${{ matrix.bench.script }}-output.txt
+  #         external-data-json-path: ./gh-pages/dev/bench/data-${{ matrix.os }}.json
+  #         github-token: ${{ secrets.BENCH_GITHUB_TOKEN }}
+
+  #     - name: Push benchmark results
+  #       if: github.event_name == 'push'
+  #       run: |
+  #         echo "Pushing benchmark results..."
+  #         cd gh-pages
+  #         git config user.name github-actions
+  #         git config user.email github@users.noreply.github.com
+  #         git add ./dev/bench/data-${{ matrix.os }}.json
+  #         git commit -m "Add benchmarks results for ${{ github.sha }}"
+  #         git push
+  #         cd ..

--- a/.github/workflows/benchmark-dev.yml
+++ b/.github/workflows/benchmark-dev.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest]
-        arch: [Win32, x64]
+        arch: [x64] #Win32,
         bench:
           - {
               script: "run-benchmarks",
@@ -69,7 +69,7 @@ jobs:
         with:
           repository: ${{ matrix.benchResultsRepo.name }}
           branch: ${{ matrix.benchResultsRepo.branch }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # token: ${{ secrets.GITHUB_TOKEN }}
           path: "./gh-pages"
           bench_name: "${{ matrix.bench.title }} (Windows ${{matrix.arch}})"
           bench_tool: "benchmarkluau"

--- a/.github/workflows/benchmark-dev.yml
+++ b/.github/workflows/benchmark-dev.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Push benchmark results
         id: pushBenchmarkAttempt1
-        continue-on-error: true
+        # continue-on-error: true
         uses: ./.github/workflows/push-results
         with:
           repository: ${{ matrix.benchResultsRepo.name }}

--- a/.github/workflows/push-results/action.yml
+++ b/.github/workflows/push-results/action.yml
@@ -5,7 +5,6 @@ inputs:
     required: true
     type: string
     description: The benchmark results repository to check out
-
   branch:
     required: true
     type: string
@@ -33,14 +32,13 @@ inputs:
 
 runs:
   using: "composite"
-  # shell: bash
   steps:
     - name: Checkout repository
       uses: actions/checkout@v3
       with:
         repository: ${{ inputs.repository }}
         ref: ${{ inputs.branch }}
-        # token: ${{ inputs.token }}
+        token: ${{ inputs.token }}
         path: "./gh-pages"
 
     - name: Store results

--- a/.github/workflows/push-results/action.yml
+++ b/.github/workflows/push-results/action.yml
@@ -17,6 +17,9 @@ inputs:
     required: true
     type: string
     description: The path to check out the results repository to
+  bench_gh_pages_branch:
+    type: string,
+    default: "main"
   bench_name:
     required: true
     type: string
@@ -46,6 +49,7 @@ runs:
       with:
         name: ${{ inputs.bench_name }}
         tool: ${{ inputs.bench_tool }}
+        gh-pages-branch: ${{ inputs.bench_gh_pages_branch }}
         output-file-path: ${{ inputs.bench_output_file_path }}
         external-data-json-path: ${{ inputs.bench_external_data_json_path }}
 

--- a/.github/workflows/push-results/action.yml
+++ b/.github/workflows/push-results/action.yml
@@ -1,0 +1,64 @@
+name: Checkout & push results
+description: Checkout a given repo and push results to GitHub
+inputs:
+  repository:
+    required: true
+    # type: string
+    description: The benchmark results repository to check out
+  branch:
+    required: true
+    # type: string
+    description: The benchmark results repository's branch to check out
+  token:
+    required: true
+    # type: string
+    description: The GitHub token to use for pushing results
+  path:
+    required: true
+    # type: string
+    description: The path to check out the results repository to
+  bench_name:
+    required: true
+    # type: string
+  bench_tool:
+    required: true
+    # type: string
+  bench_output_file_path:
+    required: true
+    # type: string
+  bench_external_data_json_path:
+    required: true
+    # type: string
+
+runs:
+  using: "composite"
+  steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+      shell: bash
+      with:
+        repository: ${{ inputs.repository }}
+        ref: ${{ inputs.branch }}
+        token: ${{ inputs.token }}
+        path: "./gh-pages"
+
+    - name: Store results
+      uses: Roblox/rhysd-github-action-benchmark@v-luau
+      shell: bash
+      with:
+        name: ${{ inputs.bench_name }}
+        tool: ${{ inputs.bench_tool }}
+        output-file-path: ${{ inputs.bench_output_file_path }}
+        external-data-json-path: ${{ inputs.bench_external_data_json_path }}
+
+    - name: Push benchmark results
+      shell: bash
+      run: |
+        echo "Pushing benchmark results..."
+        cd gh-pages
+        git config user.name github-actions
+        git config user.email github@users.noreply.github.com
+        git add *.json
+        git commit -m "Add benchmarks results for ${{ github.sha }}"
+        git push
+        cd ..

--- a/.github/workflows/push-results/action.yml
+++ b/.github/workflows/push-results/action.yml
@@ -5,9 +5,7 @@ inputs:
     required: true
     type: string
     description: The benchmark results repository to check out
-  shell:
-    type: string
-    default: "bash"
+
   branch:
     required: true
     type: string
@@ -38,7 +36,7 @@ runs:
   steps:
     - name: Checkout repository
       uses: actions/checkout@v3
-      shell: ${{ inputs.shell }}
+      shell: bash
       with:
         repository: ${{ inputs.repository }}
         ref: ${{ inputs.branch }}
@@ -47,7 +45,7 @@ runs:
 
     - name: Store results
       uses: Roblox/rhysd-github-action-benchmark@v-luau
-      shell: ${{ inputs.shell }}
+      shell: bash
       with:
         name: ${{ inputs.bench_name }}
         tool: ${{ inputs.bench_tool }}
@@ -55,7 +53,7 @@ runs:
         external-data-json-path: ${{ inputs.bench_external_data_json_path }}
 
     - name: Push benchmark results
-      shell: ${{ inputs.shell }}
+      shell: bash
       run: |
         echo "Pushing benchmark results..."
         cd gh-pages

--- a/.github/workflows/push-results/action.yml
+++ b/.github/workflows/push-results/action.yml
@@ -44,23 +44,23 @@ runs:
         token: ${{ inputs.token }}
         path: "./gh-pages"
 
-    - name: Store results
-      uses: Roblox/rhysd-github-action-benchmark@v-luau
-      with:
-        name: ${{ inputs.bench_name }}
-        tool: ${{ inputs.bench_tool }}
-        gh-pages-branch: ${{ inputs.bench_gh_pages_branch }}
-        output-file-path: ${{ inputs.bench_output_file_path }}
-        external-data-json-path: ${{ inputs.bench_external_data_json_path }}
+    # - name: Store results
+    #   uses: Roblox/rhysd-github-action-benchmark@v-luau
+    #   with:
+    #     name: ${{ inputs.bench_name }}
+    #     tool: ${{ inputs.bench_tool }}
+    #     gh-pages-branch: ${{ inputs.bench_gh_pages_branch }}
+    #     output-file-path: ${{ inputs.bench_output_file_path }}
+    #     external-data-json-path: ${{ inputs.bench_external_data_json_path }}
 
-    - name: Push benchmark results
-      shell: bash
-      run: |
-        echo "Pushing benchmark results..."
-        cd gh-pages
-        git config user.name github-actions
-        git config user.email github@users.noreply.github.com
-        git add *.json
-        git commit -m "Add benchmarks results for ${{ github.sha }}"
-        git push
-        cd ..
+    # - name: Push benchmark results
+    #   shell: bash
+    #   run: |
+    #     echo "Pushing benchmark results..."
+    #     cd gh-pages
+    #     git config user.name github-actions
+    #     git config user.email github@users.noreply.github.com
+    #     git add *.json
+    #     git commit -m "Add benchmarks results for ${{ github.sha }}"
+    #     git push
+    #     cd ..

--- a/.github/workflows/push-results/action.yml
+++ b/.github/workflows/push-results/action.yml
@@ -17,9 +17,6 @@ inputs:
     required: true
     type: string
     description: The path to check out the results repository to
-  bench_gh_pages_branch:
-    type: string,
-    default: "main"
   bench_name:
     required: true
     type: string
@@ -49,7 +46,7 @@ runs:
     #   with:
     #     name: ${{ inputs.bench_name }}
     #     tool: ${{ inputs.bench_tool }}
-    #     gh-pages-branch: ${{ inputs.bench_gh_pages_branch }}
+    #     gh-pages-branch: ${{ inputs.branch }}
     #     output-file-path: ${{ inputs.bench_output_file_path }}
     #     external-data-json-path: ${{ inputs.bench_external_data_json_path }}
 

--- a/.github/workflows/push-results/action.yml
+++ b/.github/workflows/push-results/action.yml
@@ -41,23 +41,23 @@ runs:
         token: ${{ inputs.token }}
         path: ${{ inputs.path }}
 
-    # - name: Store results
-    #   uses: Roblox/rhysd-github-action-benchmark@v-luau
-    #   with:
-    #     name: ${{ inputs.bench_name }}
-    #     tool: ${{ inputs.bench_tool }}
-    #     gh-pages-branch: ${{ inputs.branch }}
-    #     output-file-path: ${{ inputs.bench_output_file_path }}
-    #     external-data-json-path: ${{ inputs.bench_external_data_json_path }}
+    - name: Store results
+      uses: Roblox/rhysd-github-action-benchmark@v-luau
+      with:
+        name: ${{ inputs.bench_name }}
+        tool: ${{ inputs.bench_tool }}
+        gh-pages-branch: ${{ inputs.branch }}
+        output-file-path: ${{ inputs.bench_output_file_path }}
+        external-data-json-path: ${{ inputs.bench_external_data_json_path }}
 
-    # - name: Push benchmark results
-    #   shell: bash
-    #   run: |
-    #     echo "Pushing benchmark results..."
-    #     cd gh-pages
-    #     git config user.name github-actions
-    #     git config user.email github@users.noreply.github.com
-    #     git add *.json
-    #     git commit -m "Add benchmarks results for ${{ github.sha }}"
-    #     git push
-    #     cd ..
+    - name: Push benchmark results
+      shell: bash
+      run: |
+        echo "Pushing benchmark results..."
+        cd gh-pages
+        git config user.name github-actions
+        git config user.email github@users.noreply.github.com
+        git add *.json
+        git commit -m "Add benchmarks results for ${{ github.sha }}"
+        git push
+        cd ..

--- a/.github/workflows/push-results/action.yml
+++ b/.github/workflows/push-results/action.yml
@@ -33,10 +33,10 @@ inputs:
 
 runs:
   using: "composite"
+  shell: bash
   steps:
     - name: Checkout repository
       uses: actions/checkout@v3
-      shell: bash
       with:
         repository: ${{ inputs.repository }}
         ref: ${{ inputs.branch }}
@@ -45,7 +45,6 @@ runs:
 
     - name: Store results
       uses: Roblox/rhysd-github-action-benchmark@v-luau
-      shell: bash
       with:
         name: ${{ inputs.bench_name }}
         tool: ${{ inputs.bench_tool }}
@@ -53,7 +52,6 @@ runs:
         external-data-json-path: ${{ inputs.bench_external_data_json_path }}
 
     - name: Push benchmark results
-      shell: bash
       run: |
         echo "Pushing benchmark results..."
         cd gh-pages

--- a/.github/workflows/push-results/action.yml
+++ b/.github/workflows/push-results/action.yml
@@ -3,39 +3,42 @@ description: Checkout a given repo and push results to GitHub
 inputs:
   repository:
     required: true
-    # type: string
+    type: string
     description: The benchmark results repository to check out
+  shell:
+    type: string
+    default: "bash"
   branch:
     required: true
-    # type: string
+    type: string
     description: The benchmark results repository's branch to check out
   token:
     required: true
-    # type: string
+    type: string
     description: The GitHub token to use for pushing results
   path:
     required: true
-    # type: string
+    type: string
     description: The path to check out the results repository to
   bench_name:
     required: true
-    # type: string
+    type: string
   bench_tool:
     required: true
-    # type: string
+    type: string
   bench_output_file_path:
     required: true
-    # type: string
+    type: string
   bench_external_data_json_path:
     required: true
-    # type: string
+    type: string
 
 runs:
   using: "composite"
   steps:
     - name: Checkout repository
       uses: actions/checkout@v3
-      # shell: bash
+      shell: ${{ inputs.shell }}
       with:
         repository: ${{ inputs.repository }}
         ref: ${{ inputs.branch }}
@@ -44,7 +47,7 @@ runs:
 
     - name: Store results
       uses: Roblox/rhysd-github-action-benchmark@v-luau
-      # shell: bash
+      shell: ${{ inputs.shell }}
       with:
         name: ${{ inputs.bench_name }}
         tool: ${{ inputs.bench_tool }}
@@ -52,7 +55,7 @@ runs:
         external-data-json-path: ${{ inputs.bench_external_data_json_path }}
 
     - name: Push benchmark results
-      # shell: bash
+      shell: ${{ inputs.shell }}
       run: |
         echo "Pushing benchmark results..."
         cd gh-pages

--- a/.github/workflows/push-results/action.yml
+++ b/.github/workflows/push-results/action.yml
@@ -39,7 +39,7 @@ runs:
         repository: ${{ inputs.repository }}
         ref: ${{ inputs.branch }}
         token: ${{ inputs.token }}
-        path: "./gh-pages"
+        path: ${{ inputs.path }}
 
     # - name: Store results
     #   uses: Roblox/rhysd-github-action-benchmark@v-luau

--- a/.github/workflows/push-results/action.yml
+++ b/.github/workflows/push-results/action.yml
@@ -35,7 +35,7 @@ runs:
   steps:
     - name: Checkout repository
       uses: actions/checkout@v3
-      shell: bash
+      # shell: bash
       with:
         repository: ${{ inputs.repository }}
         ref: ${{ inputs.branch }}
@@ -44,7 +44,7 @@ runs:
 
     - name: Store results
       uses: Roblox/rhysd-github-action-benchmark@v-luau
-      shell: bash
+      # shell: bash
       with:
         name: ${{ inputs.bench_name }}
         tool: ${{ inputs.bench_tool }}
@@ -52,7 +52,7 @@ runs:
         external-data-json-path: ${{ inputs.bench_external_data_json_path }}
 
     - name: Push benchmark results
-      shell: bash
+      # shell: bash
       run: |
         echo "Pushing benchmark results..."
         cd gh-pages

--- a/.github/workflows/push-results/action.yml
+++ b/.github/workflows/push-results/action.yml
@@ -40,7 +40,7 @@ runs:
       with:
         repository: ${{ inputs.repository }}
         ref: ${{ inputs.branch }}
-        token: ${{ inputs.token }}
+        # token: ${{ inputs.token }}
         path: "./gh-pages"
 
     - name: Store results

--- a/.github/workflows/push-results/action.yml
+++ b/.github/workflows/push-results/action.yml
@@ -33,7 +33,7 @@ inputs:
 
 runs:
   using: "composite"
-  shell: bash
+  # shell: bash
   steps:
     - name: Checkout repository
       uses: actions/checkout@v3
@@ -52,6 +52,7 @@ runs:
         external-data-json-path: ${{ inputs.bench_external_data_json_path }}
 
     - name: Push benchmark results
+      shell: bash
       run: |
         echo "Pushing benchmark results..."
         cd gh-pages


### PR DESCRIPTION
Resolves #668 

## The problem
Benchmarks jobs run concurrently for the different operating systems. This means that when it comes time to push the benchmark results to [the assigned benchmark results repo](https://github.com/luau-lang/benchmark-data), there can be two different jobs trying to push changes at the same time. In such a case, one of the pushes will fail and we end up missing some benchmark results data from the workflow run.

## The solution
Whenever a push fails, we need to retry the steps leading up to the push (checking out the benchmark results repo, storing benchmark results, pushing the results to [a specific repo](https://github.com/luau-lang/benchmark-data)).

### Note
There are 3 push attempts before submitting to failure.

## TL;DR
This PR retries pushing benchmark results when they fail to get pushed (often due to pushing from multiple jobs concurrently)

