### PR TITLE
fix build & test conformance issues on mingw32/gcc and mingw64/clang

### DIFF
--- a/CLI/Reduce.cpp
+++ b/CLI/Reduce.cpp
@@ -15,7 +15,7 @@
 
 #define VERBOSE 0 // 1 - print out commandline invocations.  2 - print out stdout
 
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(__MINGW32__)
 
 const auto popen = &_popen;
 const auto pclose = &_pclose;

--- a/VM/src/lmem.cpp
+++ b/VM/src/lmem.cpp
@@ -98,6 +98,8 @@
  */
 #if defined(__APPLE__)
 #define ABISWITCH(x64, ms32, gcc32) (sizeof(void*) == 8 ? x64 : gcc32)
+#elif defined(__i386__) && defined(__MINGW32__) && !defined(__MINGW64__)
+#define ABISWITCH(x64, ms32, gcc32) (ms32)
 #elif defined(__i386__) && !defined(_MSC_VER)
 #define ABISWITCH(x64, ms32, gcc32) (gcc32)
 #else

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -13,7 +13,7 @@
 #ifndef NOMINMAX
 #define NOMINMAX
 #endif
-#include <Windows.h> // IsDebuggerPresent, CreateThread
+#include <Windows.h> // IsDebuggerPresent
 #endif
 
 #ifdef __APPLE__
@@ -249,22 +249,6 @@ static void setFastFlags(const std::vector<doctest::String>& flags)
     }
 }
 
-#if defined(_WIN32)
-struct thrdarg
-{
-    int* result;
-    doctest::Context* ctx;
-};
-
-DWORD WINAPI testthreadproc(LPVOID param)
-{
-    auto threadresult = ((thrdarg*)param)->result;
-    auto context = ((thrdarg*)param)->ctx;
-    *threadresult = context->run();
-    return 0;
-}
-#endif
-
 int main(int argc, char** argv)
 {
     Luau::assertHandler() = testAssertionHandler;
@@ -343,16 +327,7 @@ int main(int argc, char** argv)
         }
     }
 
-#if !defined(_WIN32)
     int result = context.run();
-#else
-    int result;
-    thrdarg args;
-    args.result = &result;
-    args.ctx = &context;
-    HANDLE testthread = CreateThread(NULL, 0x400000, testthreadproc, &args, 0, NULL);
-    WaitForSingleObject(testthread, INFINITE);
-#endif
     if (doctest::parseFlag(argc, argv, "--help") || doctest::parseFlag(argc, argv, "-h"))
     {
         printf("Additional command line options:\n");


### PR DESCRIPTION
~~tests/main.cpp:
Add Windows-only code for running test contexts under a thread with enough stack space regardless of the build settings of the compiler. GCC/Clang/MSVC settings for stack size are wildly varied and this is a catch all solution instead. This only failed on mingw64/clang. mingw32/gcc and mingw64/gcc continued working without this change.~~

CLI/Reduce.cpp:
Never worked under MinGW as-is. Add check for MinGW as they're defined.

VM/src/lmem.cpp:
MinGW layout follows more closely MSVC. Checks before were only correct for 32-bit gcc / clang in non-Windows.

NOTES:
__MINGW32__ is defined on both 32-bit and 64-bit, __MINGW64__ is 64-bit only. 32-bit MinGW compilers (both Clang & GCC) have a floating point test error on math.noise, specifically math.lua:258. All other test cases / unit tests pass. Math begins deviating at `perlin_fade`.