### PR TITLE
Update grammar.md

### DIFF
--- a/docs/_pages/grammar.md
+++ b/docs/_pages/grammar.md
@@ -53,7 +53,7 @@ fieldlist = field {fieldsep field} [fieldsep]
 field = '[' exp ']' '=' exp | NAME '=' exp | exp
 fieldsep = ',' | ';'
 
-compoundop :: '+=' | '-=' | '*=' | '/=' | '%=' | '^=' | '..='
+compoundop = '+=' | '-=' | '*=' | '/=' | '%=' | '^=' | '..='
 binop = '+' | '-' | '*' | '/' | '^' | '%' | '..' | '<' | '<=' | '>' | '>=' | '==' | '~=' | 'and' | 'or'
 unop = '-' | 'not' | '#'
 


### PR DESCRIPTION
This pull request fixes error in grammar documentation page.

It change :: to = when declaring compoundop.