### PR TITLE
Attach definition location to `TableType`

### DIFF
--- a/Analysis/include/Luau/Type.h
+++ b/Analysis/include/Luau/Type.h
@@ -375,6 +375,7 @@ struct TableType
     std::vector<TypeId> instantiatedTypeParams;
     std::vector<TypePackId> instantiatedTypePackParams;
     ModuleName definitionModuleName;
+    Location definitionLocation;
 
     std::optional<TypeId> boundTo;
     Tags tags;

--- a/Analysis/src/Anyification.cpp
+++ b/Analysis/src/Anyification.cpp
@@ -59,6 +59,7 @@ TypeId Anyification::clean(TypeId ty)
     {
         TableType clone = TableType{ttv->props, ttv->indexer, ttv->level, TableState::Sealed};
         clone.definitionModuleName = ttv->definitionModuleName;
+        clone.definitionLocation = ttv->definitionLocation;
         clone.name = ttv->name;
         clone.syntheticName = ttv->syntheticName;
         clone.tags = ttv->tags;

--- a/Analysis/src/Clone.cpp
+++ b/Analysis/src/Clone.cpp
@@ -263,6 +263,7 @@ void TypeCloner::operator()(const TableType& t)
         arg = clone(arg, dest, cloneState);
 
     ttv->definitionModuleName = t.definitionModuleName;
+    ttv->definitionLocation = t.definitionLocation;
     ttv->tags = t.tags;
 }
 
@@ -446,6 +447,7 @@ TypeId shallowClone(TypeId ty, TypeArena& dest, const TxnLog* log, bool alwaysCl
         LUAU_ASSERT(!ttv->boundTo);
         TableType clone = TableType{ttv->props, ttv->indexer, ttv->level, ttv->scope, ttv->state};
         clone.definitionModuleName = ttv->definitionModuleName;
+        clone.definitionLocation = ttv->definitionLocation;
         clone.name = ttv->name;
         clone.syntheticName = ttv->syntheticName;
         clone.instantiatedTypeParams = ttv->instantiatedTypeParams;

--- a/Analysis/src/Instantiation.cpp
+++ b/Analysis/src/Instantiation.cpp
@@ -116,6 +116,7 @@ TypeId ReplaceGenerics::clean(TypeId ty)
     {
         TableType clone = TableType{ttv->props, ttv->indexer, level, scope, TableState::Free};
         clone.definitionModuleName = ttv->definitionModuleName;
+        clone.definitionLocation = ttv->definitionLocation;
         return addType(std::move(clone));
     }
     else

--- a/Analysis/src/TypeInfer.cpp
+++ b/Analysis/src/TypeInfer.cpp
@@ -1535,6 +1535,7 @@ void TypeChecker::check(const ScopePtr& scope, const AstStatTypeAlias& typealias
                 // This is a shallow clone, original recursive links to self are not updated
                 TableType clone = TableType{ttv->props, ttv->indexer, ttv->level, ttv->state};
                 clone.definitionModuleName = ttv->definitionModuleName;
+                clone.definitionLocation = ttv->definitionLocation;
                 clone.name = name;
 
                 for (auto param : binding->typeParams)
@@ -2370,6 +2371,7 @@ TypeId TypeChecker::checkExprTable(
     TableState state = TableState::Unsealed;
     TableType table = TableType{std::move(props), indexer, scope->level, state};
     table.definitionModuleName = currentModuleName;
+    table.definitionLocation = expr.location;
     return addType(table);
 }
 
@@ -5371,6 +5373,7 @@ TypeId TypeChecker::resolveTypeWorker(const ScopePtr& scope, const AstType& anno
 
         TableType ttv{props, tableIndexer, scope->level, TableState::Sealed};
         ttv.definitionModuleName = currentModuleName;
+        ttv.definitionLocation = annotation.location;
         return addType(std::move(ttv));
     }
     else if (const auto& func = annotation.as<AstTypeFunction>())
@@ -5572,6 +5575,7 @@ TypeId TypeChecker::instantiateTypeFun(const ScopePtr& scope, const TypeFun& tf,
         ttv->instantiatedTypeParams = typeParams;
         ttv->instantiatedTypePackParams = typePackParams;
         ttv->definitionModuleName = currentModuleName;
+        ttv->definitionLocation = location;
     }
 
     return instantiated;


### PR DESCRIPTION
Having the location where the table type is defined is useful for tracking other info such as documentation comments, or pointing back through "Go To Definition" functionality etc.

This adds in the required info