### PR TITLE
Fix indexing table intersections using `x["prop"]` syntax

### DIFF
--- a/Analysis/src/TypeInfer.cpp
+++ b/Analysis/src/TypeInfer.cpp
@@ -41,6 +41,7 @@ LUAU_FASTFLAGVARIABLE(LuauTinyControlFlowAnalysis, false)
 LUAU_FASTFLAGVARIABLE(LuauTypecheckClassTypeIndexers, false)
 LUAU_FASTFLAGVARIABLE(LuauAlwaysCommitInferencesOfFunctionCalls, false)
 LUAU_FASTFLAG(LuauParseDeclareClassIndexer)
+LUAU_FASTFLAGVARIABLE(LuauIndexTableIntersectionStringExpr, false)
 
 namespace Luau
 {
@@ -3412,7 +3413,7 @@ TypeId TypeChecker::checkLValueBinding(const ScopePtr& scope, const AstExprIndex
                 return prop->type();
             }
         }
-        else if (get<IntersectionType>(exprType))
+        else if (FFlag::LuauIndexTableIntersectionStringExpr && get<IntersectionType>(exprType))
         {
             Name name = std::string(value->value.data, value->value.size);
 

--- a/Analysis/src/TypeInfer.cpp
+++ b/Analysis/src/TypeInfer.cpp
@@ -3412,6 +3412,20 @@ TypeId TypeChecker::checkLValueBinding(const ScopePtr& scope, const AstExprIndex
                 return prop->type();
             }
         }
+        else if (get<IntersectionType>(exprType))
+        {
+            Name name = std::string(value->value.data, value->value.size);
+
+            if (std::optional<TypeId> ty = getIndexTypeFromType(scope, exprType, name, expr.location, /* addErrors= */ false))
+                return *ty;
+
+            // If intersection has a table part, report that it cannot be extended just as a sealed table
+            if (isTableIntersection(exprType))
+            {
+                reportError(TypeError{expr.location, CannotExtendTable{exprType, CannotExtendTable::Property, name}});
+                return errorRecoveryType(scope);
+            }
+        }
     }
     else
     {

--- a/tests/TypeInfer.intersectionTypes.test.cpp
+++ b/tests/TypeInfer.intersectionTypes.test.cpp
@@ -880,4 +880,34 @@ TEST_CASE_FIXTURE(Fixture, "less_greedy_unification_with_intersection_types_2")
     CHECK_EQ("({| x: number |} & {| x: string |}) -> never", toString(requireType("f")));
 }
 
+TEST_CASE_FIXTURE(BuiltinsFixture, "index_property_table_intersection_1")
+{
+    CheckResult result = check(R"(
+type Foo = {
+	Bar: string,
+} & { Baz: number }
+
+local x: Foo = { Bar = "1", Baz = 2 }
+local y = x.Bar
+    )");
+
+    LUAU_REQUIRE_NO_ERRORS(result);
+}
+
+TEST_CASE_FIXTURE(BuiltinsFixture, "index_property_table_intersection_2")
+{
+    ScopedFastFlag sff{"LuauIndexTableIntersectionStringExpr", true};
+
+    CheckResult result = check(R"(
+type Foo = {
+	Bar: string,
+} & { Baz: number }
+
+local x: Foo = { Bar = "1", Baz = 2 }
+local y = x["Bar"]
+    )");
+
+    LUAU_REQUIRE_NO_ERRORS(result);
+}
+
 TEST_SUITE_END();

--- a/tests/TypeInfer.tables.test.cpp
+++ b/tests/TypeInfer.tables.test.cpp
@@ -216,9 +216,11 @@ TEST_CASE_FIXTURE(Fixture, "used_dot_instead_of_colon")
         local a = T.method()
     )");
 
-    auto it = std::find_if(result.errors.begin(), result.errors.end(), [](const TypeError& e) {
-        return nullptr != get<FunctionRequiresSelf>(e);
-    });
+    auto it = std::find_if(result.errors.begin(), result.errors.end(),
+        [](const TypeError& e)
+        {
+            return nullptr != get<FunctionRequiresSelf>(e);
+        });
     REQUIRE(it != result.errors.end());
 }
 
@@ -261,9 +263,11 @@ TEST_CASE_FIXTURE(Fixture, "used_colon_instead_of_dot")
         local a = T:method()
     )");
 
-    auto it = std::find_if(result.errors.begin(), result.errors.end(), [](const TypeError& e) {
-        return nullptr != get<FunctionDoesNotTakeSelf>(e);
-    });
+    auto it = std::find_if(result.errors.begin(), result.errors.end(),
+        [](const TypeError& e)
+        {
+            return nullptr != get<FunctionDoesNotTakeSelf>(e);
+        });
     REQUIRE(it != result.errors.end());
 }
 
@@ -3642,34 +3646,51 @@ end
     LUAU_REQUIRE_NO_ERRORS(result);
 }
 
-TEST_CASE_FIXTURE(BuiltinsFixture, "index_property_table_intersection_1")
+TEST_CASE_FIXTURE(BuiltinsFixture, "write_common_property_to_table_unions")
 {
 
     CheckResult result = check(R"(
 type Foo = {
-	Bar: string,
-} & { Baz: number }
+    Enabled: boolean,
+    Size: number,
+}
 
-local x: Foo = { Bar = "1", Baz = 2 }
-local y = x.Bar
+type Bar = {
+    Enabled: boolean,
+    Width: number,
+    Height: number,
+}
+
+local x: Foo | Bar = { Enabled = true, Size = 5 }
+
+x.Enabled = false
     )");
 
     LUAU_REQUIRE_NO_ERRORS(result);
 }
 
-TEST_CASE_FIXTURE(BuiltinsFixture, "index_property_table_intersection_2")
+TEST_CASE_FIXTURE(BuiltinsFixture, "write_common_property_to_table_unions_2")
 {
 
     CheckResult result = check(R"(
 type Foo = {
-	Bar: string,
-} & { Baz: number }
+    Enabled: boolean,
+    Size: number,
+}
 
-local x: Foo = { Bar = "1", Baz = 2 }
-local y = x["Bar"]
+type Bar = {
+    Enabled: boolean,
+    Width: number,
+    Height: number,
+}
+
+local x: Foo | Bar = { Enabled = true, Size = 5 }
+
+x.Size = 6
     )");
 
-    LUAU_REQUIRE_NO_ERRORS(result);
+    LUAU_REQUIRE_ERROR_COUNT(1, result);
+    CHECK_EQ("error", toString(result.errors[0])); // TODO
 }
 
 TEST_SUITE_END();

--- a/tests/TypeInfer.tables.test.cpp
+++ b/tests/TypeInfer.tables.test.cpp
@@ -216,11 +216,9 @@ TEST_CASE_FIXTURE(Fixture, "used_dot_instead_of_colon")
         local a = T.method()
     )");
 
-    auto it = std::find_if(result.errors.begin(), result.errors.end(),
-        [](const TypeError& e)
-        {
-            return nullptr != get<FunctionRequiresSelf>(e);
-        });
+    auto it = std::find_if(result.errors.begin(), result.errors.end(), [](const TypeError& e) {
+        return nullptr != get<FunctionRequiresSelf>(e);
+    });
     REQUIRE(it != result.errors.end());
 }
 
@@ -263,11 +261,9 @@ TEST_CASE_FIXTURE(Fixture, "used_colon_instead_of_dot")
         local a = T:method()
     )");
 
-    auto it = std::find_if(result.errors.begin(), result.errors.end(),
-        [](const TypeError& e)
-        {
-            return nullptr != get<FunctionDoesNotTakeSelf>(e);
-        });
+    auto it = std::find_if(result.errors.begin(), result.errors.end(), [](const TypeError& e) {
+        return nullptr != get<FunctionDoesNotTakeSelf>(e);
+    });
     REQUIRE(it != result.errors.end());
 }
 
@@ -3646,51 +3642,34 @@ end
     LUAU_REQUIRE_NO_ERRORS(result);
 }
 
-TEST_CASE_FIXTURE(BuiltinsFixture, "write_common_property_to_table_unions")
+TEST_CASE_FIXTURE(BuiltinsFixture, "index_property_table_intersection_1")
 {
 
     CheckResult result = check(R"(
 type Foo = {
-    Enabled: boolean,
-    Size: number,
-}
+	Bar: string,
+} & { Baz: number }
 
-type Bar = {
-    Enabled: boolean,
-    Width: number,
-    Height: number,
-}
-
-local x: Foo | Bar = { Enabled = true, Size = 5 }
-
-x.Enabled = false
+local x: Foo = { Bar = "1", Baz = 2 }
+local y = x.Bar
     )");
 
     LUAU_REQUIRE_NO_ERRORS(result);
 }
 
-TEST_CASE_FIXTURE(BuiltinsFixture, "write_common_property_to_table_unions_2")
+TEST_CASE_FIXTURE(BuiltinsFixture, "index_property_table_intersection_2")
 {
 
     CheckResult result = check(R"(
 type Foo = {
-    Enabled: boolean,
-    Size: number,
-}
+	Bar: string,
+} & { Baz: number }
 
-type Bar = {
-    Enabled: boolean,
-    Width: number,
-    Height: number,
-}
-
-local x: Foo | Bar = { Enabled = true, Size = 5 }
-
-x.Size = 6
+local x: Foo = { Bar = "1", Baz = 2 }
+local y = x["Bar"]
     )");
 
-    LUAU_REQUIRE_ERROR_COUNT(1, result);
-    CHECK_EQ("error", toString(result.errors[0])); // TODO
+    LUAU_REQUIRE_NO_ERRORS(result);
 }
 
 TEST_SUITE_END();

--- a/tests/TypeInfer.tables.test.cpp
+++ b/tests/TypeInfer.tables.test.cpp
@@ -3642,34 +3642,4 @@ end
     LUAU_REQUIRE_NO_ERRORS(result);
 }
 
-TEST_CASE_FIXTURE(BuiltinsFixture, "index_property_table_intersection_1")
-{
-
-    CheckResult result = check(R"(
-type Foo = {
-	Bar: string,
-} & { Baz: number }
-
-local x: Foo = { Bar = "1", Baz = 2 }
-local y = x.Bar
-    )");
-
-    LUAU_REQUIRE_NO_ERRORS(result);
-}
-
-TEST_CASE_FIXTURE(BuiltinsFixture, "index_property_table_intersection_2")
-{
-
-    CheckResult result = check(R"(
-type Foo = {
-	Bar: string,
-} & { Baz: number }
-
-local x: Foo = { Bar = "1", Baz = 2 }
-local y = x["Bar"]
-    )");
-
-    LUAU_REQUIRE_NO_ERRORS(result);
-}
-
 TEST_SUITE_END();

--- a/tests/TypeInfer.tables.test.cpp
+++ b/tests/TypeInfer.tables.test.cpp
@@ -3642,4 +3642,34 @@ end
     LUAU_REQUIRE_NO_ERRORS(result);
 }
 
+TEST_CASE_FIXTURE(BuiltinsFixture, "write_common_property_to_table_intersection_1")
+{
+
+    CheckResult result = check(R"(
+type Foo = {
+	Bar: string,
+} & { Baz: number }
+
+local x: Foo = { Bar = "1", Baz = 2 }
+local y = x.Bar
+    )");
+
+    LUAU_REQUIRE_NO_ERRORS(result);
+}
+
+TEST_CASE_FIXTURE(BuiltinsFixture, "write_common_property_to_table_intersection_2")
+{
+
+    CheckResult result = check(R"(
+type Foo = {
+	Bar: string,
+} & { Baz: number }
+
+local x: Foo = { Bar = "1", Baz = 2 }
+local y = x["Bar"]
+    )");
+
+    LUAU_REQUIRE_NO_ERRORS(result);
+}
+
 TEST_SUITE_END();

--- a/tests/TypeInfer.tables.test.cpp
+++ b/tests/TypeInfer.tables.test.cpp
@@ -3642,7 +3642,7 @@ end
     LUAU_REQUIRE_NO_ERRORS(result);
 }
 
-TEST_CASE_FIXTURE(BuiltinsFixture, "write_common_property_to_table_intersection_1")
+TEST_CASE_FIXTURE(BuiltinsFixture, "write_property_to_table_intersection_1")
 {
 
     CheckResult result = check(R"(
@@ -3657,7 +3657,7 @@ local y = x.Bar
     LUAU_REQUIRE_NO_ERRORS(result);
 }
 
-TEST_CASE_FIXTURE(BuiltinsFixture, "write_common_property_to_table_intersection_2")
+TEST_CASE_FIXTURE(BuiltinsFixture, "write_property_to_table_intersection_2")
 {
 
     CheckResult result = check(R"(

--- a/tests/TypeInfer.tables.test.cpp
+++ b/tests/TypeInfer.tables.test.cpp
@@ -3642,7 +3642,7 @@ end
     LUAU_REQUIRE_NO_ERRORS(result);
 }
 
-TEST_CASE_FIXTURE(BuiltinsFixture, "write_property_to_table_intersection_1")
+TEST_CASE_FIXTURE(BuiltinsFixture, "index_property_table_intersection_1")
 {
 
     CheckResult result = check(R"(
@@ -3657,7 +3657,7 @@ local y = x.Bar
     LUAU_REQUIRE_NO_ERRORS(result);
 }
 
-TEST_CASE_FIXTURE(BuiltinsFixture, "write_property_to_table_intersection_2")
+TEST_CASE_FIXTURE(BuiltinsFixture, "index_property_table_intersection_2")
 {
 
     CheckResult result = check(R"(


### PR DESCRIPTION
Right now, you can index an intersection of tables fine when using `x.prop` syntax, but not when using `x["prop"]` syntax.
This fixes it for the latter case

```lua
type Foo = {
	Bar: string,
} & { Baz: number }

local x: Foo = { Bar = "1", Baz = 2 }
local y = x["Bar"] -- TypeError: Expected type table, got '{| Bar: string |} & {| Baz: number |}' instead
```

Part of a fix to https://github.com/Roblox/luau/issues/533#issuecomment-1291779353