### PR TITLE
Make pseudo-indices relative to LUAI_MAXCSTACK

### DIFF
--- a/VM/include/lua.h
+++ b/VM/include/lua.h
@@ -17,9 +17,9 @@
 /*
 ** pseudo-indices
 */
-#define LUA_REGISTRYINDEX (-10000)
-#define LUA_ENVIRONINDEX (-10001)
-#define LUA_GLOBALSINDEX (-10002)
+#define LUA_REGISTRYINDEX (-LUAI_MAXCSTACK - 2000)
+#define LUA_ENVIRONINDEX (-LUAI_MAXCSTACK - 2001)
+#define LUA_GLOBALSINDEX (-LUAI_MAXCSTACK - 2002)
 #define lua_upvalueindex(i) (LUA_GLOBALSINDEX - (i))
 #define lua_ispseudo(i) ((i) <= LUA_REGISTRYINDEX)
 


### PR DESCRIPTION
This is useful in particular if redefine `LUAI_MAXCSTACK` to a higher value than the current one (8000).
Ie. passing `-D LUAI_MAXCSTACK=1000000` would not work as overlaps with `LUA_REGISTRYINDEX` and below.
