### PR TITLE
Add `tau` to the `math` library

### DIFF
--- a/VM/src/lmathlib.cpp
+++ b/VM/src/lmathlib.cpp
@@ -11,6 +11,9 @@
 #define PI (3.14159265358979323846)
 #define RADIANS_PER_DEGREE (PI / 180.0)
 
+#undef TAU
+#define TAU (6.28318530718)
+
 #define PCG32_INC 105
 
 static uint32_t pcg32_random(uint64_t* state)

--- a/VM/src/lmathlib.cpp
+++ b/VM/src/lmathlib.cpp
@@ -445,5 +445,7 @@ int luaopen_math(lua_State* L)
     lua_setfield(L, -2, "pi");
     lua_pushnumber(L, HUGE_VAL);
     lua_setfield(L, -2, "huge");
+    lua_pushnumber(L, TAU);
+    lua_setfield(L, -2, "tau");
     return 1;
 }


### PR DESCRIPTION
the current way of having the `tau` is like this:

```lua
local tau = math.pi * 2
```

however, it doesn’t go through all scripts

This method would make is useable in all scripts

```lua
math.tau -- math.tau = (math.pi * 2)
```

so Is there any chance this will be added?