### PR TITLE
Fix website demo's string highlighting behaviour

### DIFF
--- a/docs/assets/js/luau_mode.js
+++ b/docs/assets/js/luau_mode.js
@@ -114,7 +114,6 @@
                     break;
                 }
                 if (ch == "z" && escaped) {
-                    ignoreWhitespace = true;
                     stream.eatSpace();
                     ignoreWhitespace = stream.eol();
                 }

--- a/docs/assets/js/luau_mode.js
+++ b/docs/assets/js/luau_mode.js
@@ -108,15 +108,20 @@
   
     function string(quote) {
         return function(stream, state) {
-            var escaped = false, ch;
+            var escaped = false, ignoreWhitespace = false, ch;
             while ((ch = stream.next()) != null) {
                 if (ch == quote && !escaped) {
                     break;
                 }
+                if (ch == "z" && escaped) {
+                    ignoreWhitespace = true;
+                    stream.eatSpace();
+                    ignoreWhitespace = stream.eol();
+                }
                 escaped = !escaped && ch == "\\";
             }
 
-            if (!escaped) {
+            if (!ignoreWhitespace) {
                 state.cur = normal;
             }
             return "string";


### PR DESCRIPTION
Fixes #935:
* String literals that include `\z` escape sequence followed by newline characters are now correctly highlighted.
* Unescaped backslash (`\`) character at the end of the line no longer acts like the `\z` escape sequence inside string literals when highlighting.