### PR TITLE
Fix coverage github action by using clang++ without a specific version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,7 +86,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: install
       run: |
-        sudo apt install llvm
+        sudo apt install llvm-10
     - name: make coverage
       run: |
         CXX=clang++-10 make -j2 config=coverage native=1 coverage

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,10 +86,10 @@ jobs:
     - uses: actions/checkout@v2
     - name: install
       run: |
-        sudo apt install llvm-10
+        sudo apt install llvm
     - name: make coverage
       run: |
-        CXX=clang++-10 make -j2 config=coverage native=1 coverage
+        CXX=clang++ make -j2 config=coverage native=1 coverage
     - name: upload coverage
       uses: codecov/codecov-action@v3
       with:


### PR DESCRIPTION
Github fails to find clang++-10.
Since we install llvm without a specific version number, we shouldn't use clang++-10 with a version number.

I tried installing llvm-10, but that package is not available on github (any more?).