### PR TITLE
Sync to upstream/release/681

### DIFF
--- a/Analysis/include/Luau/Constraint.h
+++ b/Analysis/include/Luau/Constraint.h
@@ -283,6 +283,25 @@ struct SimplifyConstraint
     TypeId ty;
 };
 
+// push_function_type_constraint expectedFunctionType => functionType
+//
+// Attempt to "push" the types of `expectedFunctionType` into `functionType`,
+// assuming that `expr` is a lambda who's ungeneralized type is `functionType`.
+// Similar to `FunctionCheckConstraint`. For example:
+//
+//  local Foo = {} :: { bar : (number) -> () }
+//
+//  function Foo.bar(x) end
+//
+// This will force `x` to be inferred as `number`.
+struct PushFunctionTypeConstraint
+{
+    TypeId expectedFunctionType;
+    TypeId functionType;
+    NotNull<AstExprFunction> expr;
+    bool isSelf;
+};
+
 using ConstraintV = Variant<
     SubtypeConstraint,
     PackSubtypeConstraint,
@@ -302,7 +321,8 @@ using ConstraintV = Variant<
     ReducePackConstraint,
     EqualityConstraint,
     TableCheckConstraint,
-    SimplifyConstraint>;
+    SimplifyConstraint,
+    PushFunctionTypeConstraint>;
 
 struct Constraint
 {

--- a/Analysis/include/Luau/ConstraintGenerator.h
+++ b/Analysis/include/Luau/ConstraintGenerator.h
@@ -494,6 +494,9 @@ private:
     );
 
     TypeId simplifyUnion(const ScopePtr& scope, Location location, TypeId left, TypeId right);
+
+    void updateRValueRefinements(const ScopePtr& scope, DefId def, TypeId ty) const;
+    void updateRValueRefinements(Scope* scope, DefId def, TypeId ty) const;
 };
 
 } // namespace Luau

--- a/Analysis/include/Luau/ConstraintSolver.h
+++ b/Analysis/include/Luau/ConstraintSolver.h
@@ -256,6 +256,8 @@ public:
 
     bool tryDispatch(const SimplifyConstraint& c, NotNull<const Constraint> constraint);
 
+    bool tryDispatch(const PushFunctionTypeConstraint& c, NotNull<const Constraint> constraint);
+
     // for a, ... in some_table do
     // also handles __iter metamethod
     bool tryDispatchIterableTable(TypeId iteratorTy, const IterableConstraint& c, NotNull<const Constraint> constraint, bool force);

--- a/Analysis/include/Luau/DataFlowGraph.h
+++ b/Analysis/include/Luau/DataFlowGraph.h
@@ -46,6 +46,8 @@ struct DataFlowGraph
 
     const RefinementKey* getRefinementKey(const AstExpr* expr) const;
 
+    std::optional<Symbol> getSymbolFromDef(const Def* def) const;
+
 private:
     DataFlowGraph(NotNull<DefArena> defArena, NotNull<RefinementKeyArena> keyArena);
 
@@ -63,6 +65,7 @@ private:
     // There's no AstStatDeclaration, and it feels useless to introduce it just to enforce an invariant in one place.
     // All keys in this maps are really only statements that ambiently declares a symbol.
     DenseHashMap<const AstStat*, const Def*> declaredDefs{nullptr};
+    DenseHashMap<const Def*, Symbol> defToSymbol{nullptr};
 
     DenseHashMap<const AstExpr*, const RefinementKey*> astRefinementKeys{nullptr};
     friend struct DataFlowGraphBuilder;

--- a/Analysis/include/Luau/Module.h
+++ b/Analysis/include/Luau/Module.h
@@ -152,7 +152,9 @@ struct Module
     // Once a module has been typechecked, we clone its public interface into a
     // separate arena. This helps us to force Type ownership into a DAG rather
     // than a DCG.
-    void clonePublicInterface(NotNull<BuiltinTypes> builtinTypes, InternalErrorReporter& ice);
+    void clonePublicInterface_DEPRECATED(NotNull<BuiltinTypes> builtinTypes, InternalErrorReporter& ice);
+
+    void clonePublicInterface(NotNull<BuiltinTypes> builtinTypes, InternalErrorReporter& ice, SolverMode mode);
 };
 
 } // namespace Luau

--- a/Analysis/src/Constraint.cpp
+++ b/Analysis/src/Constraint.cpp
@@ -4,6 +4,7 @@
 #include "Luau/VisitType.h"
 
 LUAU_FASTFLAG(LuauEagerGeneralization4)
+LUAU_FASTFLAG(LuauPushFunctionTypesInFunctionStatement)
 
 namespace Luau
 {
@@ -222,6 +223,14 @@ DenseHashSet<TypeId> Constraint::getMaybeMutatedFreeTypes_DEPRECATED() const
         rci.traverse(tcc->exprType);
     }
 
+    if (FFlag::LuauPushFunctionTypesInFunctionStatement)
+    {
+        if (auto pftc = get<PushFunctionTypeConstraint>(*this))
+        {
+            rci.traverse(pftc->functionType);
+        }
+    }
+
     return types;
 }
 
@@ -316,6 +325,14 @@ TypeIds Constraint::getMaybeMutatedFreeTypes() const
     else if (auto tcc = get<TableCheckConstraint>(*this))
     {
         rci.traverse(tcc->exprType);
+    }
+
+    if (FFlag::LuauPushFunctionTypesInFunctionStatement)
+    {
+        if (auto pftc = get<PushFunctionTypeConstraint>(*this))
+        {
+            rci.traverse(pftc->functionType);
+        }
     }
 
     return types;

--- a/Analysis/src/Frontend.cpp
+++ b/Analysis/src/Frontend.cpp
@@ -1672,7 +1672,10 @@ ModulePtr check(
     }
 
     unfreeze(result->interfaceTypes);
-    result->clonePublicInterface(builtinTypes, *iceHandler);
+    if (FFlag::LuauUseWorkspacePropToChooseSolver)
+        result->clonePublicInterface(builtinTypes, *iceHandler, SolverMode::New);
+    else
+        result->clonePublicInterface_DEPRECATED(builtinTypes, *iceHandler);
 
     if (FFlag::DebugLuauForbidInternalTypes)
     {

--- a/Analysis/src/ToString.cpp
+++ b/Analysis/src/ToString.cpp
@@ -2023,6 +2023,8 @@ std::string toString(const Constraint& constraint, ToStringOptions& opts)
             return "table_check " + tos(c.expectedType) + " :> " + tos(c.exprType);
         else if constexpr (std::is_same_v<T, SimplifyConstraint>)
             return "simplify " + tos(c.ty);
+        else if constexpr (std::is_same_v<T, PushFunctionTypeConstraint>)
+            return "push_function_type " + tos(c.expectedFunctionType) + " => " + tos(c.functionType);
         else
             static_assert(always_false_v<T>, "Non-exhaustive constraint switch");
     };

--- a/Analysis/src/TypeInfer.cpp
+++ b/Analysis/src/TypeInfer.cpp
@@ -32,6 +32,7 @@ LUAU_FASTINTVARIABLE(LuauVisitRecursionLimit, 500)
 LUAU_FASTFLAG(LuauKnowsTheDataModel3)
 LUAU_FASTFLAGVARIABLE(DebugLuauFreezeDuringUnification)
 LUAU_FASTFLAG(LuauInstantiateInSubtyping)
+LUAU_FASTFLAG(LuauUseWorkspacePropToChooseSolver)
 
 LUAU_FASTFLAGVARIABLE(LuauReduceCheckBinaryExprStackPressure)
 
@@ -303,7 +304,11 @@ ModulePtr TypeChecker::checkWithoutRecursionCheck(const SourceModule& module, Mo
     normalizer.clearCaches();
     normalizer.arena = nullptr;
 
-    currentModule->clonePublicInterface(builtinTypes, *iceHandler);
+    if (FFlag::LuauUseWorkspacePropToChooseSolver)
+        currentModule->clonePublicInterface(builtinTypes, *iceHandler, SolverMode::Old);
+    else
+        currentModule->clonePublicInterface_DEPRECATED(builtinTypes, *iceHandler);
+
     freeze(currentModule->internalTypes);
     freeze(currentModule->interfaceTypes);
 

--- a/tests/TypeInfer.generics.test.cpp
+++ b/tests/TypeInfer.generics.test.cpp
@@ -18,6 +18,8 @@ LUAU_FASTFLAG(LuauReportSubtypingErrors)
 LUAU_FASTFLAG(LuauEagerGeneralization4)
 LUAU_FASTFLAG(LuauStuckTypeFunctionsStillDispatch)
 LUAU_FASTFLAG(LuauRemoveTypeCallsForReadWriteProps)
+LUAU_FASTFLAG(DebugLuauAssertOnForcedConstraint)
+LUAU_FASTFLAG(LuauPushFunctionTypesInFunctionStatement)
 
 using namespace Luau;
 
@@ -1234,6 +1236,13 @@ TEST_CASE_FIXTURE(Fixture, "generic_table_method")
 
 TEST_CASE_FIXTURE(Fixture, "correctly_instantiate_polymorphic_member_functions")
 {
+    // Prior to `LuauPushFunctionTypesInFunctionStatement`, we _always_ forced
+    // a constraint when solving this block.
+    ScopedFastFlag sffs[] = {
+        {FFlag::DebugLuauAssertOnForcedConstraint, true},
+        {FFlag::LuauPushFunctionTypesInFunctionStatement, true},
+    };
+
     CheckResult result = check(R"(
         local T = {}
 


### PR DESCRIPTION
# What's Changed?
Short week, so a slightly shorter release! This one has been focused on improving polish in fragment autocomplete and the new solver.

## New Type Solver
* Fix a bug where we didn't infer self types correctly under bidirectional type inference.
* Improve the memory consumption of the new solver by reducing the number of expensive allocations performed by `Substitution`.
* The New non strict Mode shouldn't issue errors when we call checked functions with `never` values.
* Extend the number of cases in which the new non strict mode can report unknown symbols.
* Fix a bug where `and` and `or` expressions didn't correctly forward information computed by their operands. This should allow more programs using these expressions to complete typechecking correctly.
* Small performance improvements for `Generalization`

## Fragment Autocomplete
* Fragment autocomplete provides richer autofill information when typing `self.|`
* Fragment autocomplete now uses refinement information computed in the new solver to provide more accurate incremental completion.

## Code Generation
* Fix a bug where Codegen could sometimes try to execute a non-executable page

---
Co-authored-by: Ariel Weiss <aaronweiss@roblox.com>
Co-authored-by: Hunter Goldstein <hgoldstein@roblox.com>
Co-authored-by: Vighnesh Vijay <vvijay@roblox.com>
Co-authored-by: Vyacheslav Egorov <vegorov@roblox.com>
