### PR TITLE
Support `["prop"]` syntax on class definitions

### DIFF
--- a/tests/TypeInfer.definitions.test.cpp
+++ b/tests/TypeInfer.definitions.test.cpp
@@ -362,4 +362,21 @@ TEST_CASE_FIXTURE(Fixture, "class_definition_overload_metamethods")
     CHECK_EQ(toString(requireType("shouldBeVector")), "Vector3");
 }
 
+TEST_CASE_FIXTURE(Fixture, "class_definition_string_props")
+{
+    loadDefinition(R"(
+        declare class Foo
+            ["a property"]: string
+        end
+    )");
+
+    CheckResult result = check(R"(
+        local x: Foo
+        local y = x["a property"]
+    )");
+
+    LUAU_REQUIRE_NO_ERRORS(result);
+    CHECK_EQ(toString(requireType("y")), "string");
+}
+
 TEST_SUITE_END();


### PR DESCRIPTION
Some classes have properties which are not valid identifiers (such as https://create.roblox.com/docs/reference/engine/classes/Studio)

This adds support for the following syntax in definition files:
```lua
declare class Foo
    ["a property"]: string
end
```

Closes #702 