### PR TITLE
Implement bit32.byteswap

### DIFF
--- a/Analysis/src/EmbeddedBuiltinDefinitions.cpp
+++ b/Analysis/src/EmbeddedBuiltinDefinitions.cpp
@@ -21,6 +21,7 @@ declare bit32: {
     replace: (n: number, v: number, field: number, width: number?) -> number,
     countlz: (n: number) -> number,
     countrz: (n: number) -> number,
+    byteswap: (n: number) -> number,
 }
 
 declare math: {

--- a/CodeGen/src/OptimizeConstProp.cpp
+++ b/CodeGen/src/OptimizeConstProp.cpp
@@ -504,6 +504,7 @@ static void handleBuiltinEffects(ConstPropState& state, LuauBuiltinFunction bfid
     case LBF_GETMETATABLE:
     case LBF_TONUMBER:
     case LBF_TOSTRING:
+    case LBF_BIT32_BYTESWAP:
         break;
     case LBF_TABLE_INSERT:
         state.invalidateHeap();

--- a/Common/include/Luau/Bytecode.h
+++ b/Common/include/Luau/Bytecode.h
@@ -560,6 +560,9 @@ enum LuauBuiltinFunction
     // tonumber/tostring
     LBF_TONUMBER,
     LBF_TOSTRING,
+
+    // bit32.byteswap(n)
+    LBF_BIT32_BYTESWAP,
 };
 
 // Capture type, used in LOP_CAPTURE

--- a/Compiler/src/Builtins.cpp
+++ b/Compiler/src/Builtins.cpp
@@ -4,7 +4,7 @@
 #include "Luau/Bytecode.h"
 #include "Luau/Compiler.h"
 
-LUAU_FASTFLAG(LuauBit32ByteswapBuiltin)
+LUAU_FASTFLAGVARIABLE(LuauBit32ByteswapBuiltin, true)
 
 namespace Luau
 {
@@ -168,11 +168,8 @@ static int getBuiltinFunctionId(const Builtin& builtin, const CompileOptions& op
             return LBF_BIT32_COUNTLZ;
         if (builtin.method == "countrz")
             return LBF_BIT32_COUNTRZ;
-        if (builtin.method == "byteswap")
-        {
-            LUAU_ASSERT(FFlag::LuauBit32ByteswapBuiltin);
+        if (FFlag::LuauBit32ByteswapBuiltin && builtin.method == "byteswap")
             return LBF_BIT32_BYTESWAP;
-        }
     }
 
     if (builtin.object == "string")

--- a/Compiler/src/Builtins.cpp
+++ b/Compiler/src/Builtins.cpp
@@ -4,7 +4,7 @@
 #include "Luau/Bytecode.h"
 #include "Luau/Compiler.h"
 
-LUAU_FASTFLAGVARIABLE(LuauBit32ByteswapBuiltin, true)
+LUAU_FASTFLAGVARIABLE(LuauBit32ByteswapBuiltin, false)
 
 namespace Luau
 {

--- a/Compiler/src/Builtins.cpp
+++ b/Compiler/src/Builtins.cpp
@@ -4,6 +4,8 @@
 #include "Luau/Bytecode.h"
 #include "Luau/Compiler.h"
 
+LUAU_FASTFLAG(LuauBit32ByteswapBuiltin)
+
 namespace Luau
 {
 namespace Compile
@@ -166,6 +168,11 @@ static int getBuiltinFunctionId(const Builtin& builtin, const CompileOptions& op
             return LBF_BIT32_COUNTLZ;
         if (builtin.method == "countrz")
             return LBF_BIT32_COUNTRZ;
+        if (builtin.method == "byteswap")
+        {
+            LUAU_ASSERT(FFlag::LuauBit32ByteswapBuiltin);
+            return LBF_BIT32_BYTESWAP;
+        }
     }
 
     if (builtin.object == "string")
@@ -402,6 +409,9 @@ BuiltinInfo getBuiltinInfo(int bfid)
 
     case LBF_TOSTRING:
         return {1, 1};
+
+    case LBF_BIT32_BYTESWAP:
+        return {1, 1, BuiltinInfo::Flag_NoneSafe};
     };
 
     LUAU_UNREACHABLE();

--- a/VM/src/lbitlib.cpp
+++ b/VM/src/lbitlib.cpp
@@ -5,7 +5,7 @@
 #include "lcommon.h"
 #include "lnumutils.h"
 
-LUAU_FASTFLAG(LuauBit32Byteswap)
+LUAU_FASTFLAGVARIABLE(LuauBit32Byteswap, true)
 
 #define ALLONES ~0u
 #define NBITS int(8 * sizeof(unsigned))
@@ -214,9 +214,11 @@ static int b_countrz(lua_State* L)
 
 static int b_swap(lua_State* L)
 {
-    LUAU_ASSERT(FFlag::LuauBit32Byteswap);
+    if (!FFlag::LuauBit32Byteswap)
+        luaL_error(L, "bit32.byteswap isn't enabled");
+
     b_uint n = luaL_checkunsigned(L, 1);
-    n = ((n >> 24) & 0xff) | ((n << 8) & 0xff0000) | ((n >> 8) & 0xff00) | ((n << 24) & 0xff000000);
+    n = (n << 24) | ((n << 8) & 0xff0000) | (n >> 8 & 0xff00) | n >> 24;
 
     lua_pushunsigned(L, n);
     return 1;

--- a/VM/src/lbitlib.cpp
+++ b/VM/src/lbitlib.cpp
@@ -218,7 +218,7 @@ static int b_swap(lua_State* L)
         luaL_error(L, "bit32.byteswap isn't enabled");
 
     b_uint n = luaL_checkunsigned(L, 1);
-    n = (n << 24) | ((n << 8) & 0xff0000) | (n >> 8 & 0xff00) | n >> 24;
+    n = (n << 24) | ((n << 8) & 0xff0000) | ((n >> 8) & 0xff00) | (n >> 24);
 
     lua_pushunsigned(L, n);
     return 1;

--- a/VM/src/lbitlib.cpp
+++ b/VM/src/lbitlib.cpp
@@ -5,7 +5,7 @@
 #include "lcommon.h"
 #include "lnumutils.h"
 
-LUAU_FASTFLAGVARIABLE(LuauBit32Byteswap, true)
+LUAU_FASTFLAGVARIABLE(LuauBit32Byteswap, false)
 
 #define ALLONES ~0u
 #define NBITS int(8 * sizeof(unsigned))

--- a/VM/src/lbitlib.cpp
+++ b/VM/src/lbitlib.cpp
@@ -5,6 +5,8 @@
 #include "lcommon.h"
 #include "lnumutils.h"
 
+LUAU_FASTFLAG(LuauBit32Byteswap)
+
 #define ALLONES ~0u
 #define NBITS int(8 * sizeof(unsigned))
 
@@ -210,6 +212,16 @@ static int b_countrz(lua_State* L)
     return 1;
 }
 
+static int b_swap(lua_State* L)
+{
+    LUAU_ASSERT(FFlag::LuauBit32Byteswap);
+    b_uint n = luaL_checkunsigned(L, 1);
+    n = ((n >> 24) & 0xff) | ((n << 8) & 0xff0000) | ((n >> 8) & 0xff00) | ((n << 24) & 0xff000000);
+
+    lua_pushunsigned(L, n);
+    return 1;
+}
+
 static const luaL_Reg bitlib[] = {
     {"arshift", b_arshift},
     {"band", b_and},
@@ -225,6 +237,7 @@ static const luaL_Reg bitlib[] = {
     {"rshift", b_rshift},
     {"countlz", b_countlz},
     {"countrz", b_countrz},
+    {"byteswap", b_swap},
     {NULL, NULL},
 };
 

--- a/VM/src/lbuiltins.cpp
+++ b/VM/src/lbuiltins.cpp
@@ -1326,7 +1326,8 @@ static int luauF_byteswap(lua_State* L, StkId res, TValue* arg0, int nresults, S
         double a1 = nvalue(arg0);
         unsigned n;
         luai_num2unsigned(n, a1);
-        n = (n << 24) | ((n << 8) & 0xff0000) | (n >> 8 & 0xff00) | n >> 24;
+
+        n = (n << 24) | ((n << 8) & 0xff0000) | ((n >> 8) & 0xff00) | (n >> 24);
 
         setnvalue(res, double(n));
         return 1;

--- a/VM/src/lbuiltins.cpp
+++ b/VM/src/lbuiltins.cpp
@@ -1319,6 +1319,21 @@ static int luauF_tostring(lua_State* L, StkId res, TValue* arg0, int nresults, S
     return -1;
 }
 
+static int luauF_byteswap(lua_State* L, StkId res, TValue* arg0, int nresults, StkId args, int nparams)
+{
+    if (nparams >= 1 && nresults <= 1 && ttisnumber(arg0))
+    {
+        double a1 = nvalue(arg0);
+        unsigned n;
+        luai_num2unsigned(n, a1);
+
+        setnvalue(res, double(((n >> 24) & 0xff) | ((n << 8) & 0xff0000) | ((n >> 8) & 0xff00) | ((n << 24) & 0xff000000)));
+        return 1;
+    }
+
+    return -1;
+}
+
 static int luauF_missing(lua_State* L, StkId res, TValue* arg0, int nresults, StkId args, int nparams)
 {
     return -1;
@@ -1485,6 +1500,8 @@ const luau_FastFunction luauF_table[256] = {
 
     luauF_tonumber,
     luauF_tostring,
+
+    luauF_byteswap,
 
 // When adding builtins, add them above this line; what follows is 64 "dummy" entries with luauF_missing fallback.
 // This is important so that older versions of the runtime that don't support newer builtins automatically fall back via luauF_missing.

--- a/VM/src/lbuiltins.cpp
+++ b/VM/src/lbuiltins.cpp
@@ -1326,8 +1326,9 @@ static int luauF_byteswap(lua_State* L, StkId res, TValue* arg0, int nresults, S
         double a1 = nvalue(arg0);
         unsigned n;
         luai_num2unsigned(n, a1);
+        n = (n << 24) | ((n << 8) & 0xff0000) | (n >> 8 & 0xff00) | n >> 24;
 
-        setnvalue(res, double(((n >> 24) & 0xff) | ((n << 8) & 0xff0000) | ((n >> 8) & 0xff00) | ((n << 24) & 0xff000000)));
+        setnvalue(res, double(n));
         return 1;
     }
 

--- a/docs/_pages/library.md
+++ b/docs/_pages/library.md
@@ -728,6 +728,12 @@ function bit32.countrz(n: number): number
 
 Returns the number of consecutive zero bits in the 32-bit representation of `n` starting from the right-most (least significant) bit. Returns 32 if `n` is zero.
 
+```
+function bit32.byteswap(n: number): number
+```
+
+Returns `n` with the order of the bytes swappped.
+
 ## utf8 library
 
 Strings in Luau can contain arbitrary bytes; however, in many applications strings representing text contain UTF8 encoded data by convention, that can be inspected and manipulated using `utf8` library.

--- a/docs/_pages/library.md
+++ b/docs/_pages/library.md
@@ -728,12 +728,6 @@ function bit32.countrz(n: number): number
 
 Returns the number of consecutive zero bits in the 32-bit representation of `n` starting from the right-most (least significant) bit. Returns 32 if `n` is zero.
 
-```
-function bit32.byteswap(n: number): number
-```
-
-Returns `n` with the order of the bytes swappped.
-
 ## utf8 library
 
 Strings in Luau can contain arbitrary bytes; however, in many applications strings representing text contain UTF8 encoded data by convention, that can be inspected and manipulated using `utf8` library.

--- a/tests/Conformance.test.cpp
+++ b/tests/Conformance.test.cpp
@@ -407,6 +407,7 @@ TEST_CASE("GC")
 
 TEST_CASE("Bitwise")
 {
+    ScopedFastFlag sffs{"LuauBit32Byteswap", true};
     runConformance("bitwise.lua");
 }
 

--- a/tests/conformance/bitwise.lua
+++ b/tests/conformance/bitwise.lua
@@ -137,7 +137,7 @@ assert(bit32.countrz(0x7fffffff) == 0)
 -- testing byteswap
 assert(bit32.byteswap(0x10203040) == 0x40302010)
 assert(bit32.byteswap(0) == 0)
-assert(bit32.byteswap(0xffffffff) == 0xffffffff)
+assert(bit32.byteswap(-1) == 0xffffffff)
 
 --[[
 This test verifies a fix in luauF_replace() where if the 4th

--- a/tests/conformance/bitwise.lua
+++ b/tests/conformance/bitwise.lua
@@ -134,6 +134,11 @@ assert(bit32.countrz(0x80000000) == 31)
 assert(bit32.countrz(0x40000000) == 30)
 assert(bit32.countrz(0x7fffffff) == 0)
 
+-- testing byteswap
+assert(bit32.byteswap(0x10203040) == 0x40302010)
+assert(bit32.byteswap(0) == 0)
+assert(bit32.byteswap(0xffffffff) == 0xffffffff)
+
 --[[
 This test verifies a fix in luauF_replace() where if the 4th
 parameter was not a number, but the first three are numbers, it will
@@ -164,5 +169,6 @@ assert(bit32.btest("1", 3) == true)
 assert(bit32.countlz("42") == 26)
 assert(bit32.countrz("42") == 1)
 assert(bit32.extract("42", 1, 3) == 5)
+assert(bit32.byteswap("0xa1b2c3d4") == 0xd4c3d2a1)
 
 return('OK')

--- a/tests/conformance/bitwise.lua
+++ b/tests/conformance/bitwise.lua
@@ -169,6 +169,6 @@ assert(bit32.btest("1", 3) == true)
 assert(bit32.countlz("42") == 26)
 assert(bit32.countrz("42") == 1)
 assert(bit32.extract("42", 1, 3) == 5)
-assert(bit32.byteswap("0xa1b2c3d4") == 0xd4c3d2a1)
+assert(bit32.byteswap("0xa1b2c3d4") == 0xd4c3b2a1)
 
 return('OK')


### PR DESCRIPTION
I've decided to take a stab at implementing `bit32.byteswap` from the [recently merged RFC](https://github.com/Roblox/luau/blob/master/rfcs/function-bit32-byteswap.md). I asked on Discord for some guidance, but for the sake of posterity: this is my first time doing this and I am likely to have made some mistakes.

The biggest gaps in this implementation are the lack of tests and the lack of native codegen support. I'd appreciate help with those since I'm not sure what's relevant for me to touch for tests, and I'm told that relevant assembler instructions don't exist publicly yet. Intuition tells me that Luau-side tests would go into `tests/conformance/bitwise.luau` but this is not well documented and I'm not sure how I'm meant to test built-in implementations.

The current implementation compiles down to `bswap` and `rev` on x86 and ARM respectively when optimized.