### PR TITLE
Add lua_rawsetfield

### DIFF
--- a/VM/include/lua.h
+++ b/VM/include/lua.h
@@ -210,6 +210,7 @@ LUA_API void lua_getfenv(lua_State* L, int idx);
 */
 LUA_API void lua_settable(lua_State* L, int idx);
 LUA_API void lua_setfield(lua_State* L, int idx, const char* k);
+LUA_API void lua_rawsetfield(lua_State* L, int idx, const char* k);
 LUA_API void lua_rawset(lua_State* L, int idx);
 LUA_API void lua_rawseti(lua_State* L, int idx, int n);
 LUA_API int lua_setmetatable(lua_State* L, int objindex);

--- a/VM/src/lapi.cpp
+++ b/VM/src/lapi.cpp
@@ -847,6 +847,19 @@ void lua_setfield(lua_State* L, int idx, const char* k)
     return;
 }
 
+void lua_rawsetfield(lua_State* L, int idx, const char* k)
+{
+    api_checknelems(L, 1);
+    StkId t = index2addr(L, idx);
+    api_checkvalidindex(L, t);
+    if (hvalue(t)->readonly)
+        luaG_runerror(L, "Attempt to modify a readonly table");
+    setobj2t(L, luaH_setstr(L, hvalue(t), luaS_new(L, k)), L->top - 1);
+    luaC_barriert(L, hvalue(t), L->top - 1);
+    L->top--;
+    return;
+}
+
 void lua_rawset(lua_State* L, int idx)
 {
     api_checknelems(L, 2);

--- a/VM/src/lapi.cpp
+++ b/VM/src/lapi.cpp
@@ -851,7 +851,7 @@ void lua_rawsetfield(lua_State* L, int idx, const char* k)
 {
     api_checknelems(L, 1);
     StkId t = index2addr(L, idx);
-    api_checkvalidindex(L, t);
+    api_check(L, ttistable(t));
     if (hvalue(t)->readonly)
         luaG_runerror(L, "Attempt to modify a readonly table");
     setobj2t(L, luaH_setstr(L, hvalue(t), luaS_new(L, k)), L->top - 1);

--- a/tests/Conformance.test.cpp
+++ b/tests/Conformance.test.cpp
@@ -746,6 +746,8 @@ TEST_CASE("ApiTables")
     lua_newtable(L);
     lua_pushnumber(L, 123.0);
     lua_setfield(L, -2, "key");
+    lua_pushnumber(L, 456.0);
+    lua_rawsetfield(L, -2, "key2");
     lua_pushstring(L, "test");
     lua_rawseti(L, -2, 5);
 
@@ -761,8 +763,8 @@ TEST_CASE("ApiTables")
     lua_pop(L, 1);
 
     // lua_rawgetfield
-    CHECK(lua_rawgetfield(L, -1, "key") == LUA_TNUMBER);
-    CHECK(lua_tonumber(L, -1) == 123.0);
+    CHECK(lua_rawgetfield(L, -1, "key2") == LUA_TNUMBER);
+    CHECK(lua_tonumber(L, -1) == 456.0);
     lua_pop(L, 1);
 
     // lua_rawget


### PR DESCRIPTION
Luau currently has the following functions in the C API for dealing with tables without invoking metamethods:

lua_rawgetfield
lua_rawget
lua_rawgeti
lua_rawset
lua_rawseti

This change adds the missing function lua_rawsetfield for consistency and because it's more efficient to use it in place of plain lua_rawset which requires pushing the key and value separately.