### PR TITLE
Pass string content to autocomplete callback

### DIFF
--- a/Analysis/include/Luau/Autocomplete.h
+++ b/Analysis/include/Luau/Autocomplete.h
@@ -89,7 +89,8 @@ struct AutocompleteResult
 };
 
 using ModuleName = std::string;
-using StringCompletionCallback = std::function<std::optional<AutocompleteEntryMap>(std::string tag, std::optional<const ClassType*> ctx)>;
+using StringCompletionCallback =
+    std::function<std::optional<AutocompleteEntryMap>(std::string tag, std::optional<const ClassType*> ctx, std::optional<std::string> contents)>;
 
 AutocompleteResult autocomplete(Frontend& frontend, const ModuleName& moduleName, Position position, StringCompletionCallback callback);
 

--- a/Analysis/src/Autocomplete.cpp
+++ b/Analysis/src/Autocomplete.cpp
@@ -1292,8 +1292,6 @@ static std::optional<AutocompleteEntryMap> autocompleteStringParams(const Source
         return std::nullopt;
     }
 
-    std::optional<std::string> candidateString = getStringContents(nodes.back());
-
     AstExprCall* candidate = nodes.at(nodes.size() - 2)->as<AstExprCall>();
     if (!candidate)
     {
@@ -1312,6 +1310,8 @@ static std::optional<AutocompleteEntryMap> autocompleteStringParams(const Source
     {
         return std::nullopt;
     }
+
+    std::optional<std::string> candidateString = getStringContents(nodes.back());
 
     auto performCallback = [&](const FunctionType* funcType) -> std::optional<AutocompleteEntryMap>
     {


### PR DESCRIPTION
Closes #718 

We pass an extra `contents` parameter to the string callback function to provide contextual information for autocomplete.

Because we support both string literals and simple interpolated strings, we pass it through as a `std::string` value.

This is a breaking change