### PR TITLE
LinterConfig.h: add missing stdint.h include

### DIFF
--- a/Analysis/include/Luau/LinterConfig.h
+++ b/Analysis/include/Luau/LinterConfig.h
@@ -5,6 +5,7 @@
 
 #include <string>
 #include <vector>
+#include <stdint.h>
 
 namespace Luau
 {


### PR DESCRIPTION
Without stdint.h following is raised while trying to build luau:

```
In file included from /home/xy/source/public/github.com/Roblox/luau/Analysis/include/Luau/Config.h:4,
                 from /home/xy/source/public/github.com/Roblox/luau/Analysis/src/Config.cpp:2:
/home/xy/source/public/github.com/Roblox/luau/Analysis/include/Luau/LinterConfig.h:60:12: error: ‘uint64_t’ does not name a type
   60 |     static uint64_t parseMask(const std::vector<HotComment>& hotcomments);
      |            ^~~~~~~~
/home/xy/source/public/github.com/Roblox/luau/Analysis/include/Luau/LinterConfig.h:8:1: note: ‘uint64_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
    7 | #include <vector>
  +++ |+#include <cstdint>
    8 | 
/home/xy/source/public/github.com/Roblox/luau/Analysis/include/Luau/LinterConfig.h:65:5: error: ‘uint64_t’ does not name a type
   65 |     uint64_t warningMask = 0;
      |     ^~~~~~~~
/home/xy/source/public/github.com/Roblox/luau/Analysis/include/Luau/LinterConfig.h:65:5: note: ‘uint64_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
/home/xy/source/public/github.com/Roblox/luau/Analysis/include/Luau/LinterConfig.h: In member function ‘void Luau::LintOptions::enableWarning(Luau::LintWarning::Code)’:
/home/xy/source/public/github.com/Roblox/luau/Analysis/include/Luau/LinterConfig.h:69:9: error: ‘warningMask’ was not declared in this scope
   69 |         warningMask |= 1ull << code;
      |         ^~~~~~~~~~~
/home/xy/source/public/github.com/Roblox/luau/Analysis/include/Luau/LinterConfig.h: In member function ‘void Luau::LintOptions::disableWarning(Luau::LintWarning::Code)’:
/home/xy/source/public/github.com/Roblox/luau/Analysis/include/Luau/LinterConfig.h:73:9: error: ‘warningMask’ was not declared in this scope
   73 |         warningMask &= ~(1ull << code);
      |         ^~~~~~~~~~~
/home/xy/source/public/github.com/Roblox/luau/Analysis/include/Luau/LinterConfig.h: In member function ‘bool Luau::LintOptions::isEnabled(Luau::LintWarning::Code) const’:
/home/xy/source/public/github.com/Roblox/luau/Analysis/include/Luau/LinterConfig.h:78:22: error: ‘warningMask’ was not declared in this scope
   78 |         return 0 != (warningMask & (1ull << code));
      |                      ^~~~~~~~~~~
[ 23%] Building CXX object CMakeFiles/Luau.Analysis.dir/Analysis/src/ConstraintGraphBuilder.cpp.o
make[2]: *** [CMakeFiles/Luau.Analysis.dir/build.make:174: CMakeFiles/Luau.Analysis.dir/Analysis/src/
```