### PR TITLE
Fix segfault in `loadDefinition` for unit tests

### DIFF
--- a/tests/Fixture.cpp
+++ b/tests/Fixture.cpp
@@ -429,7 +429,8 @@ LoadDefinitionFileResult Fixture::loadDefinition(const std::string& source)
     LoadDefinitionFileResult result = frontend.loadDefinitionFile(source, "@test");
     freeze(typeChecker.globalTypes);
 
-    dumpErrors(result.module);
+    if (result.module)
+        dumpErrors(result.module);
     REQUIRE_MESSAGE(result.success, "loadDefinition: unable to load definition file");
     return result;
 }


### PR DESCRIPTION
`module` can be empty if the definition file has syntax errors