### PR TITLE
Use `const char* const*` over `const char**`

### DIFF
--- a/Compiler/include/Luau/Compiler.h
+++ b/Compiler/include/Luau/Compiler.h
@@ -39,7 +39,7 @@ struct CompileOptions
     const char* vectorType = nullptr;
 
     // null-terminated array of globals that are mutable; disables the import optimization for fields accessed through these
-    const char** mutableGlobals = nullptr;
+    const char* const* mutableGlobals = nullptr;
 };
 
 class CompileError : public std::exception

--- a/Compiler/include/luacode.h
+++ b/Compiler/include/luacode.h
@@ -35,7 +35,7 @@ struct lua_CompileOptions
     const char* vectorType;
 
     // null-terminated array of globals that are mutable; disables the import optimization for fields accessed through these
-    const char** mutableGlobals;
+    const char* const* mutableGlobals;
 };
 
 // compile source to bytecode; when source compilation fails, the resulting bytecode contains the encoded error. use free() to destroy

--- a/Compiler/src/ValueTracking.cpp
+++ b/Compiler/src/ValueTracking.cpp
@@ -82,13 +82,13 @@ struct ValueVisitor : AstVisitor
     }
 };
 
-void assignMutable(DenseHashMap<AstName, Global>& globals, const AstNameTable& names, const char** mutableGlobals)
+void assignMutable(DenseHashMap<AstName, Global>& globals, const AstNameTable& names, const char* const* mutableGlobals)
 {
     if (AstName name = names.get("_G"); name.value)
         globals[name] = Global::Mutable;
 
     if (mutableGlobals)
-        for (const char** ptr = mutableGlobals; *ptr; ++ptr)
+        for (const char* const* ptr = mutableGlobals; *ptr; ++ptr)
             if (AstName name = names.get(*ptr); name.value)
                 globals[name] = Global::Mutable;
 }

--- a/Compiler/src/ValueTracking.h
+++ b/Compiler/src/ValueTracking.h
@@ -28,7 +28,7 @@ struct Variable
     bool constant = false;   // is the variable's value a compile-time constant? filled by constantFold
 };
 
-void assignMutable(DenseHashMap<AstName, Global>& globals, const AstNameTable& names, const char** mutableGlobals);
+void assignMutable(DenseHashMap<AstName, Global>& globals, const AstNameTable& names, const char* const* mutableGlobals);
 void trackValues(DenseHashMap<AstName, Global>& globals, DenseHashMap<AstLocal*, Variable>& variables, AstNode* root);
 
 inline Global getGlobalState(const DenseHashMap<AstName, Global>& globals, AstName name)

--- a/tests/Compiler.test.cpp
+++ b/tests/Compiler.test.cpp
@@ -4213,7 +4213,7 @@ RETURN R0 0
     bcb.setDumpFlags(Luau::BytecodeBuilder::Dump_Code);
     Luau::CompileOptions options;
     const char* mutableGlobals[] = {"Game", "Workspace", "game", "plugin", "script", "shared", "workspace", NULL};
-    options.mutableGlobals = &mutableGlobals[0];
+    options.mutableGlobals = mutableGlobals;
     Luau::compileOrThrow(bcb, source, options);
 
     CHECK_EQ("\n" + bcb.dumpFunction(0), R"(


### PR DESCRIPTION
The FFI difference becomes significant in languages like Rust where you can't necessarily just cast a const pointer.