### PR TITLE
Fix some EBNF cases in grammar.md

### DIFF
--- a/docs/_pages/grammar.md
+++ b/docs/_pages/grammar.md
@@ -28,7 +28,7 @@ laststat = 'return' [explist] | 'break' | 'continue'
 
 funcname = NAME {'.' NAME} [':' NAME]
 funcbody = ['<' GenericTypeList '>'] '(' [parlist] ')' [':' ReturnType] block 'end'
-parlist = bindinglist [',' '...'] | '...' [':' GenericTypePack]
+parlist = bindinglist [',' '...'] | '...' [':' (Type | GenericTypePack)]
 
 explist = {exp ','} exp
 namelist = NAME {',' NAME}
@@ -93,6 +93,6 @@ TableIndexer = '[' Type ']' ':' Type
 TableProp = NAME ':' Type
 TablePropOrIndexer = TableProp | TableIndexer
 PropList = TablePropOrIndexer {fieldsep TablePropOrIndexer} [fieldsep]
-TableType = '{' [(PropList | Type)] '}'
+TableType = '{' Type '}' | '{' [PropList] '}'
 FunctionType = ['<' GenericTypeList '>'] '(' [BoundTypeList] ')' '->' ReturnType
 ```

--- a/docs/_pages/grammar.md
+++ b/docs/_pages/grammar.md
@@ -28,7 +28,7 @@ laststat = 'return' [explist] | 'break' | 'continue'
 
 funcname = NAME {'.' NAME} [':' NAME]
 funcbody = ['<' GenericTypeList '>'] '(' [parlist] ')' [':' ReturnType] block 'end'
-parlist = bindinglist [',' '...'] | '...'
+parlist = bindinglist [',' '...'] | '...' [':' GenericTypePack]
 
 explist = {exp ','} exp
 namelist = NAME {',' NAME}

--- a/docs/_pages/grammar.md
+++ b/docs/_pages/grammar.md
@@ -83,6 +83,7 @@ GenericTypeListWithDefaults =
     GenericTypePackParameterWithDefault {',' GenericTypePackParameterWithDefault}
 
 TypeList = Type [',' TypeList] | '...' Type
+BoundTypeList = [NAME ':'] Type [',' BoundTypeList] | '...' Type
 TypeParams = (Type | TypePack | VariadicTypePack | GenericTypePack) [',' TypeParams]
 TypePack = '(' [TypeList] ')'
 GenericTypePack = NAME '...'
@@ -93,5 +94,5 @@ TableProp = NAME ':' Type
 TablePropOrIndexer = TableProp | TableIndexer
 PropList = TablePropOrIndexer {fieldsep TablePropOrIndexer} [fieldsep]
 TableType = '{' [PropList] '}'
-FunctionType = ['<' GenericTypeList '>'] '(' [TypeList] ')' '->' ReturnType
+FunctionType = ['<' GenericTypeList '>'] '(' [BoundTypeList] ')' '->' ReturnType
 ```

--- a/docs/_pages/grammar.md
+++ b/docs/_pages/grammar.md
@@ -93,6 +93,6 @@ TableIndexer = '[' Type ']' ':' Type
 TableProp = NAME ':' Type
 TablePropOrIndexer = TableProp | TableIndexer
 PropList = TablePropOrIndexer {fieldsep TablePropOrIndexer} [fieldsep]
-TableType = '{' [PropList] '}'
+TableType = '{' [(PropList | Type)] '}'
 FunctionType = ['<' GenericTypeList '>'] '(' [BoundTypeList] ')' '->' ReturnType
 ```


### PR DESCRIPTION
I added some cases that were missing in the grammar.md
I'm pretty confident about all of them except for:
```ebnf
parlist = bindinglist [',' '...'] | '...' [':' GenericTypePack]
```
Can there be more than just GenericTypePack? I think `(Type | GenericTypePack)` may be the right one here.