### PR TITLE
Change the type of the argument for `require` from `any` to `unknown`

### DIFF
--- a/Analysis/src/EmbeddedBuiltinDefinitions.cpp
+++ b/Analysis/src/EmbeddedBuiltinDefinitions.cpp
@@ -97,7 +97,7 @@ declare os: {
     clock: () -> number,
 }
 
-declare function require(target: any): any
+declare function require(target: unknown): any
 
 declare function getfenv(target: any): { [string]: any }
 


### PR DESCRIPTION
This would help in regards to https://github.com/Roblox/luau/issues/876

This still allows anything to be passed into the call, without the drawbacks of using `any`.

I do not believe this will negatively impact anything, and the tests still pass, but I cannot confirm this.