### PR TITLE
Add missing include for integer types

### DIFF
--- a/Ast/include/Luau/Ast.h
+++ b/Ast/include/Luau/Ast.h
@@ -8,6 +8,7 @@
 #include <string>
 
 #include <string.h>
+#include <stdint.h>
 
 namespace Luau
 {

--- a/Ast/src/StringUtils.cpp
+++ b/Ast/src/StringUtils.cpp
@@ -7,6 +7,7 @@
 #include <vector>
 #include <string>
 #include <string.h>
+#include <stdint.h>
 
 namespace Luau
 {


### PR DESCRIPTION
Closes #924

`uintptr_t` and `uint32` (and possibly more) were undefined because `cstdint` was not included.
