### PR TITLE
Support `__call` on class type vars

### DIFF
--- a/Analysis/src/TypeInfer.cpp
+++ b/Analysis/src/TypeInfer.cpp
@@ -49,6 +49,7 @@ LUAU_FASTFLAGVARIABLE(LuauReportShadowedTypeAlias, false)
 LUAU_FASTFLAGVARIABLE(LuauBetterMessagingOnCountMismatch, false)
 LUAU_FASTFLAGVARIABLE(LuauArgMismatchReportFunctionLocation, false)
 LUAU_FASTFLAGVARIABLE(LuauImplicitElseRefinement, false)
+LUAU_FASTFLAGVARIABLE(LuauCallableClasses, false)
 
 namespace Luau
 {
@@ -4140,7 +4141,7 @@ std::optional<WithPredicate<TypePackId>> TypeChecker::checkCallOverload(const Sc
     if (const MetatableTypeVar* mttv = get<MetatableTypeVar>(fn))
     {
         callTy = getIndexTypeFromType(scope, mttv->metatable, "__call", expr.func->location, /* addErrors= */ false);
-    } else if (const ClassTypeVar* ctv = get<ClassTypeVar>(fn); ctv && ctv->metatable)
+    } else if (const ClassTypeVar* ctv = get<ClassTypeVar>(fn); FFlag::LuauCallableClasses && ctv && ctv->metatable)
     {
         callTy = getIndexTypeFromType(scope, *ctv->metatable, "__call", expr.func->location, /* addErrors= */ false);
     }

--- a/Analysis/src/TypeInfer.cpp
+++ b/Analysis/src/TypeInfer.cpp
@@ -4141,12 +4141,14 @@ std::optional<WithPredicate<TypePackId>> TypeChecker::checkCallOverload(const Sc
     if (const MetatableTypeVar* mttv = get<MetatableTypeVar>(fn))
     {
         callTy = getIndexTypeFromType(scope, mttv->metatable, "__call", expr.func->location, /* addErrors= */ false);
-    } else if (const ClassTypeVar* ctv = get<ClassTypeVar>(fn); FFlag::LuauCallableClasses && ctv && ctv->metatable)
+    }
+    else if (const ClassTypeVar* ctv = get<ClassTypeVar>(fn); FFlag::LuauCallableClasses && ctv && ctv->metatable)
     {
         callTy = getIndexTypeFromType(scope, *ctv->metatable, "__call", expr.func->location, /* addErrors= */ false);
     }
 
-    if (callTy) {
+    if (callTy)
+    {
         // Construct arguments with 'self' added in front
         TypePackId metaCallArgPack = addTypePack(TypePackVar(TypePack{args->head, args->tail}));
 

--- a/tests/TypeInfer.classes.test.cpp
+++ b/tests/TypeInfer.classes.test.cpp
@@ -523,6 +523,8 @@ TEST_CASE_FIXTURE(ClassFixture, "unions_of_intersections_of_classes")
 
 TEST_CASE_FIXTURE(ClassFixture, "callable_classes")
 {
+    ScopedFastFlag luauCallableClasses{"LuauCallableClasses", true};
+
     CheckResult result = check(R"(
         local x : CallableClass
         local y = x("testing")

--- a/tests/TypeInfer.classes.test.cpp
+++ b/tests/TypeInfer.classes.test.cpp
@@ -91,6 +91,13 @@ struct ClassFixture : BuiltinsFixture
         typeChecker.globalScope->exportedTypeBindings["Vector2"] = TypeFun{{}, vector2InstanceType};
         addGlobalBinding(frontend, "Vector2", vector2Type, "@test");
 
+        TypeId callableClassMetaType = arena.addType(TableTypeVar{});
+        TypeId callableClassType = arena.addType(ClassTypeVar{"CallableClass", {}, nullopt, callableClassMetaType, {}, {}, "Test"});
+        getMutable<TableTypeVar>(callableClassMetaType)->props = {
+            {"__call", {makeFunction(arena, nullopt, {callableClassType, typeChecker.stringType}, {typeChecker.numberType})}},
+        };
+        typeChecker.globalScope->exportedTypeBindings["CallableClass"] = TypeFun{{}, callableClassType};
+
         for (const auto& [name, tf] : typeChecker.globalScope->exportedTypeBindings)
             persist(tf.type);
 
@@ -512,6 +519,17 @@ TEST_CASE_FIXTURE(ClassFixture, "unions_of_intersections_of_classes")
     )");
 
     LUAU_REQUIRE_NO_ERRORS(result);
+}
+
+TEST_CASE_FIXTURE(ClassFixture, "callable_classes")
+{
+    CheckResult result = check(R"(
+        local x : CallableClass
+        local y = x("testing")
+    )");
+
+    LUAU_REQUIRE_NO_ERRORS(result);
+    CHECK_EQ("number", toString(requireType("y")));
 }
 
 TEST_SUITE_END();


### PR DESCRIPTION
Currently, the metatable of a class type var is not correctly checked to see if it is callable (i.e. has a `__call` metatable).
We resolve this issue by checking the metatable in `checkCallOverload`

Fixes #756 