### PR TITLE
Fix grammar issues

### DIFF
--- a/docs/_pages/grammar.md
+++ b/docs/_pages/grammar.md
@@ -76,7 +76,7 @@ GenericTypePackParameter = NAME '...'
 GenericTypeList = NAME [',' GenericTypeList] | GenericTypePackParameter {',' GenericTypePackParameter}
 
 GenericTypePackParameterWithDefault = NAME '...' ['=' (TypePack | VariadicTypePack | GenericTypePack)]
-GenericTypeListWithDefaults = NAME ['=' Type] [',' GenericTypeListWithDefaults] | GenericTypePackParameter {',' GenericTypePackParameter}
+GenericTypeListWithDefaults = NAME ['=' Type] [',' GenericTypeListWithDefaults] | GenericTypePackParameterWithDefault {',' GenericTypePackParameterWithDefault}
 
 TypeList = Type [',' TypeList] | '...' Type
 TypeParams = (Type | TypePack | VariadicTypePack | GenericTypePack) [',' TypeParams]

--- a/docs/_pages/grammar.md
+++ b/docs/_pages/grammar.md
@@ -64,13 +64,13 @@ SimpleType =
     'typeof' '(' exp ')' |
     TableType |
     FunctionType |
-    '(' SimpleType ')'
+    '(' Type ')'
 
 SingletonType = STRING | 'true' | 'false'
 
 UnionSuffix = {'?'} ['|' SimpleType]
 IntersectionSuffix = ['&' SimpleType]
-Type = SimpleType {UnionSuffix | IntersectionSuffix}
+Type = SimpleType {UnionSuffix} | SimpleType {IntersectionSuffix}
 
 GenericTypePackParameter = NAME '...'
 GenericTypeList = NAME [',' GenericTypeList] | GenericTypePackParameter {',' GenericTypePackParameter}

--- a/docs/_pages/grammar.md
+++ b/docs/_pages/grammar.md
@@ -77,7 +77,7 @@ GenericTypeList = NAME [',' GenericTypeList] | GenericTypePackParameter {',' Gen
 
 GenericTypePackParameterWithDefault = NAME '...' '=' (TypePack | VariadicTypePack | GenericTypePack)
 GenericTypeListWithDefaults =
-    GenericTypeList |
+    GenericTypeList {',' GenericTypePackParameterWithDefault} |
     NAME {',' NAME} {',' NAME '=' Type} {',' GenericTypePackParameterWithDefault} |
     NAME '=' Type {',' GenericTypePackParameterWithDefault} |
     GenericTypePackParameterWithDefault {',' GenericTypePackParameterWithDefault}

--- a/docs/_pages/grammar.md
+++ b/docs/_pages/grammar.md
@@ -22,12 +22,12 @@ stat = varlist '=' explist |
     'function' funcname funcbody |
     'local' 'function' NAME funcbody |
     'local' bindinglist ['=' explist] |
-    ['export'] 'type' NAME ['<' GenericTypeParameterList '>'] '=' Type
+    ['export'] 'type' NAME ['<' GenericTypeListWithDefaults '>'] '=' Type
 
 laststat = 'return' [explist] | 'break' | 'continue'
 
 funcname = NAME {'.' NAME} [':' NAME]
-funcbody = ['<' GenericTypeParameterList '>'] '(' [parlist] ')' [':' ReturnType] block 'end'
+funcbody = ['<' GenericTypeList '>'] '(' [parlist] ')' [':' ReturnType] block 'end'
 parlist = bindinglist [',' '...'] | '...'
 
 explist = {exp ','} exp
@@ -72,8 +72,12 @@ Type =
     Type ['|' Type] |
     Type ['&' Type]
 
-GenericTypePackParameter = NAME '...' ['=' (TypePack | VariadicTypePack | GenericTypePack)]
-GenericTypeParameterList = NAME ['=' Type] [',' GenericTypeParameterList] | GenericTypePackParameter {',' GenericTypePackParameter}
+GenericTypePackParameter = NAME '...'
+GenericTypeList = NAME [',' GenericTypeList] | GenericTypePackParameter {',' GenericTypePackParameter}
+
+GenericTypePackParameterWithDefault = NAME '...' ['=' (TypePack | VariadicTypePack | GenericTypePack)]
+GenericTypeListWithDefaults = NAME ['=' Type] [',' GenericTypeListWithDefaults] | GenericTypePackParameter {',' GenericTypePackParameter}
+
 TypeList = Type [',' TypeList] | '...' Type
 TypeParams = (Type | TypePack | VariadicTypePack | GenericTypePack) [',' TypeParams]
 TypePack = '(' [TypeList] ')'
@@ -85,5 +89,5 @@ TableProp = NAME ':' Type
 TablePropOrIndexer = TableProp | TableIndexer
 PropList = TablePropOrIndexer {fieldsep TablePropOrIndexer} [fieldsep]
 TableType = '{' PropList '}'
-FunctionType = ['<' GenericTypeParameterList '>'] '(' [TypeList] ')' '->' ReturnType
+FunctionType = ['<' GenericTypeList '>'] '(' [TypeList] ')' '->' ReturnType
 ```

--- a/docs/_pages/grammar.md
+++ b/docs/_pages/grammar.md
@@ -68,15 +68,19 @@ SimpleType =
 
 SingletonType = STRING | 'true' | 'false'
 
-UnionSuffix = {'?'} ['|' SimpleType]
-IntersectionSuffix = ['&' SimpleType]
-Type = SimpleType {UnionSuffix} | SimpleType {IntersectionSuffix}
+UnionSuffix = {'?'} {'|' SimpleType {'?'}}
+IntersectionSuffix = {'&' SimpleType}
+Type = SimpleType (UnionSuffix | IntersectionSuffix)
 
 GenericTypePackParameter = NAME '...'
 GenericTypeList = NAME [',' GenericTypeList] | GenericTypePackParameter {',' GenericTypePackParameter}
 
-GenericTypePackParameterWithDefault = NAME '...' ['=' (TypePack | VariadicTypePack | GenericTypePack)]
-GenericTypeListWithDefaults = NAME ['=' Type] [',' GenericTypeListWithDefaults] | GenericTypePackParameterWithDefault {',' GenericTypePackParameterWithDefault}
+GenericTypePackParameterWithDefault = NAME '...' '=' (TypePack | VariadicTypePack | GenericTypePack)
+GenericTypeListWithDefaults =
+    GenericTypeList |
+    NAME {',' NAME} {',' NAME '=' Type} {',' GenericTypePackParameterWithDefault} |
+    NAME '=' Type {',' GenericTypePackParameterWithDefault} |
+    GenericTypePackParameterWithDefault {',' GenericTypePackParameterWithDefault}
 
 TypeList = Type [',' TypeList] | '...' Type
 TypeParams = (Type | TypePack | VariadicTypePack | GenericTypePack) [',' TypeParams]

--- a/docs/_pages/grammar.md
+++ b/docs/_pages/grammar.md
@@ -63,15 +63,14 @@ SimpleType =
     NAME ['.' NAME] [ '<' [TypeParams] '>' ] |
     'typeof' '(' exp ')' |
     TableType |
-    FunctionType
+    FunctionType |
+    '(' SimpleType ')'
 
 SingletonType = STRING | 'true' | 'false'
 
-Type =
-    Type ['?'] |
-    Type ['|' Type] |
-    Type ['&' Type] |
-    '(' Type ')'
+UnionSuffix = {'?'} ['|' SimpleType]
+IntersectionSuffix = ['&' SimpleType]
+Type = SimpleType {UnionSuffix | IntersectionSuffix}
 
 GenericTypePackParameter = NAME '...'
 GenericTypeList = NAME [',' GenericTypeList] | GenericTypePackParameter {',' GenericTypePackParameter}

--- a/docs/_pages/grammar.md
+++ b/docs/_pages/grammar.md
@@ -88,6 +88,6 @@ TableIndexer = '[' Type ']' ':' Type
 TableProp = NAME ':' Type
 TablePropOrIndexer = TableProp | TableIndexer
 PropList = TablePropOrIndexer {fieldsep TablePropOrIndexer} [fieldsep]
-TableType = '{' PropList '}'
+TableType = '{' [PropList] '}'
 FunctionType = ['<' GenericTypeList '>'] '(' [TypeList] ')' '->' ReturnType
 ```

--- a/docs/_pages/grammar.md
+++ b/docs/_pages/grammar.md
@@ -68,9 +68,10 @@ SimpleType =
 SingletonType = STRING | 'true' | 'false'
 
 Type =
-    SimpleType ['?'] |
+    Type ['?'] |
     Type ['|' Type] |
-    Type ['&' Type]
+    Type ['&' Type] |
+    '(' Type ')'
 
 GenericTypePackParameter = NAME '...'
 GenericTypeList = NAME [',' GenericTypeList] | GenericTypePackParameter {',' GenericTypePackParameter}


### PR DESCRIPTION
- The type list for function declarations does not accept defaults, but the grammar incorrectly allowed this.
- Allow the empty table type `{}`
- Allow composite types and types surrounded by parentheses (e.g. `string??`, `(string)`, `(string | number) & boolean`)