### PR TITLE
Improve the type for `os.date` using overloads

### DIFF
--- a/Analysis/src/EmbeddedBuiltinDefinitions.cpp
+++ b/Analysis/src/EmbeddedBuiltinDefinitions.cpp
@@ -92,7 +92,7 @@ type DateTypeResult = {
 
 declare os: {
     time: (time: DateTypeArg?) -> number,
-    date: (formatString: string?, time: number?) -> DateTypeResult | string,
+    date: ((formatString: "*t" | "!*t", time: number?) -> DateTypeResult) & ((formatString: string?, time: number?) -> string),
     difftime: (t2: DateTypeResult | number, t1: DateTypeResult | number) -> number,
     clock: () -> number,
 }


### PR DESCRIPTION
Improves the type of `os.date` based on its documentation https://create.roblox.com/docs/reference/engine/libraries/os#date

We know that the DateTypeResult table is only returned when the format string is either "*t" or "!*t", and otherwise its just a formatted string. This changes the type to showcase this appropriately.

I put the more strict type first in the overload because the ordering makes a difference

Note: the API docs used in studio (https://github.com/MaximumADHD/Roblox-Client-Tracker/blob/roblox/api-docs/en-us.json) may need to be updated to reflect the overloaded type instead.

![image](https://user-images.githubusercontent.com/19635171/226919224-e9e8703b-2729-44b0-93f6-434c01bda204.png)

It may be possible to add a lint of this too to provide analysis similar to how `string.format` works with a FormatString error. Will leave that for a different PR though
