### PR TITLE
Fix { range to be within the interpolated string

### DIFF
--- a/Ast/src/Lexer.cpp
+++ b/Ast/src/Lexer.cpp
@@ -641,8 +641,8 @@ Lexeme Lexer::readInterpolatedStringSection(Position start, Lexeme::Type formatT
                 return brokenDoubleBrace;
             }
 
-            Lexeme lexemeOutput(Location(start, position()), Lexeme::InterpStringBegin, &buffer[startOffset], offset - startOffset);
             consume();
+            Lexeme lexemeOutput(Location(start, position()), Lexeme::InterpStringBegin, &buffer[startOffset], offset - startOffset);
             return lexemeOutput;
         }
 

--- a/Ast/src/Lexer.cpp
+++ b/Ast/src/Lexer.cpp
@@ -642,7 +642,7 @@ Lexeme Lexer::readInterpolatedStringSection(Position start, Lexeme::Type formatT
             }
 
             consume();
-            Lexeme lexemeOutput(Location(start, position()), Lexeme::InterpStringBegin, &buffer[startOffset], offset - startOffset);
+            Lexeme lexemeOutput(Location(start, position()), Lexeme::InterpStringBegin, &buffer[startOffset], offset - startOffset - 1);
             return lexemeOutput;
         }
 

--- a/tests/AstJsonEncoder.test.cpp
+++ b/tests/AstJsonEncoder.test.cpp
@@ -183,7 +183,7 @@ TEST_CASE_FIXTURE(JsonEncoderFixture, "encode_AstExprInterpString")
     AstStat* statement = expectParseStatement("local a = `var = {x}`");
 
     std::string_view expected =
-        R"({"type":"AstStatLocal","location":"0,0 - 0,17","vars":[{"luauType":null,"name":"a","type":"AstLocal","location":"0,6 - 0,7"}],"values":[{"type":"AstExprInterpString","location":"0,10 - 0,17","strings":["var = ",""],"expressions":[{"type":"AstExprGlobal","location":"0,18 - 0,19","global":"x"}]}]})";
+        R"({"type":"AstStatLocal","location":"0,0 - 0,18","vars":[{"luauType":null,"name":"a","type":"AstLocal","location":"0,6 - 0,7"}],"values":[{"type":"AstExprInterpString","location":"0,10 - 0,18","strings":["var = ",""],"expressions":[{"type":"AstExprGlobal","location":"0,18 - 0,19","global":"x"}]}]})";
 
     CHECK(toJson(statement) == expected);
 }


### PR DESCRIPTION
Corrects `{` range to be inside the interpolated string, needed for syntax highlighting.