### PR TITLE
Keep using ubuntu-20.04 in GitHub Actions (and clang++-10 in coverage)

### DIFF
--- a/.github/workflows/benchmark-dev.yml
+++ b/.github/workflows/benchmark-dev.yml
@@ -108,7 +108,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-20.04, macos-latest]
         bench:
           - {
               script: "run-benchmarks",

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,9 +20,9 @@ jobs:
   unix:
     strategy:
       matrix:
-        os: [ubuntu, macos]
-    name: ${{matrix.os}}
-    runs-on: ${{matrix.os}}-latest
+        os: [{name: ubuntu, version: ubuntu-20.04}, {name: macos, version: macos-latest}]
+    name: ${{matrix.os.name}}
+    runs-on: ${{matrix.os.version}}
     steps:
     - uses: actions/checkout@v1
     - name: make tests
@@ -81,7 +81,7 @@ jobs:
         Debug/luau-analyze tests/conformance/assert.lua
 
   coverage:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
     - name: install
@@ -89,7 +89,7 @@ jobs:
         sudo apt install llvm
     - name: make coverage
       run: |
-        CXX=clang++ make -j2 config=coverage native=1 coverage
+        CXX=clang++-10 make -j2 config=coverage native=1 coverage
     - name: upload coverage
       uses: codecov/codecov-action@v3
       with:
@@ -97,7 +97,7 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
 
   web:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v1
     - uses: actions/checkout@v2

--- a/.github/workflows/new-release.yml
+++ b/.github/workflows/new-release.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   create-release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     outputs:
       upload_url: ${{ steps.create_release.outputs.upload_url }}
     steps:
@@ -30,9 +30,9 @@ jobs:
     needs: ["create-release"]
     strategy:
       matrix:
-        os: [ubuntu, macos, windows]
-    name: ${{matrix.os}}
-    runs-on: ${{matrix.os}}-latest
+        os: [{name: ubuntu, version: ubuntu-20.04}, {name: macos, version: macos-latest}, {name: windows, version: windows-latest}]
+    name: ${{matrix.os.name}}
+    runs-on: ${{matrix.os.version}}
     steps:
     - uses: actions/checkout@v1
     - name: configure
@@ -40,23 +40,23 @@ jobs:
     - name: build
       run: cmake --build . --target Luau.Repl.CLI Luau.Analyze.CLI --config Release -j 2
     - name: pack
-      if: matrix.os != 'windows'
-      run: zip luau-${{matrix.os}}.zip luau*
+      if: matrix.os.name != 'windows'
+      run: zip luau-${{matrix.os.name}}.zip luau*
     - name: pack
-      if: matrix.os == 'windows'
-      run: 7z a luau-${{matrix.os}}.zip .\Release\luau*.exe
+      if: matrix.os.name == 'windows'
+      run: 7z a luau-${{matrix.os.name}}.zip .\Release\luau*.exe
     - uses: actions/upload-release-asset@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ needs.create-release.outputs.upload_url }}
-        asset_path: luau-${{matrix.os}}.zip
-        asset_name: luau-${{matrix.os}}.zip
+        asset_path: luau-${{matrix.os.name}}.zip
+        asset_name: luau-${{matrix.os.name}}.zip
         asset_content_type: application/octet-stream
 
   web:
     needs: ["create-release"]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v1
     - uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,9 +14,9 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu, macos, windows]
-    name: ${{matrix.os}}
-    runs-on: ${{matrix.os}}-latest
+        os: [{name: ubuntu, version: ubuntu-20.04}, {name: macos, version: macos-latest}, {name: windows, version: windows-latest}]
+    name: ${{matrix.os.name}}
+    runs-on: ${{matrix.os.version}}
     steps:
     - uses: actions/checkout@v1
     - name: configure
@@ -24,18 +24,18 @@ jobs:
     - name: build
       run: cmake --build . --target Luau.Repl.CLI Luau.Analyze.CLI --config Release -j 2
     - uses: actions/upload-artifact@v2
-      if: matrix.os != 'windows'
+      if: matrix.os.name != 'windows'
       with:
-        name: luau-${{matrix.os}}
+        name: luau-${{matrix.os.name}}
         path: luau*
     - uses: actions/upload-artifact@v2
-      if: matrix.os == 'windows'
+      if: matrix.os.name == 'windows'
       with:
-        name: luau-${{matrix.os}}
+        name: luau-${{matrix.os.name}}
         path: Release\luau*.exe
 
   web:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v1
     - uses: actions/checkout@v2


### PR DESCRIPTION
### Problem
ubuntu-latest was updated to 22.04 which removes clang++-10 we used for coverage stats and creates a pre-compiled binary that requires a glibc upgrade https://github.com/Roblox/luau/issues/773

### Solution
Pin to ubuntu-20.04 using multi-value matrix configurations.
In coverage configuration, we use clang++-10 once again.