### PR TITLE
Add lua_cleartable

### DIFF
--- a/VM/include/lua.h
+++ b/VM/include/lua.h
@@ -316,6 +316,8 @@ LUA_API void lua_setuserdatadtor(lua_State* L, int tag, void (*dtor)(lua_State*,
 
 LUA_API void lua_clonefunction(lua_State* L, int idx);
 
+LUA_API void lua_cleartable(lua_State* L, int idx);
+
 /*
 ** reference system, can be used to pin objects
 */

--- a/VM/src/lapi.cpp
+++ b/VM/src/lapi.cpp
@@ -1376,6 +1376,16 @@ void lua_clonefunction(lua_State* L, int idx)
     api_incr_top(L);
 }
 
+void lua_cleartable(lua_State* L, int idx)
+{
+    StkId t = index2addr(L, idx);
+    api_check(L, ttistable(t));
+    Table* tt = hvalue(t);
+    if (tt->readonly)
+        luaG_runerror(L, "Attempt to modify a readonly table");
+    luaH_clear(tt);
+}
+
 lua_Callbacks* lua_callbacks(lua_State* L)
 {
     return &L->global->cb;

--- a/tests/Conformance.test.cpp
+++ b/tests/Conformance.test.cpp
@@ -778,6 +778,11 @@ TEST_CASE("ApiTables")
     CHECK(strcmp(lua_tostring(L, -1), "test") == 0);
     lua_pop(L, 1);
 
+    // lua_cleartable
+    lua_cleartable(L, -1);
+    lua_pushnil(L);
+    CHECK(lua_next(L, -2) == 0);
+
     lua_pop(L, 1);
 }
 


### PR DESCRIPTION
To my understanding lua_cleartable does not need GC barriers because it's only removing elements and not modifying the stack. But I'm not a GC expert so please correct if I'm wrong.

resolves #672