### PR TITLE
Switch coverage build to later clang version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,7 +67,7 @@ jobs:
         Debug/luau-analyze tests/conformance/assert.lua
 
   coverage:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v2
     - name: install
@@ -75,7 +75,7 @@ jobs:
         sudo apt install llvm
     - name: make coverage
       run: |
-        CXX=clang++-10 make -j2 config=coverage coverage
+        CXX=clang++ make -j2 config=coverage coverage
     - name: upload coverage
       uses: codecov/codecov-action@v3
       with:


### PR DESCRIPTION
We've used clang-10 because of packaging issues in Ubuntu 20, but they should be resolved in Ubuntu 22