### PR TITLE
Fix Arch Linux install instructions to use AUR

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ You can install and run Luau by downloading the compiled binaries from [a recent
 Alternatively, you can use one of the packaged distributions (note that these are not maintained by Luau development team):
 
 - macOS: [Install Homebrew](https://docs.brew.sh/Installation) and run `brew install luau`
-- Arch Linux: Run `pacman -S luau`
+- Arch Linux: From the AUR (Arch Linux User Repository), install one of these packages via a AUR helper or manually (by cloning their repo and using ``makepkg``): [luau](https://aur.archlinux.org/packages/luau) (manual build), [luau-git](https://aur.archlinux.org/packages/luau-git) (manual build by cloning this repo), or [luau-bin](https://aur.archlinux.org/packages/luau-bin) (pre-built binaries from releases)
 - Alpine Linux: [Enable community repositories](https://wiki.alpinelinux.org/w/index.php?title=Enable_Community_Repository) and run `apk add luau`
 
 After installing, you will want to validate the installation was successful by running the test case [here](https://luau-lang.org/getting-started).


### PR DESCRIPTION
The existing instruction is incorrect, the luau package exists on the Arch Linux User Repository (AUR), not at the official repository.

Feel free to suggest edits if something is wrong/missing, thanks!

(I also have a pkgbuild that builds every executable possible excluding tests (repl, analyze, ast, reduce), however I did not include this since releases only include repl and analyze)