### PR TITLE
Fixed lerp() duplicate when compiling for C++20

### DIFF
--- a/VM/src/lmathlib.cpp
+++ b/VM/src/lmathlib.cpp
@@ -300,12 +300,10 @@ static float fade(float t)
     return t * t * t * (t * (t * 6 - 15) + 10);
 }
 
-#if __cplusplus <= 201703L
-static float lerp(float t, float a, float b)
+static float math_lerp(float t, float a, float b)
 {
     return a + t * (b - a);
 }
-#endif
 
 static float grad(unsigned char hash, float x, float y, float z)
 {
@@ -344,10 +342,10 @@ static float perlin(float x, float y, float z)
     int ba = p[b] + zi;
     int bb = p[b + 1] + zi;
 
-    return lerp(w,
-        lerp(v, lerp(u, grad(p[aa], xf, yf, zf), grad(p[ba], xf - 1, yf, zf)), lerp(u, grad(p[ab], xf, yf - 1, zf), grad(p[bb], xf - 1, yf - 1, zf))),
-        lerp(v, lerp(u, grad(p[aa + 1], xf, yf, zf - 1), grad(p[ba + 1], xf - 1, yf, zf - 1)),
-            lerp(u, grad(p[ab + 1], xf, yf - 1, zf - 1), grad(p[bb + 1], xf - 1, yf - 1, zf - 1))));
+    return math_lerp(w,
+        math_lerp(v, math_lerp(u, grad(p[aa], xf, yf, zf), grad(p[ba], xf - 1, yf, zf)), math_lerp(u, grad(p[ab], xf, yf - 1, zf), grad(p[bb], xf - 1, yf - 1, zf))),
+        math_lerp(v, math_lerp(u, grad(p[aa + 1], xf, yf, zf - 1), grad(p[ba + 1], xf - 1, yf, zf - 1)),
+            math_lerp(u, grad(p[ab + 1], xf, yf - 1, zf - 1), grad(p[bb + 1], xf - 1, yf - 1, zf - 1))));
 }
 
 static int math_noise(lua_State* L)

--- a/VM/src/lmathlib.cpp
+++ b/VM/src/lmathlib.cpp
@@ -300,13 +300,11 @@ static float fade(float t)
     return t * t * t * (t * (t * 6 - 15) + 10);
 }
 
-#ifdef __clang__
 #if __cplusplus <= 201703L
 static float lerp(float t, float a, float b)
 {
     return a + t * (b - a);
 }
-#endif
 #endif
 
 static float grad(unsigned char hash, float x, float y, float z)

--- a/VM/src/lmathlib.cpp
+++ b/VM/src/lmathlib.cpp
@@ -300,10 +300,14 @@ static float fade(float t)
     return t * t * t * (t * (t * 6 - 15) + 10);
 }
 
+#ifdef __clang__
+#if __cplusplus <= 201703L
 static float lerp(float t, float a, float b)
 {
     return a + t * (b - a);
 }
+#endif
+#endif
 
 static float grad(unsigned char hash, float x, float y, float z)
 {


### PR DESCRIPTION
Hey!

I've noticed luau failing to compile on Clang:

    luaaau/luau/VM/src/lmathlib.cpp:303: error: declaration conflicts with target of using declaration already in scope
    luaaau/luau/VM/src/lmathlib.cpp:303:14: error: declaration conflicts with target of using declaration already in scope
    static float lerp(float t, float a, float b)
                 ^
    /usr/bin/../lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/cmath:1911:3: note: target of using declaration
      lerp(float __a, float __b, float __t) noexcept
      ^
    /usr/bin/../lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/math.h:183:12: note: using declaration
    using std::lerp;
               ^

So I looked at the `math.h` file and found this:

    #if __cplusplus > 201703L
    using std::lerp;
    #endif // C++20

So it seems like `std::lerp()` is put into the global namespace above C++17. That means that we already have a `lerp()` implementation in the global namespace! I decided to simply do this in luaus code:

    #if __cplusplus <= 201703L
    static float lerp(float t, float a, float b)
    {
        return a + t * (b - a);
    }
    #endif

And voila, everything is compiling just fine now.

This probably isn't the cleanest solution, and I initially thought it simply was a Clang issue when I commited. Please comment your thoughts. :smile:

Niansa