### PR TITLE
Add `lua_getallocf` api function

### DIFF
--- a/VM/include/lua.h
+++ b/VM/include/lua.h
@@ -324,7 +324,6 @@ LUA_API void lua_clonefunction(lua_State* L, int idx);
 LUA_API void lua_cleartable(lua_State* L, int idx);
 
 LUA_API lua_Alloc lua_getallocf(lua_State* L, void** ud);
-LUA_API void lua_setallocf(lua_State* L, lua_Alloc f, void* ud);
 
 /*
 ** reference system, can be used to pin objects

--- a/VM/include/lua.h
+++ b/VM/include/lua.h
@@ -323,6 +323,9 @@ LUA_API void lua_clonefunction(lua_State* L, int idx);
 
 LUA_API void lua_cleartable(lua_State* L, int idx);
 
+LUA_API lua_Alloc lua_getallocf(lua_State* L, void** ud);
+LUA_API void lua_setallocf(lua_State* L, lua_Alloc f, void* ud);
+
 /*
 ** reference system, can be used to pin objects
 */

--- a/VM/src/lapi.cpp
+++ b/VM/src/lapi.cpp
@@ -1440,9 +1440,3 @@ lua_Alloc lua_getallocf(lua_State* L, void** ud)
         *ud = L->global->ud;
     return f;
 }
-
-void lua_setallocf(lua_State* L, lua_Alloc f, void* ud)
-{
-    L->global->frealloc = f;
-    L->global->ud = ud;
-}

--- a/VM/src/lapi.cpp
+++ b/VM/src/lapi.cpp
@@ -1432,3 +1432,17 @@ size_t lua_totalbytes(lua_State* L, int category)
     api_check(L, category < LUA_MEMORY_CATEGORIES);
     return category < 0 ? L->global->totalbytes : L->global->memcatbytes[category];
 }
+
+lua_Alloc lua_getallocf(lua_State* L, void** ud)
+{
+    lua_Alloc f = L->global->frealloc;
+    if (ud)
+        *ud = L->global->ud;
+    return f;
+}
+
+void lua_setallocf(lua_State* L, lua_Alloc f, void* ud)
+{
+    L->global->frealloc = f;
+    L->global->ud = ud;
+}

--- a/tests/Conformance.test.cpp
+++ b/tests/Conformance.test.cpp
@@ -1169,10 +1169,10 @@ TEST_CASE("AllocApi")
     StateRef globalState(lua_newstate(limitedRealloc, &ud), lua_close);
     lua_State* L = globalState.get();
 
-    void* ud_check = nullptr;
-    bool allocfIsSet = lua_getallocf(L, &ud_check) == limitedRealloc;
+    void* udCheck = nullptr;
+    bool allocfIsSet = lua_getallocf(L, &udCheck) == limitedRealloc;
     CHECK(allocfIsSet);
-    CHECK(ud_check == &ud);
+    CHECK(udCheck == &ud);
 }
 
 #if !LUA_USE_LONGJMP

--- a/tests/Conformance.test.cpp
+++ b/tests/Conformance.test.cpp
@@ -1173,16 +1173,6 @@ TEST_CASE("AllocApi")
     bool allocfIsSet = lua_getallocf(L, &ud_check) == limitedRealloc;
     CHECK(allocfIsSet);
     CHECK(ud_check == &ud);
-
-    auto limitedReallocAlt = [](void* ud, void* ptr, size_t osize, size_t nsize) -> void* {
-        return limitedRealloc(ud, ptr, osize, nsize);
-    };
-
-    int ud2 = 0;
-    lua_setallocf(L, limitedReallocAlt, &ud2);
-    allocfIsSet = lua_getallocf(L, &ud_check) == limitedReallocAlt;
-    CHECK(allocfIsSet);
-    CHECK(ud_check == &ud2);
 }
 
 #if !LUA_USE_LONGJMP


### PR DESCRIPTION
These functions match with the corresponding Lua 5.1-5.4 functions:
[`lua_getallocf`](https://www.lua.org/manual/5.4/manual.html#lua_getallocf) and [source](https://www.lua.org/source/5.4/lapi.c.html#lua_getallocf)
~[`lua_setallocf`](https://www.lua.org/manual/5.4/manual.html#lua_setallocf) and [source](https://www.lua.org/source/5.4/lapi.c.html#lua_setallocf)~

In my case they would be useful to getting/manipulating auxiliary "userdata" pointer passed to allocator.
