### PR TITLE
Fix reverse deps > 1 node away not correctly marked as dirty

### DIFF
--- a/Analysis/src/Frontend.cpp
+++ b/Analysis/src/Frontend.cpp
@@ -30,6 +30,7 @@ LUAU_FASTFLAGVARIABLE(LuauAutocompleteDynamicLimits, false)
 LUAU_FASTINTVARIABLE(LuauAutocompleteCheckTimeoutMs, 100)
 LUAU_FASTFLAGVARIABLE(DebugLuauDeferredConstraintResolution, false)
 LUAU_FASTFLAG(DebugLuauLogSolverToJson);
+LUAU_FASTFLAGVARIABLE(LuauFixMarkDirtyReverseDeps, false)
 
 namespace Luau
 {
@@ -807,13 +808,26 @@ void Frontend::markDirty(const ModuleName& name, std::vector<ModuleName>* marked
         sourceNode.dirtyModule = true;
         sourceNode.dirtyModuleForAutocomplete = true;
 
-        if (0 == reverseDeps.count(next))
-            continue;
+        if (FFlag::LuauFixMarkDirtyReverseDeps)
+        {
+            if (0 == reverseDeps.count(next))
+                continue;
 
-        sourceModules.erase(next);
+            sourceModules.erase(next);
 
-        const std::vector<ModuleName>& dependents = reverseDeps[next];
-        queue.insert(queue.end(), dependents.begin(), dependents.end());
+            const std::vector<ModuleName>& dependents = reverseDeps[next];
+            queue.insert(queue.end(), dependents.begin(), dependents.end());
+        }
+        else
+        {
+            if (0 == reverseDeps.count(name))
+                continue;
+
+            sourceModules.erase(name);
+
+            const std::vector<ModuleName>& dependents = reverseDeps[name];
+            queue.insert(queue.end(), dependents.begin(), dependents.end());
+        }
     }
 }
 

--- a/Analysis/src/Frontend.cpp
+++ b/Analysis/src/Frontend.cpp
@@ -807,12 +807,12 @@ void Frontend::markDirty(const ModuleName& name, std::vector<ModuleName>* marked
         sourceNode.dirtyModule = true;
         sourceNode.dirtyModuleForAutocomplete = true;
 
-        if (0 == reverseDeps.count(name))
+        if (0 == reverseDeps.count(next))
             continue;
 
-        sourceModules.erase(name);
+        sourceModules.erase(next);
 
-        const std::vector<ModuleName>& dependents = reverseDeps[name];
+        const std::vector<ModuleName>& dependents = reverseDeps[next];
         queue.insert(queue.end(), dependents.begin(), dependents.end());
     }
 }

--- a/tests/Frontend.test.cpp
+++ b/tests/Frontend.test.cpp
@@ -517,6 +517,29 @@ TEST_CASE_FIXTURE(FrontendFixture, "recheck_if_dependent_script_is_dirty")
     CHECK_EQ("{| b_value: string |}", toString(*bExports));
 }
 
+TEST_CASE_FIXTURE(FrontendFixture, "mark_transitive_deps_as_dirty")
+{
+    fileResolver.source["game/Gui/Modules/A"] = "return {hello=5, world=true}";
+    fileResolver.source["game/Gui/Modules/B"] = R"(
+        return require(game:GetService('Gui').Modules.A)
+    )";
+    fileResolver.source["game/Gui/Modules/C"] = R"(
+        local Modules = game:GetService('Gui').Modules
+        local B = require(Modules.B)
+        return {c_value = B.hello}
+    )";
+
+    frontend.check("game/Gui/Modules/C");
+
+    std::vector<Luau::ModuleName> markedDirty;
+    frontend.markDirty("game/Gui/Modules/A", &markedDirty);
+
+    REQUIRE(markedDirty.size() == 3);
+    CHECK(std::find(markedDirty.begin(), markedDirty.end(), "game/Gui/Modules/A") != markedDirty.end());
+    CHECK(std::find(markedDirty.begin(), markedDirty.end(), "game/Gui/Modules/B") != markedDirty.end());
+    CHECK(std::find(markedDirty.begin(), markedDirty.end(), "game/Gui/Modules/C") != markedDirty.end());
+}
+
 #if 0
 // Does not work yet. :(
 TEST_CASE_FIXTURE(FrontendFixture, "recheck_if_dependent_script_has_a_parse_error")
@@ -619,9 +642,11 @@ TEST_CASE_FIXTURE(FrontendFixture, "report_syntax_error_in_required_file")
 
     CHECK_EQ("Modules/A", result.errors[0].moduleName);
 
-    bool b = std::any_of(begin(result.errors), end(result.errors), [](auto&& e) -> bool {
-        return get<SyntaxError>(e);
-    });
+    bool b = std::any_of(begin(result.errors), end(result.errors),
+        [](auto&& e) -> bool
+        {
+            return get<SyntaxError>(e);
+        });
     if (!b)
     {
         CHECK_MESSAGE(false, "Expected a syntax error!");

--- a/tests/Frontend.test.cpp
+++ b/tests/Frontend.test.cpp
@@ -517,7 +517,7 @@ TEST_CASE_FIXTURE(FrontendFixture, "recheck_if_dependent_script_is_dirty")
     CHECK_EQ("{| b_value: string |}", toString(*bExports));
 }
 
-TEST_CASE_FIXTURE(FrontendFixture, "mark_transitive_deps_as_dirty")
+TEST_CASE_FIXTURE(FrontendFixture, "mark_non_immediate_reverse_deps_as_dirty")
 {
     fileResolver.source["game/Gui/Modules/A"] = "return {hello=5, world=true}";
     fileResolver.source["game/Gui/Modules/B"] = R"(

--- a/tests/Frontend.test.cpp
+++ b/tests/Frontend.test.cpp
@@ -642,11 +642,9 @@ TEST_CASE_FIXTURE(FrontendFixture, "report_syntax_error_in_required_file")
 
     CHECK_EQ("Modules/A", result.errors[0].moduleName);
 
-    bool b = std::any_of(begin(result.errors), end(result.errors),
-        [](auto&& e) -> bool
-        {
-            return get<SyntaxError>(e);
-        });
+    bool b = std::any_of(begin(result.errors), end(result.errors), [](auto&& e) -> bool {
+        return get<SyntaxError>(e);
+    });
     if (!b)
     {
         CHECK_MESSAGE(false, "Expected a syntax error!");

--- a/tests/Frontend.test.cpp
+++ b/tests/Frontend.test.cpp
@@ -519,6 +519,10 @@ TEST_CASE_FIXTURE(FrontendFixture, "recheck_if_dependent_script_is_dirty")
 
 TEST_CASE_FIXTURE(FrontendFixture, "mark_non_immediate_reverse_deps_as_dirty")
 {
+    ScopedFastFlag sff[] = {
+        {"LuauFixMarkDirtyReverseDeps", true},
+    };
+
     fileResolver.source["game/Gui/Modules/A"] = "return {hello=5, world=true}";
     fileResolver.source["game/Gui/Modules/B"] = R"(
         return require(game:GetService('Gui').Modules.A)


### PR DESCRIPTION
`Frontend.markDirty()` does not correctly mark reverse dependencies that are not immediate as dirty.
This is because it would keep adding the reverse deps of `name` into the queue to mark as dirty, instead of the reverse deps of `next`