### PR TITLE
Enable compile-time user configuration for LUA_VECTOR_SIZE

### DIFF
--- a/VM/include/luaconf.h
+++ b/VM/include/luaconf.h
@@ -143,6 +143,8 @@
         long l; \
     }
 
+#ifndef LUA_VECTOR_SIZE
 #define LUA_VECTOR_SIZE 3 // must be 3 or 4
+#endif
 
 #define LUA_EXTRA_SIZE (LUA_VECTOR_SIZE - 2)


### PR DESCRIPTION
Add #ifndef guard to enable users to define at compile-time without having to modify the luau source.