### PR TITLE
Sync to upstream/release/690

### DIFF
--- a/Analysis/include/Luau/AstUtils.h
+++ b/Analysis/include/Luau/AstUtils.h
@@ -1,0 +1,19 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+#pragma once
+
+#include "Luau/Ast.h"
+#include "Luau/DenseHash.h"
+#include "Luau/NotNull.h"
+#include "Luau/TypeFwd.h"
+
+namespace Luau
+{
+
+// Search through the expression 'expr' for types that are known to represent
+// uniquely held references. Append these types to 'uniqueTypes'.
+void findUniqueTypes(NotNull<DenseHashSet<TypeId>> uniqueTypes, AstExpr* expr, NotNull<const DenseHashMap<const AstExpr*, TypeId>> astTypes);
+
+void findUniqueTypes(NotNull<DenseHashSet<TypeId>> uniqueTypes, AstArray<AstExpr*> exprs, NotNull<const DenseHashMap<const AstExpr*, TypeId>> astTypes);
+void findUniqueTypes(NotNull<DenseHashSet<TypeId>> uniqueTypes, const std::vector<AstExpr*>& exprs, NotNull<const DenseHashMap<const AstExpr*, TypeId>> astTypes);
+
+}

--- a/Analysis/include/Luau/Constraint.h
+++ b/Analysis/include/Luau/Constraint.h
@@ -92,6 +92,10 @@ struct FunctionCallConstraint
     TypeId fn;
     TypePackId argsPack;
     TypePackId result;
+
+    // callSite can be nullptr in the case that this constraint was
+    // synthetically generated from some other constraint. eg
+    // IterableConstraint.
     class AstExprCall* callSite = nullptr;
     std::vector<std::optional<TypeId>> discriminantTypes;
 

--- a/Analysis/include/Luau/ConstraintSolver.h
+++ b/Analysis/include/Luau/ConstraintSolver.h
@@ -108,7 +108,7 @@ struct ConstraintSolver
     std::vector<NotNull<Constraint>> constraints;
     NotNull<DenseHashMap<Scope*, TypeId>> scopeToFunction;
     NotNull<Scope> rootScope;
-    ModuleName currentModuleName;
+    ModulePtr module;
 
     // The dataflow graph of the program, used in constraint generation and for magic functions.
     NotNull<const DataFlowGraph> dfg;
@@ -169,7 +169,7 @@ struct ConstraintSolver
         NotNull<Normalizer> normalizer,
         NotNull<Simplifier> simplifier,
         NotNull<TypeFunctionRuntime> typeFunctionRuntime,
-        ModuleName moduleName,
+        ModulePtr module,
         NotNull<ModuleResolver> moduleResolver,
         std::vector<RequireCycle> requireCycles,
         DcrLogger* logger,
@@ -185,7 +185,7 @@ struct ConstraintSolver
         NotNull<Scope> rootScope,
         std::vector<NotNull<Constraint>> constraints,
         NotNull<DenseHashMap<Scope*, TypeId>> scopeToFunction,
-        ModuleName moduleName,
+        ModulePtr module,
         NotNull<ModuleResolver> moduleResolver,
         std::vector<RequireCycle> requireCycles,
         DcrLogger* logger,

--- a/Analysis/include/Luau/GlobalTypes.h
+++ b/Analysis/include/Luau/GlobalTypes.h
@@ -20,7 +20,7 @@ struct GlobalTypes
     TypeArena globalTypes;
     SourceModule globalNames; // names for symbols entered into globalScope
 
-    ScopePtr globalScope;     // shared by all modules
+    ScopePtr globalScope;             // shared by all modules
     ScopePtr globalTypeFunctionScope; // shared by all modules
 
     SolverMode mode = SolverMode::Old;

--- a/Analysis/include/Luau/Module.h
+++ b/Analysis/include/Luau/Module.h
@@ -159,6 +159,8 @@ struct Module
     void clonePublicInterface_DEPRECATED(NotNull<BuiltinTypes> builtinTypes, InternalErrorReporter& ice);
 
     void clonePublicInterface(NotNull<BuiltinTypes> builtinTypes, InternalErrorReporter& ice, SolverMode mode);
+
+    bool constraintGenerationDidNotComplete = true;
 };
 
 } // namespace Luau

--- a/Analysis/include/Luau/OverloadResolution.h
+++ b/Analysis/include/Luau/OverloadResolution.h
@@ -62,9 +62,20 @@ struct OverloadResolver
     std::vector<std::pair<TypeId, ErrorVec>> nonviableOverloads;
     InsertionOrderedMap<TypeId, std::pair<OverloadResolver::Analysis, size_t>> resolution;
 
+    std::pair<OverloadResolver::Analysis, TypeId> selectOverload(
+        TypeId ty,
+        TypePackId args,
+        NotNull<DenseHashSet<TypeId>> uniqueTypes,
+        bool useFreeTypeBounds
+    );
 
-    std::pair<OverloadResolver::Analysis, TypeId> selectOverload(TypeId ty, TypePackId args, bool useFreeTypeBounds);
-    void resolve(TypeId fnTy, const TypePack* args, AstExpr* selfExpr, const std::vector<AstExpr*>* argExprs);
+    void resolve(
+        TypeId fnTy,
+        const TypePack* args,
+        AstExpr* selfExpr,
+        const std::vector<AstExpr*>* argExprs,
+        NotNull<DenseHashSet<TypeId>> uniqueTypes
+    );
 
 private:
     std::optional<ErrorVec> testIsSubtype(const Location& location, TypeId subTy, TypeId superTy);
@@ -74,6 +85,7 @@ private:
         const TypePack* args,
         AstExpr* fnLoc,
         const std::vector<AstExpr*>* argExprs,
+        NotNull<DenseHashSet<TypeId>> uniqueTypes,
         bool callMetamethodOk = true
     );
     static bool isLiteral(AstExpr* expr);
@@ -83,7 +95,8 @@ private:
         const FunctionType* fn,
         const TypePack* args,
         AstExpr* fnExpr,
-        const std::vector<AstExpr*>* argExprs
+        const std::vector<AstExpr*>* argExprs,
+        NotNull<DenseHashSet<TypeId>> uniqueTypes
     );
     size_t indexof(Analysis analysis);
     void add(Analysis analysis, TypeId ty, ErrorVec&& errors);

--- a/Analysis/include/Luau/Transpiler.h
+++ b/Analysis/include/Luau/Transpiler.h
@@ -25,7 +25,7 @@ void dump(AstNode* node);
 // Never fails on a well-formed AST
 std::string transpile(AstStatBlock& ast);
 std::string transpileWithTypes(AstStatBlock& block);
-std::string transpileWithTypes(AstStatBlock &block, const CstNodeMap& cstNodeMap);
+std::string transpileWithTypes(AstStatBlock& block, const CstNodeMap& cstNodeMap);
 
 // Only fails when parsing fails
 TranspileResult transpile(std::string_view source, ParseOptions options = ParseOptions{}, bool withTypes = false);

--- a/Analysis/include/Luau/Type.h
+++ b/Analysis/include/Luau/Type.h
@@ -317,8 +317,12 @@ struct MagicFunctionTypeCheckContext
 
 struct MagicFunction
 {
-    virtual std::optional<WithPredicate<TypePackId>>
-    handleOldSolver(struct TypeChecker&, const std::shared_ptr<struct Scope>&, const class AstExprCall&, WithPredicate<TypePackId>) = 0;
+    virtual std::optional<WithPredicate<TypePackId>> handleOldSolver(
+        struct TypeChecker&,
+        const std::shared_ptr<struct Scope>&,
+        const class AstExprCall&,
+        WithPredicate<TypePackId>
+    ) = 0;
 
     // Callback to allow custom typechecking of builtin function calls whose argument types
     // will only be resolved after constraint solving. For example, the arguments to string.format
@@ -355,13 +359,7 @@ struct FunctionType
     );
 
     // Local monomorphic function
-    FunctionType(
-        TypeLevel level,
-        TypePackId argTypes,
-        TypePackId retTypes,
-        std::optional<FunctionDefinition> defn = {},
-        bool hasSelf = false
-    );
+    FunctionType(TypeLevel level, TypePackId argTypes, TypePackId retTypes, std::optional<FunctionDefinition> defn = {}, bool hasSelf = false);
 
     // Local polymorphic function
     FunctionType(

--- a/Analysis/include/Luau/TypePack.h
+++ b/Analysis/include/Luau/TypePack.h
@@ -231,7 +231,11 @@ bool isEmpty(TypePackId tp);
 /// Flattens out a type pack.  Also returns a valid TypePackId tail if the type pack's full size is not known
 std::pair<std::vector<TypeId>, std::optional<TypePackId>> flatten(TypePackId tp);
 std::pair<std::vector<TypeId>, std::optional<TypePackId>> flatten(TypePackId tp, const TxnLog& log);
-std::pair<std::vector<TypeId>, std::optional<TypePackId>> flatten(TypePackId tp, const DenseHashMap<TypePackId, TypePackId>& mappedGenericPacks);
+// TODO: Clip with LuauSubtypingGenericPacksDoesntUseVariance
+std::pair<std::vector<TypeId>, std::optional<TypePackId>> flatten_DEPRECATED(
+    TypePackId tp,
+    const DenseHashMap<TypePackId, TypePackId>& mappedGenericPacks
+);
 
 /// Returs true if the type pack arose from a function that is declared to be variadic.
 /// Returns *false* for function argument packs that are inferred to be safe to oversaturate!
@@ -256,5 +260,17 @@ LUAU_NOINLINE T* emplaceTypePack(TypePackVar* ty, Args&&... args)
 
 template<>
 LUAU_NOINLINE Unifiable::Bound<TypePackId>* emplaceTypePack<BoundTypePack>(TypePackVar* ty, TypePackId& tyArg);
+
+/*
+ * Takes a slice of a TypePack, starting at sliceIndex, and up to and including the tail. toBeSliced should be already decomposed into head and tail.
+ */
+TypePackId sliceTypePack(
+    size_t sliceIndex,
+    TypePackId toBeSliced,
+    std::vector<TypeId>& head,
+    std::optional<TypePackId> tail,
+    NotNull<BuiltinTypes> builtinTypes,
+    NotNull<TypeArena> arena
+);
 
 } // namespace Luau

--- a/Analysis/include/Luau/TypePath.h
+++ b/Analysis/include/Luau/TypePath.h
@@ -111,9 +111,17 @@ struct Reduction
     bool operator==(const Reduction& other) const;
 };
 
+// Component representing a mapped generic pack. Allows traversal into the pack that a generic pack was mapped to.
+struct GenericPackMapping
+{
+    TypePackId mappedType;
+
+    bool operator==(const GenericPackMapping& other) const;
+};
+
 /// A single component of a path, representing one inner type or type pack to
 /// traverse into.
-using Component = Luau::Variant<Property, Index, TypeField, PackField, PackSlice, Reduction>;
+using Component = Luau::Variant<Property, Index, TypeField, PackField, PackSlice, Reduction, GenericPackMapping>;
 
 /// A path through a type or type pack accessing a particular type or type pack
 /// contained within.
@@ -190,6 +198,7 @@ struct PathHash
     size_t operator()(const PackField& field) const;
     size_t operator()(const PackSlice& slice) const;
     size_t operator()(const Reduction& reduction) const;
+    size_t operator()(const GenericPackMapping& mapping) const;
     size_t operator()(const Component& component) const;
     size_t operator()(const Path& path) const;
 };
@@ -218,6 +227,7 @@ struct PathBuilder
     PathBuilder& rets();
     PathBuilder& tail();
     PathBuilder& packSlice(size_t start_index);
+    PathBuilder& mappedGenericPack(TypePackId mappedType);
 };
 
 } // namespace TypePath
@@ -231,10 +241,21 @@ std::string toString(const TypePath::Path& path, bool prefixDot = false);
 /// Converts a Path to a human readable string for error reporting.
 std::string toStringHuman(const TypePath::Path& path);
 
-// TODO: clip traverse_DEPRECATED along with `LuauReturnMappedGenericPacksFromSubtyping2`
+// To keep my head straight when clipping:
+// LuauReturnMappedGenericPacksFromSubtyping2 expects mappedGenericPacks AND arena
+// LuauSubtypingGenericPacksDoesntUseVariance expects just arena. this is the final state
+
+// TODO: clip below two along with `LuauReturnMappedGenericPacksFromSubtyping2`
 std::optional<TypeOrPack> traverse_DEPRECATED(TypeId root, const Path& path, NotNull<BuiltinTypes> builtinTypes);
 std::optional<TypeOrPack> traverse_DEPRECATED(TypePackId root, const Path& path, NotNull<BuiltinTypes> builtinTypes);
 std::optional<TypeOrPack> traverse(
+    TypePackId root,
+    const Path& path,
+    NotNull<BuiltinTypes> builtinTypes,
+    NotNull<TypeArena> arena
+);
+// TODO: Clip with LuauSubtypingGenericPacksDoesntUseVariance
+std::optional<TypeOrPack> traverse_DEPRECATED(
     TypePackId root,
     const Path& path,
     NotNull<BuiltinTypes> builtinTypes,
@@ -242,6 +263,13 @@ std::optional<TypeOrPack> traverse(
     NotNull<TypeArena> arena
 );
 std::optional<TypeOrPack> traverse(
+    TypeId root,
+    const Path& path,
+    NotNull<BuiltinTypes> builtinTypes,
+    NotNull<TypeArena> arena
+);
+// TODO: Clip with LuauSubtypingGenericPacksDoesntUseVariance
+std::optional<TypeOrPack> traverse_DEPRECATED(
     TypeId root,
     const Path& path,
     NotNull<BuiltinTypes> builtinTypes,
@@ -264,11 +292,24 @@ std::optional<TypeId> traverseForType_DEPRECATED(TypeId root, const Path& path, 
 /// @param mappedGenericPacks the mapping for any encountered generic packs we want to reify
 /// @param arena a TypeArena, required if path has a PackSlice component
 /// @returns the TypeId at the end of the path, or nullopt if the traversal failed.
-std::optional<TypeId> traverseForType(
+std::optional<TypeId> traverseForType_DEPRECATED(
     TypeId root,
     const Path& path,
     NotNull<BuiltinTypes> builtinTypes,
     NotNull<const DenseHashMap<TypePackId, TypePackId>> mappedGenericPacks,
+    NotNull<TypeArena> arena
+);
+
+/// Traverses a path from a type to its end point, which must be a type.
+/// @param root the entry point of the traversal
+/// @param path the path to traverse
+/// @param builtinTypes the built-in types in use (used to acquire the string metatable)
+/// @param arena a TypeArena, required if path has a PackSlice component
+/// @returns the TypeId at the end of the path, or nullopt if the traversal failed.
+std::optional<TypeId> traverseForType(
+    TypeId root,
+    const Path& path,
+    NotNull<BuiltinTypes> builtinTypes,
     NotNull<TypeArena> arena
 );
 
@@ -286,11 +327,24 @@ std::optional<TypeId> traverseForType_DEPRECATED(TypePackId root, const Path& pa
 /// @param mappedGenericPacks the mapping for any encountered generic packs we want to reify
 /// @param arena a TypeArena, required if path has a PackSlice component
 /// @returns the TypeId at the end of the path, or nullopt if the traversal failed.
-std::optional<TypeId> traverseForType(
+std::optional<TypeId> traverseForType_DEPRECATED(
     TypePackId root,
     const Path& path,
     NotNull<BuiltinTypes> builtinTypes,
     NotNull<const DenseHashMap<TypePackId, TypePackId>> mappedGenericPacks,
+    NotNull<TypeArena> arena
+);
+
+/// Traverses a path from a type pack to its end point, which must be a type.
+/// @param root the entry point of the traversal
+/// @param path the path to traverse
+/// @param builtinTypes the built-in types in use (used to acquire the string metatable)
+/// @param arena a TypeArena, required if path has a PackSlice component
+/// @returns the TypeId at the end of the path, or nullopt if the traversal failed.
+std::optional<TypeId> traverseForType(
+    TypePackId root,
+    const Path& path,
+    NotNull<BuiltinTypes> builtinTypes,
     NotNull<TypeArena> arena
 );
 
@@ -309,11 +363,24 @@ std::optional<TypePackId> traverseForPack_DEPRECATED(TypeId root, const Path& pa
 /// @param mappedGenericPacks the mapping for any encountered generic packs we want to reify
 /// @param arena a TypeArena, required if path has a PackSlice component
 /// @returns the TypePackId at the end of the path, or nullopt if the traversal failed.
-std::optional<TypePackId> traverseForPack(
+std::optional<TypePackId> traverseForPack_DEPRECATED(
     TypeId root,
     const Path& path,
     NotNull<BuiltinTypes> builtinTypes,
     NotNull<const DenseHashMap<TypePackId, TypePackId>> mappedGenericPacks,
+    NotNull<TypeArena> arena
+);
+
+/// Traverses a path from a type to its end point, which must be a type pack.
+/// @param root the entry point of the traversal
+/// @param path the path to traverse
+/// @param builtinTypes the built-in types in use (used to acquire the string metatable)
+/// @param arena a TypeArena, required if path has a PackSlice component
+/// @returns the TypePackId at the end of the path, or nullopt if the traversal failed.
+std::optional<TypePackId> traverseForPack(
+    TypeId root,
+    const Path& path,
+    NotNull<BuiltinTypes> builtinTypes,
     NotNull<TypeArena> arena
 );
 
@@ -331,7 +398,7 @@ std::optional<TypePackId> traverseForPack_DEPRECATED(TypePackId root, const Path
 /// @param mappedGenericPacks the mapping for any encountered generic packs we want to reify
 /// @param arena a TypeArena, required if path has a PackSlice component
 /// @returns the TypePackId at the end of the path, or nullopt if the traversal failed.
-std::optional<TypePackId> traverseForPack(
+std::optional<TypePackId> traverseForPack_DEPRECATED(
     TypePackId root,
     const Path& path,
     NotNull<BuiltinTypes> builtinTypes,
@@ -339,8 +406,29 @@ std::optional<TypePackId> traverseForPack(
     NotNull<TypeArena> arena
 );
 
+/// Traverses a path from a type pack to its end point, which must be a type pack.
+/// @param root the entry point of the traversal
+/// @param path the path to traverse
+/// @param builtinTypes the built-in types in use (used to acquire the string metatable)
+/// @param arena a TypeArena, required if path has a PackSlice component
+/// @returns the TypePackId at the end of the path, or nullopt if the traversal failed.
+std::optional<TypePackId> traverseForPack(
+    TypePackId root,
+    const Path& path,
+    NotNull<BuiltinTypes> builtinTypes,
+    NotNull<TypeArena> arena
+);
+
 /// Traverses a path of Index and PackSlices to compute the index of the type the path points to
 /// Returns std::nullopt if the path isn't n PackSlice components followed by an Index component
 std::optional<size_t> traverseForIndex(const Path& path);
+
+// Flattens a type pack with generic packs into a type pack without generic packs, using the generics mapping encoded in path.
+// Path is assumed to contain only PackField::Tail and GenericPackMapping components.
+TypePack flattenPackWithPath(TypePackId root, const Path& path);
+
+TypePack traverseForFlattenedPack(TypeId root, const Path& path, NotNull<BuiltinTypes> builtinTypes, NotNull<TypeArena> arena);
+
+bool matchesPrefix(const Path& prefix, const Path& full);
 
 } // namespace Luau

--- a/Analysis/include/Luau/Unifier2.h
+++ b/Analysis/include/Luau/Unifier2.h
@@ -33,7 +33,7 @@ enum class UnifyResult
     TooComplex
 };
 
-inline UnifyResult operator &(UnifyResult lhs, UnifyResult rhs)
+inline UnifyResult operator&(UnifyResult lhs, UnifyResult rhs)
 {
     if (lhs == UnifyResult::Ok)
         return rhs;

--- a/Analysis/src/AstUtils.cpp
+++ b/Analysis/src/AstUtils.cpp
@@ -1,0 +1,64 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+
+#include "Luau/Ast.h"
+#include "Luau/Type.h"
+
+namespace Luau
+{
+
+struct AstExprTableFinder : AstVisitor
+{
+    NotNull<DenseHashSet<TypeId>> result;
+    NotNull<const DenseHashMap<const AstExpr*, TypeId>> astTypes;
+
+    explicit AstExprTableFinder(NotNull<DenseHashSet<TypeId>> result, NotNull<const DenseHashMap<const AstExpr*, TypeId>> astTypes)
+        : result(result)
+        , astTypes(astTypes)
+    {}
+
+    bool visit(AstExpr* expr) override
+    {
+        return false;
+    }
+
+    bool visit(AstExprTable* tbl) override
+    {
+        const TypeId* ty = astTypes->find(tbl);
+        LUAU_ASSERT(ty);
+        if (ty)
+            result->insert(*ty);
+
+        return true;
+    }
+};
+
+void findUniqueTypes(NotNull<DenseHashSet<TypeId>> uniqueTypes, AstExpr* expr, NotNull<const DenseHashMap<const AstExpr*, TypeId>> astTypes)
+{
+    AstExprTableFinder finder{uniqueTypes, astTypes};
+    expr->visit(&finder);
+}
+
+template <typename Iter>
+void findUniqueTypes(NotNull<DenseHashSet<TypeId>> uniqueTypes, Iter startIt, Iter endIt, NotNull<const DenseHashMap<const AstExpr*, TypeId>> astTypes)
+{
+    while (startIt != endIt)
+    {
+        AstExpr* expr = *startIt;
+        if (expr->is<AstExprTable>())
+            findUniqueTypes(uniqueTypes, expr, astTypes);
+        ++startIt;
+    }
+}
+
+
+void findUniqueTypes(NotNull<DenseHashSet<TypeId>> uniqueTypes, AstArray<AstExpr*> exprs, NotNull<const DenseHashMap<const AstExpr*, TypeId>> astTypes)
+{
+    findUniqueTypes(uniqueTypes, exprs.begin(), exprs.end(), astTypes);
+}
+
+void findUniqueTypes(NotNull<DenseHashSet<TypeId>> uniqueTypes, const std::vector<AstExpr*>& exprs, NotNull<const DenseHashMap<const AstExpr*, TypeId>> astTypes)
+{
+    findUniqueTypes(uniqueTypes, exprs.begin(), exprs.end(), astTypes);
+}
+
+}

--- a/Analysis/src/BuiltinDefinitions.cpp
+++ b/Analysis/src/BuiltinDefinitions.cpp
@@ -42,79 +42,123 @@ namespace Luau
 
 struct MagicSelect final : MagicFunction
 {
-    std::optional<WithPredicate<TypePackId>>
-    handleOldSolver(struct TypeChecker&, const std::shared_ptr<struct Scope>&, const class AstExprCall&, WithPredicate<TypePackId>) override;
+    std::optional<WithPredicate<TypePackId>> handleOldSolver(
+        struct TypeChecker&,
+        const std::shared_ptr<struct Scope>&,
+        const class AstExprCall&,
+        WithPredicate<TypePackId>
+    ) override;
     bool infer(const MagicFunctionCallContext& ctx) override;
 };
 
 struct MagicSetMetatable final : MagicFunction
 {
-    std::optional<WithPredicate<TypePackId>>
-    handleOldSolver(struct TypeChecker&, const std::shared_ptr<struct Scope>&, const class AstExprCall&, WithPredicate<TypePackId>) override;
+    std::optional<WithPredicate<TypePackId>> handleOldSolver(
+        struct TypeChecker&,
+        const std::shared_ptr<struct Scope>&,
+        const class AstExprCall&,
+        WithPredicate<TypePackId>
+    ) override;
     bool infer(const MagicFunctionCallContext& ctx) override;
 };
 
 struct MagicAssert final : MagicFunction
 {
-    std::optional<WithPredicate<TypePackId>>
-    handleOldSolver(struct TypeChecker&, const std::shared_ptr<struct Scope>&, const class AstExprCall&, WithPredicate<TypePackId>) override;
+    std::optional<WithPredicate<TypePackId>> handleOldSolver(
+        struct TypeChecker&,
+        const std::shared_ptr<struct Scope>&,
+        const class AstExprCall&,
+        WithPredicate<TypePackId>
+    ) override;
     bool infer(const MagicFunctionCallContext& ctx) override;
 };
 
 struct MagicPack final : MagicFunction
 {
-    std::optional<WithPredicate<TypePackId>>
-    handleOldSolver(struct TypeChecker&, const std::shared_ptr<struct Scope>&, const class AstExprCall&, WithPredicate<TypePackId>) override;
+    std::optional<WithPredicate<TypePackId>> handleOldSolver(
+        struct TypeChecker&,
+        const std::shared_ptr<struct Scope>&,
+        const class AstExprCall&,
+        WithPredicate<TypePackId>
+    ) override;
     bool infer(const MagicFunctionCallContext& ctx) override;
 };
 
 struct MagicRequire final : MagicFunction
 {
-    std::optional<WithPredicate<TypePackId>>
-    handleOldSolver(struct TypeChecker&, const std::shared_ptr<struct Scope>&, const class AstExprCall&, WithPredicate<TypePackId>) override;
+    std::optional<WithPredicate<TypePackId>> handleOldSolver(
+        struct TypeChecker&,
+        const std::shared_ptr<struct Scope>&,
+        const class AstExprCall&,
+        WithPredicate<TypePackId>
+    ) override;
     bool infer(const MagicFunctionCallContext& ctx) override;
 };
 
 struct MagicClone final : MagicFunction
 {
-    std::optional<WithPredicate<TypePackId>>
-    handleOldSolver(struct TypeChecker&, const std::shared_ptr<struct Scope>&, const class AstExprCall&, WithPredicate<TypePackId>) override;
+    std::optional<WithPredicate<TypePackId>> handleOldSolver(
+        struct TypeChecker&,
+        const std::shared_ptr<struct Scope>&,
+        const class AstExprCall&,
+        WithPredicate<TypePackId>
+    ) override;
     bool infer(const MagicFunctionCallContext& ctx) override;
 };
 
 struct MagicFreeze final : MagicFunction
 {
-    std::optional<WithPredicate<TypePackId>>
-    handleOldSolver(struct TypeChecker&, const std::shared_ptr<struct Scope>&, const class AstExprCall&, WithPredicate<TypePackId>) override;
+    std::optional<WithPredicate<TypePackId>> handleOldSolver(
+        struct TypeChecker&,
+        const std::shared_ptr<struct Scope>&,
+        const class AstExprCall&,
+        WithPredicate<TypePackId>
+    ) override;
     bool infer(const MagicFunctionCallContext& ctx) override;
 };
 
 struct MagicFormat final : MagicFunction
 {
-    std::optional<WithPredicate<TypePackId>>
-    handleOldSolver(struct TypeChecker&, const std::shared_ptr<struct Scope>&, const class AstExprCall&, WithPredicate<TypePackId>) override;
+    std::optional<WithPredicate<TypePackId>> handleOldSolver(
+        struct TypeChecker&,
+        const std::shared_ptr<struct Scope>&,
+        const class AstExprCall&,
+        WithPredicate<TypePackId>
+    ) override;
     bool infer(const MagicFunctionCallContext& ctx) override;
     bool typeCheck(const MagicFunctionTypeCheckContext& ctx) override;
 };
 
 struct MagicMatch final : MagicFunction
 {
-    std::optional<WithPredicate<TypePackId>>
-    handleOldSolver(struct TypeChecker&, const std::shared_ptr<struct Scope>&, const class AstExprCall&, WithPredicate<TypePackId>) override;
+    std::optional<WithPredicate<TypePackId>> handleOldSolver(
+        struct TypeChecker&,
+        const std::shared_ptr<struct Scope>&,
+        const class AstExprCall&,
+        WithPredicate<TypePackId>
+    ) override;
     bool infer(const MagicFunctionCallContext& ctx) override;
 };
 
 struct MagicGmatch final : MagicFunction
 {
-    std::optional<WithPredicate<TypePackId>>
-    handleOldSolver(struct TypeChecker&, const std::shared_ptr<struct Scope>&, const class AstExprCall&, WithPredicate<TypePackId>) override;
+    std::optional<WithPredicate<TypePackId>> handleOldSolver(
+        struct TypeChecker&,
+        const std::shared_ptr<struct Scope>&,
+        const class AstExprCall&,
+        WithPredicate<TypePackId>
+    ) override;
     bool infer(const MagicFunctionCallContext& ctx) override;
 };
 
 struct MagicFind final : MagicFunction
 {
-    std::optional<WithPredicate<TypePackId>>
-    handleOldSolver(struct TypeChecker&, const std::shared_ptr<struct Scope>&, const class AstExprCall&, WithPredicate<TypePackId>) override;
+    std::optional<WithPredicate<TypePackId>> handleOldSolver(
+        struct TypeChecker&,
+        const std::shared_ptr<struct Scope>&,
+        const class AstExprCall&,
+        WithPredicate<TypePackId>
+    ) override;
     bool infer(const MagicFunctionCallContext& ctx) override;
 };
 
@@ -411,10 +455,7 @@ void registerBuiltinGlobals(Frontend& frontend, GlobalTypes& globals, bool typeC
         // setmetatable<T: {}, MT>(T, MT) -> setmetatable<T, MT>
         TypeId setmtReturn = arena.addType(TypeFunctionInstanceType{builtinTypeFunctions().setmetatableFunc, {genericT, genericMT}});
         addGlobalBinding(
-            globals,
-            "setmetatable",
-            makeFunction(arena, std::nullopt, {genericT, genericMT}, {}, {genericT, genericMT}, {setmtReturn}),
-            "@luau"
+            globals, "setmetatable", makeFunction(arena, std::nullopt, {genericT, genericMT}, {}, {genericT, genericMT}, {setmtReturn}), "@luau"
         );
     }
     else
@@ -442,13 +483,17 @@ void registerBuiltinGlobals(Frontend& frontend, GlobalTypes& globals, bool typeC
     {
         // declare function assert<T>(value: T, errorMessage: string?): intersect<T, ~(false?)>
         TypeId genericT = arena.addType(GenericType{globalScope, "T"});
-        TypeId refinedTy = arena.addType(TypeFunctionInstanceType{
-            NotNull{&builtinTypeFunctions().intersectFunc}, {genericT, arena.addType(NegationType{builtinTypes->falsyType})}, {}
-        });
+        TypeId refinedTy = arena.addType(
+            TypeFunctionInstanceType{
+                NotNull{&builtinTypeFunctions().intersectFunc}, {genericT, arena.addType(NegationType{builtinTypes->falsyType})}, {}
+            }
+        );
 
-        TypeId assertTy = arena.addType(FunctionType{
-            {genericT}, {}, arena.addTypePack(TypePack{{genericT, builtinTypes->optionalStringType}}), arena.addTypePack(TypePack{{refinedTy}})
-        });
+        TypeId assertTy = arena.addType(
+            FunctionType{
+                {genericT}, {}, arena.addTypePack(TypePack{{genericT, builtinTypes->optionalStringType}}), arena.addTypePack(TypePack{{refinedTy}})
+            }
+        );
         addGlobalBinding(globals, "assert", assertTy, "@luau");
     }
 
@@ -699,83 +744,80 @@ bool MagicFormat::typeCheck(const MagicFunctionTypeCheckContext& context)
 
     if (iter == end(context.arguments))
     {
-        context.typechecker->reportError(
-            CountMismatch{1, std::nullopt, 0, CountMismatch::Arg, true, "string.format"}, context.callSite->location
-            );
-            return true;
-        }
+        context.typechecker->reportError(CountMismatch{1, std::nullopt, 0, CountMismatch::Arg, true, "string.format"}, context.callSite->location);
+        return true;
+    }
 
-        // we'll suppress any errors for `string.format` if the format string is error suppressing.
-        if (shouldSuppressErrors(NotNull{&context.typechecker->normalizer}, follow(*iter)) == ErrorSuppression::Suppress)
+    // we'll suppress any errors for `string.format` if the format string is error suppressing.
+    if (shouldSuppressErrors(NotNull{&context.typechecker->normalizer}, follow(*iter)) == ErrorSuppression::Suppress)
+    {
+        return true;
+    }
+
+    AstExprConstantString* fmt = nullptr;
+    if (auto index = context.callSite->func->as<AstExprIndexName>(); index && context.callSite->self)
+        fmt = unwrapGroup(index->expr)->as<AstExprConstantString>();
+
+    if (!context.callSite->self && context.callSite->args.size > 0)
+        fmt = context.callSite->args.data[0]->as<AstExprConstantString>();
+
+    std::optional<std::string_view> formatString;
+    if (fmt)
+        formatString = {fmt->value.data, fmt->value.size};
+    else if (auto singleton = get<SingletonType>(follow(*iter)))
+    {
+        if (auto stringSingleton = get<StringSingleton>(singleton))
+            formatString = {stringSingleton->value};
+    }
+
+    if (!formatString)
+    {
+        context.typechecker->reportError(CannotCheckDynamicStringFormatCalls{}, context.callSite->location);
+        return true;
+    }
+
+    // CLI-150726: The block below effectively constructs a type pack and then type checks it by going parameter-by-parameter.
+    // This does _not_ handle cases like:
+    //
+    //  local foo : () -> (...string) = (nil :: any)
+    //  print(string.format("%s %d %s", foo()))
+    //
+    // ... which should be disallowed.
+
+    std::vector<TypeId> expected = parseFormatString(context.builtinTypes, formatString->data(), formatString->size());
+
+    const auto& [params, tail] = flatten(context.arguments);
+
+    size_t paramOffset = 1;
+    // Compare the expressions passed with the types the function expects to determine whether this function was called with : or .
+    bool calledWithSelf = expected.size() == context.callSite->args.size;
+    // unify the prefix one argument at a time
+    for (size_t i = 0; i < expected.size() && i + paramOffset < params.size(); ++i)
+    {
+        TypeId actualTy = params[i + paramOffset];
+        TypeId expectedTy = expected[i];
+        Location location = context.callSite->args.data[std::min(context.callSite->args.size - 1, i + (calledWithSelf ? 0 : paramOffset))]->location;
+        // use subtyping instead here
+        SubtypingResult result = context.typechecker->subtyping->isSubtype(actualTy, expectedTy, context.checkScope);
+
+        if (!result.isSubtype)
         {
-            return true;
-        }
-
-        AstExprConstantString* fmt = nullptr;
-        if (auto index = context.callSite->func->as<AstExprIndexName>(); index && context.callSite->self)
-            fmt = unwrapGroup(index->expr)->as<AstExprConstantString>();
-
-        if (!context.callSite->self && context.callSite->args.size > 0)
-            fmt = context.callSite->args.data[0]->as<AstExprConstantString>();
-
-        std::optional<std::string_view> formatString;
-        if (fmt)
-            formatString = {fmt->value.data, fmt->value.size};
-        else if (auto singleton = get<SingletonType>(follow(*iter)))
-        {
-            if (auto stringSingleton = get<StringSingleton>(singleton))
-                formatString = {stringSingleton->value};
-        }
-
-        if (!formatString)
-        {
-            context.typechecker->reportError(CannotCheckDynamicStringFormatCalls{}, context.callSite->location);
-            return true;
-        }
-
-        // CLI-150726: The block below effectively constructs a type pack and then type checks it by going parameter-by-parameter.
-        // This does _not_ handle cases like:
-        //
-        //  local foo : () -> (...string) = (nil :: any)
-        //  print(string.format("%s %d %s", foo()))
-        //
-        // ... which should be disallowed.
-
-        std::vector<TypeId> expected = parseFormatString(context.builtinTypes, formatString->data(), formatString->size());
-
-        const auto& [params, tail] = flatten(context.arguments);
-
-        size_t paramOffset = 1;
-        // Compare the expressions passed with the types the function expects to determine whether this function was called with : or .
-        bool calledWithSelf = expected.size() == context.callSite->args.size;
-        // unify the prefix one argument at a time
-        for (size_t i = 0; i < expected.size() && i + paramOffset < params.size(); ++i)
-        {
-            TypeId actualTy = params[i + paramOffset];
-            TypeId expectedTy = expected[i];
-            Location location =
-                context.callSite->args.data[std::min(context.callSite->args.size - 1, i + (calledWithSelf ? 0 : paramOffset))]->location;
-            // use subtyping instead here
-            SubtypingResult result = context.typechecker->subtyping->isSubtype(actualTy, expectedTy, context.checkScope);
-
-            if (!result.isSubtype)
+            switch (shouldSuppressErrors(NotNull{&context.typechecker->normalizer}, actualTy))
             {
-                switch (shouldSuppressErrors(NotNull{&context.typechecker->normalizer}, actualTy))
-                {
-                    case ErrorSuppression::Suppress:
-                        break;
-                    case ErrorSuppression::NormalizationFailed:
-                        break;
-                    case ErrorSuppression::DoNotSuppress:
-                        Reasonings reasonings = context.typechecker->explainReasonings(actualTy, expectedTy, location, result);
+            case ErrorSuppression::Suppress:
+                break;
+            case ErrorSuppression::NormalizationFailed:
+                break;
+            case ErrorSuppression::DoNotSuppress:
+                Reasonings reasonings = context.typechecker->explainReasonings(actualTy, expectedTy, location, result);
 
-                        if (!reasonings.suppressed)
-                            context.typechecker->reportError(TypeMismatch{expectedTy, actualTy, reasonings.toString()}, location);
-                }
+                if (!reasonings.suppressed)
+                    context.typechecker->reportError(TypeMismatch{expectedTy, actualTy, reasonings.toString()}, location);
             }
         }
+    }
 
-        return true;
+    return true;
 }
 
 static std::vector<TypeId> parsePatternString(NotNull<BuiltinTypes> builtinTypes, const char* data, size_t size)
@@ -1127,11 +1169,13 @@ TypeId makeStringMetatable(NotNull<BuiltinTypes> builtinTypes, SolverMode mode)
 
     const TypeId stringToStringType = makeFunction(*arena, std::nullopt, {}, {}, {stringType}, {}, {stringType}, /* checked */ true);
 
-    const TypeId replArgType = arena->addType(UnionType{
-        {stringType,
-         arena->addType(TableType({}, TableIndexer(stringType, stringType), TypeLevel{}, TableState::Generic)),
-         makeFunction(*arena, std::nullopt, {}, {}, {stringType}, {}, {stringType}, /* checked */ false)}
-    });
+    const TypeId replArgType = arena->addType(
+        UnionType{
+            {stringType,
+             arena->addType(TableType({}, TableIndexer(stringType, stringType), TypeLevel{}, TableState::Generic)),
+             makeFunction(*arena, std::nullopt, {}, {}, {stringType}, {}, {stringType}, /* checked */ false)}
+        }
+    );
     const TypeId gsubFunc =
         makeFunction(*arena, stringType, {}, {}, {stringType, replArgType, optionalNumber}, {}, {stringType, numberType}, /* checked */ false);
     const TypeId gmatchFunc =
@@ -1194,10 +1238,12 @@ TypeId makeStringMetatable(NotNull<BuiltinTypes> builtinTypes, SolverMode mode)
              /* checked */ true
          )}},
         {"pack",
-         {arena->addType(FunctionType{
-             arena->addTypePack(TypePack{{stringType}, variadicTailPack}),
-             oneStringPack,
-         })}},
+         {arena->addType(
+             FunctionType{
+                 arena->addTypePack(TypePack{{stringType}, variadicTailPack}),
+                 oneStringPack,
+             }
+         )}},
         {"packsize", {makeFunction(*arena, stringType, {}, {}, {}, {}, {numberType}, /* checked */ true)}},
         {"unpack", {arena->addType(std::move(stringDotUnpack))}},
     };
@@ -1622,8 +1668,12 @@ static std::optional<TypeId> freezeTable(TypeId inputType, const MagicFunctionCa
     return std::nullopt;
 }
 
-std::optional<WithPredicate<TypePackId>> MagicFreeze::
-    handleOldSolver(struct TypeChecker&, const std::shared_ptr<struct Scope>&, const class AstExprCall&, WithPredicate<TypePackId>)
+std::optional<WithPredicate<TypePackId>> MagicFreeze::handleOldSolver(
+    struct TypeChecker&,
+    const std::shared_ptr<struct Scope>&,
+    const class AstExprCall&,
+    WithPredicate<TypePackId>
+)
 {
     return std::nullopt;
 }
@@ -1754,7 +1804,7 @@ bool MagicRequire::infer(const MagicFunctionCallContext& context)
     if (!checkRequirePathDcr(context.solver, context.callSite->args.data[0]))
         return false;
 
-    if (auto moduleInfo = context.solver->moduleResolver->resolveModuleInfo(context.solver->currentModuleName, *context.callSite))
+    if (auto moduleInfo = context.solver->moduleResolver->resolveModuleInfo(context.solver->module->name, *context.callSite))
     {
         TypeId moduleType = context.solver->resolveModule(*moduleInfo, context.callSite->location);
         TypePackId moduleResult = context.solver->arena->addTypePack({moduleType});

--- a/Analysis/src/DcrLogger.cpp
+++ b/Analysis/src/DcrLogger.cpp
@@ -306,10 +306,12 @@ void DcrLogger::captureGenerationModule(const ModulePtr& module)
 void DcrLogger::captureGenerationError(const TypeError& error)
 {
     std::string stringifiedError = toString(error);
-    generationLog.errors.push_back(ErrorSnapshot{
-        /* message */ std::move(stringifiedError),
-        /* location */ error.location,
-    });
+    generationLog.errors.push_back(
+        ErrorSnapshot{
+            /* message */ std::move(stringifiedError),
+            /* location */ error.location,
+        }
+    );
 }
 
 void DcrLogger::pushBlock(NotNull<const Constraint> constraint, TypeId block)
@@ -442,10 +444,12 @@ void DcrLogger::captureFinalSolverState(const Scope* rootScope, const std::vecto
 void DcrLogger::captureTypeCheckError(const TypeError& error)
 {
     std::string stringifiedError = toString(error);
-    checkLog.errors.push_back(ErrorSnapshot{
-        /* message */ std::move(stringifiedError),
-        /* location */ error.location,
-    });
+    checkLog.errors.push_back(
+        ErrorSnapshot{
+            /* message */ std::move(stringifiedError),
+            /* location */ error.location,
+        }
+    );
 }
 
 std::vector<ConstraintBlock> DcrLogger::snapshotBlocks(NotNull<const Constraint> c)

--- a/Analysis/src/EqSatSimplification.cpp
+++ b/Analysis/src/EqSatSimplification.cpp
@@ -4,6 +4,7 @@
 #include "Luau/EqSatSimplificationImpl.h"
 
 #include "Luau/EGraph.h"
+#include "Luau/HashUtil.h"
 #include "Luau/Id.h"
 #include "Luau/Language.h"
 
@@ -84,9 +85,9 @@ size_t TTable::Hash::operator()(const TTable& value) const
     // We're using pointers here, which does mean platform divergence. I think
     // it's okay? (famous last words, I know)
     for (StringId s : value.propNames)
-        EqSat::hashCombine(hash, EqSat::languageHash(s));
+        hashCombine(hash, EqSat::languageHash(s));
 
-    EqSat::hashCombine(hash, EqSat::languageHash(value.storage));
+    hashCombine(hash, EqSat::languageHash(value.storage));
 
     return hash;
 }
@@ -415,12 +416,14 @@ Id toId(
         // `TypeFunctionInstanceType` outside of the provided arena so that
         // we can access the members without fear of the specific TFIT being
         // overwritten with a bound type.
-        return cache(egraph.add(TTypeFun{
-            std::make_shared<const TypeFunctionInstanceType>(
-                tfun->function, tfun->typeArguments, tfun->packArguments, tfun->userFuncName, tfun->userFuncData
-            ),
-            std::move(parts)
-        }));
+        return cache(egraph.add(
+            TTypeFun{
+                std::make_shared<const TypeFunctionInstanceType>(
+                    tfun->function, tfun->typeArguments, tfun->packArguments, tfun->userFuncName, tfun->userFuncData
+                ),
+                std::move(parts)
+            }
+        ));
     }
     else if (get<NoRefineType>(ty))
         return egraph.add(TNoRefine{});
@@ -2368,11 +2371,12 @@ void Simplifier::intersectTableProperty(Id id)
                                     newIntersectionParts.push_back(intersectionParts[index]);
                             }
 
-                            Id newTableProp =
-                                egraph.add(Intersection{
+                            Id newTableProp = egraph.add(
+                                Intersection{
                                     toId(egraph, builtinTypes, mappingIdToClass, stringCache, *it->second.readTy),
                                     toId(egraph, builtinTypes, mappingIdToClass, stringCache, *table1Ty->props.begin()->second.readTy)
-                                });
+                                }
+                            );
 
                             newIntersectionParts.push_back(egraph.add(TTable{jId, {stringCache.add(it->first)}, {newTableProp}}));
 

--- a/Analysis/src/Error.cpp
+++ b/Analysis/src/Error.cpp
@@ -126,9 +126,10 @@ struct ErrorConverter
             return "'" + s + "'";
         };
 
-        auto constructErrorMessage =
-            [&](std::string givenType, std::string wantedType, std::optional<std::string> givenModule, std::optional<std::string> wantedModule
-            ) -> std::string
+        auto constructErrorMessage = [&](std::string givenType,
+                                         std::string wantedType,
+                                         std::optional<std::string> givenModule,
+                                         std::optional<std::string> wantedModule) -> std::string
         {
             std::string given = givenModule ? quote(givenType) + " from " + quote(*givenModule) : quote(givenType);
             std::string wanted = wantedModule ? quote(wantedType) + " from " + quote(*wantedModule) : quote(wantedType);

--- a/Analysis/src/FileResolver.cpp
+++ b/Analysis/src/FileResolver.cpp
@@ -120,8 +120,10 @@ static RequireSuggestions makeSuggestionsFromNode(std::unique_ptr<RequireNode> n
     return result;
 }
 
-std::optional<RequireSuggestions> RequireSuggester::getRequireSuggestionsImpl(const ModuleName& requirer, const std::optional<std::string>& path)
-    const
+std::optional<RequireSuggestions> RequireSuggester::getRequireSuggestionsImpl(
+    const ModuleName& requirer,
+    const std::optional<std::string>& path
+) const
 {
     if (!path)
         return std::nullopt;

--- a/Analysis/src/FragmentAutocomplete.cpp
+++ b/Analysis/src/FragmentAutocomplete.cpp
@@ -992,18 +992,18 @@ ScopePtr findClosestScope_DEPRECATED(const ModulePtr& module, const AstStat* nea
 ScopePtr findClosestScope(const ModulePtr& module, const Position& scopePos)
 {
     LUAU_ASSERT(module->hasModuleScope());
-        ScopePtr closest = module->getModuleScope();
-        // find the scope the nearest statement belonged to.
-        for (const auto& [loc, sc] : module->scopes)
-        {
-            // We bias towards the later scopes because those correspond to inner scopes.
-            // in the case of if statements, we create two scopes at the same location for the body of the then
-            // and else branches, so we need to bias later. This is why the closest update condition has a <=
-            // instead of a <
-            if (sc->location.contains(scopePos) && closest->location.begin <= sc->location.begin)
-                closest = sc;
-        }
-        return closest;
+    ScopePtr closest = module->getModuleScope();
+    // find the scope the nearest statement belonged to.
+    for (const auto& [loc, sc] : module->scopes)
+    {
+        // We bias towards the later scopes because those correspond to inner scopes.
+        // in the case of if statements, we create two scopes at the same location for the body of the then
+        // and else branches, so we need to bias later. This is why the closest update condition has a <=
+        // instead of a <
+        if (sc->location.contains(scopePos) && closest->location.begin <= sc->location.begin)
+            closest = sc;
+    }
+    return closest;
 }
 
 std::optional<FragmentParseResult> parseFragment_DEPRECATED(
@@ -1248,7 +1248,7 @@ FragmentTypeCheckResult typecheckFragment_(
         NotNull(cg.rootScope),
         borrowConstraints(cg.constraints),
         NotNull{&cg.scopeToFunction},
-        incrementalModule->name,
+        incrementalModule,
         NotNull{&resolver},
         {},
         nullptr,
@@ -1403,7 +1403,7 @@ FragmentTypeCheckResult typecheckFragment__DEPRECATED(
         NotNull(cg.rootScope),
         borrowConstraints(cg.constraints),
         NotNull{&cg.scopeToFunction},
-        incrementalModule->name,
+        incrementalModule,
         NotNull{&resolver},
         {},
         nullptr,

--- a/Analysis/src/Frontend.cpp
+++ b/Analysis/src/Frontend.cpp
@@ -47,6 +47,7 @@ LUAU_FASTFLAGVARIABLE(DebugLuauAlwaysShowConstraintSolvingIncomplete)
 LUAU_FASTFLAG(LuauLimitDynamicConstraintSolving3)
 LUAU_FASTFLAG(LuauEmplaceNotPushBack)
 LUAU_FASTFLAG(LuauExplicitSkipBoundTypes)
+LUAU_FASTFLAG(LuauNoConstraintGenRecursionLimitIce)
 
 namespace Luau
 {
@@ -235,7 +236,8 @@ LoadDefinitionFileResult Frontend::loadDefinitionFile(
         return LoadDefinitionFileResult{false, std::move(parseResult), std::move(sourceModule), nullptr};
 
     Frontend::Stats dummyStats;
-    ModulePtr checkedModule = check(sourceModule, Mode::Definition, {}, std::nullopt, /*forAutocomplete*/ false, /*recordJsonLog*/ false, dummyStats, {});
+    ModulePtr checkedModule =
+        check(sourceModule, Mode::Definition, {}, std::nullopt, /*forAutocomplete*/ false, /*recordJsonLog*/ false, dummyStats, {});
 
     if (checkedModule->errors.size() > 0)
         return LoadDefinitionFileResult{false, std::move(parseResult), std::move(sourceModule), std::move(checkedModule)};
@@ -1045,8 +1047,9 @@ void Frontend::checkBuildQueueItem(BuildQueueItem& item)
         return;
     }
 
-    ModulePtr module =
-        check(sourceModule, mode, requireCycles, environmentScope, /*forAutocomplete*/ false, item.recordJsonLog, item.stats, std::move(typeCheckLimits));
+    ModulePtr module = check(
+        sourceModule, mode, requireCycles, environmentScope, /*forAutocomplete*/ false, item.recordJsonLog, item.stats, std::move(typeCheckLimits)
+    );
 
     double duration = getTimestamp() - timestamp;
 
@@ -1437,17 +1440,17 @@ ModulePtr check(
     LUAU_TIMETRACE_ARGUMENT("module", sourceModule.name.c_str());
     LUAU_TIMETRACE_ARGUMENT("name", sourceModule.humanReadableName.c_str());
 
-    ModulePtr result = std::make_shared<Module>();
-    result->checkedInNewSolver = true;
-    result->name = sourceModule.name;
-    result->humanReadableName = sourceModule.humanReadableName;
-    result->mode = mode;
-    result->internalTypes.owningModule = result.get();
-    result->interfaceTypes.owningModule = result.get();
-    result->internalTypes.collectSingletonStats = options.collectTypeAllocationStats;
-    result->allocator = sourceModule.allocator;
-    result->names = sourceModule.names;
-    result->root = sourceModule.root;
+    ModulePtr module = std::make_shared<Module>();
+    module->checkedInNewSolver = true;
+    module->name = sourceModule.name;
+    module->humanReadableName = sourceModule.humanReadableName;
+    module->mode = mode;
+    module->internalTypes.owningModule = module.get();
+    module->interfaceTypes.owningModule = module.get();
+    module->internalTypes.collectSingletonStats = options.collectTypeAllocationStats;
+    module->allocator = sourceModule.allocator;
+    module->names = sourceModule.names;
+    module->root = sourceModule.root;
 
     iceHandler->moduleName = sourceModule.name;
 
@@ -1455,27 +1458,27 @@ ModulePtr check(
     if (recordJsonLog)
     {
         logger = std::make_unique<DcrLogger>();
-        std::optional<SourceCode> source = fileResolver->readSource(result->name);
+        std::optional<SourceCode> source = fileResolver->readSource(module->name);
         if (source)
         {
             logger->captureSource(source->source);
         }
     }
 
-    DataFlowGraph dfg = DataFlowGraphBuilder::build(sourceModule.root, NotNull{&result->defArena}, NotNull{&result->keyArena}, iceHandler);
+    DataFlowGraph dfg = DataFlowGraphBuilder::build(sourceModule.root, NotNull{&module->defArena}, NotNull{&module->keyArena}, iceHandler);
 
     UnifierSharedState unifierState{iceHandler};
     unifierState.counters.recursionLimit = FInt::LuauTypeInferRecursionLimit;
     unifierState.counters.iterationLimit = limits.unifierIterationLimit.value_or(FInt::LuauTypeInferIterationLimit);
 
-    Normalizer normalizer{&result->internalTypes, builtinTypes, NotNull{&unifierState}, SolverMode::New};
-    SimplifierPtr simplifier = newSimplifier(NotNull{&result->internalTypes}, builtinTypes);
+    Normalizer normalizer{&module->internalTypes, builtinTypes, NotNull{&unifierState}, SolverMode::New};
+    SimplifierPtr simplifier = newSimplifier(NotNull{&module->internalTypes}, builtinTypes);
     TypeFunctionRuntime typeFunctionRuntime{iceHandler, NotNull{&limits}};
 
     typeFunctionRuntime.allowEvaluation = true;
 
     ConstraintGenerator cg{
-        result,
+        module,
         NotNull{&normalizer},
         NotNull{simplifier.get()},
         NotNull{&typeFunctionRuntime},
@@ -1490,7 +1493,7 @@ ModulePtr check(
         requireCycles
     };
 
-    // FIXME: Delete this flag when clipping FFlag::LuauEagerGeneralization4.
+    // FIXME: Unwrap this std::option when clipping FFlag::LuauEagerGeneralization4.
     //
     // This optional<> only exists so that we can run one constructor when the flag
     // is set, and another when it is unset.
@@ -1499,13 +1502,15 @@ ModulePtr check(
     if (FFlag::LuauEagerGeneralization4)
     {
         ConstraintSet constraintSet = cg.run(sourceModule.root);
-        result->errors = std::move(constraintSet.errors);
+        module->errors = std::move(constraintSet.errors);
+        if (FFlag::LuauNoConstraintGenRecursionLimitIce)
+            module->constraintGenerationDidNotComplete = cg.recursionLimitMet;
 
         cs.emplace(
             NotNull{&normalizer},
             NotNull{simplifier.get()},
             NotNull{&typeFunctionRuntime},
-            result->name,
+            module,
             moduleResolver,
             requireCycles,
             logger.get(),
@@ -1517,7 +1522,9 @@ ModulePtr check(
     else
     {
         cg.visitModuleRoot(sourceModule.root);
-        result->errors = std::move(cg.errors);
+        module->errors = std::move(cg.errors);
+        if (FFlag::LuauNoConstraintGenRecursionLimitIce)
+            module->constraintGenerationDidNotComplete = cg.recursionLimitMet;
 
         cs.emplace(
             NotNull{&normalizer},
@@ -1526,7 +1533,7 @@ ModulePtr check(
             NotNull(cg.rootScope),
             borrowConstraints(cg.constraints),
             NotNull{&cg.scopeToFunction},
-            result->name,
+            module,
             moduleResolver,
             requireCycles,
             logger.get(),
@@ -1546,11 +1553,11 @@ ModulePtr check(
     }
     catch (const TimeLimitError&)
     {
-        result->timeout = true;
+        module->timeout = true;
     }
     catch (const UserCancelError&)
     {
-        result->cancelled = true;
+        module->cancelled = true;
     }
 
     stats.dynamicConstraintsCreated += cs->solverConstraints.size();
@@ -1565,23 +1572,23 @@ ModulePtr check(
     }
 
     for (TypeError& e : cs->errors)
-        result->errors.emplace_back(std::move(e));
+        module->errors.emplace_back(std::move(e));
 
-    result->scopes = std::move(cg.scopes);
-    result->type = sourceModule.type;
-    result->upperBoundContributors = std::move(cs->upperBoundContributors);
+    module->scopes = std::move(cg.scopes);
+    module->type = sourceModule.type;
+    module->upperBoundContributors = std::move(cs->upperBoundContributors);
 
-    if (result->timeout || result->cancelled)
+    if (module->timeout || module->cancelled)
     {
         // If solver was interrupted, skip typechecking and replace all module results with error-supressing types to avoid leaking blocked/pending
         // types
-        ScopePtr moduleScope = result->getModuleScope();
+        ScopePtr moduleScope = module->getModuleScope();
         moduleScope->returnType = builtinTypes->errorTypePack;
 
-        for (auto& [name, ty] : result->declaredGlobals)
+        for (auto& [name, ty] : module->declaredGlobals)
             ty = builtinTypes->errorType;
 
-        for (auto& [name, tf] : result->exportedTypeBindings)
+        for (auto& [name, tf] : module->exportedTypeBindings)
             tf.type = builtinTypes->errorType;
     }
     else
@@ -1600,7 +1607,7 @@ ModulePtr check(
                     NotNull{&dfg},
                     NotNull{&limits},
                     sourceModule,
-                    result.get()
+                    module.get()
                 );
                 break;
             case Mode::Definition:
@@ -1614,7 +1621,7 @@ ModulePtr check(
                     NotNull{&limits},
                     logger.get(),
                     sourceModule,
-                    result.get()
+                    module.get()
                 );
                 break;
             case Mode::NoCheck:
@@ -1623,11 +1630,11 @@ ModulePtr check(
         }
         catch (const TimeLimitError&)
         {
-            result->timeout = true;
+            module->timeout = true;
         }
         catch (const UserCancelError&)
         {
-            result->cancelled = true;
+            module->cancelled = true;
         }
     }
 
@@ -1636,16 +1643,16 @@ ModulePtr check(
     // this is probably, on the whole, a good decision to not annoy users though.
     if (FFlag::LuauNewNonStrictSuppressSoloConstraintSolvingIncomplete)
     {
-        if (result->errors.size() == 1 && get<ConstraintSolvingIncompleteError>(result->errors[0]) &&
+        if (module->errors.size() == 1 && get<ConstraintSolvingIncompleteError>(module->errors[0]) &&
             !FFlag::DebugLuauAlwaysShowConstraintSolvingIncomplete)
-            result->errors.clear();
+            module->errors.clear();
     }
 
     ExpectedTypeVisitor etv{
-        NotNull{&result->astTypes},
-        NotNull{&result->astExpectedTypes},
-        NotNull{&result->astResolvedTypes},
-        NotNull{&result->internalTypes},
+        NotNull{&module->astTypes},
+        NotNull{&module->astExpectedTypes},
+        NotNull{&module->astResolvedTypes},
+        NotNull{&module->internalTypes},
         builtinTypes,
         NotNull{parentScope.get()}
     };
@@ -1661,37 +1668,37 @@ ModulePtr check(
 
             // `result->returnType` is not filled in yet, so we
             // traverse the return type of the root module.
-            finder.traverse(result->getModuleScope()->returnType);
+            finder.traverse(module->getModuleScope()->returnType);
 
-            for (const auto& [_, binding] : result->exportedTypeBindings)
+            for (const auto& [_, binding] : module->exportedTypeBindings)
                 finder.traverse(binding.type);
 
-            for (const auto& [_, ty] : result->astTypes)
+            for (const auto& [_, ty] : module->astTypes)
                 finder.traverse(ty);
 
-            for (const auto& [_, ty] : result->astExpectedTypes)
+            for (const auto& [_, ty] : module->astExpectedTypes)
                 finder.traverse(ty);
 
-            for (const auto& [_, tp] : result->astTypePacks)
+            for (const auto& [_, tp] : module->astTypePacks)
                 finder.traverse(tp);
 
-            for (const auto& [_, ty] : result->astResolvedTypes)
+            for (const auto& [_, ty] : module->astResolvedTypes)
                 finder.traverse(ty);
 
-            for (const auto& [_, ty] : result->astOverloadResolvedTypes)
+            for (const auto& [_, ty] : module->astOverloadResolvedTypes)
                 finder.traverse(ty);
 
-            for (const auto& [_, tp] : result->astResolvedTypePacks)
+            for (const auto& [_, tp] : module->astResolvedTypePacks)
                 finder.traverse(tp);
         }
     }
 
 
-    unfreeze(result->interfaceTypes);
+    unfreeze(module->interfaceTypes);
     if (FFlag::LuauUseWorkspacePropToChooseSolver)
-        result->clonePublicInterface(builtinTypes, *iceHandler, SolverMode::New);
+        module->clonePublicInterface(builtinTypes, *iceHandler, SolverMode::New);
     else
-        result->clonePublicInterface_DEPRECATED(builtinTypes, *iceHandler);
+        module->clonePublicInterface_DEPRECATED(builtinTypes, *iceHandler);
 
     if (!FFlag::LuauLimitDynamicConstraintSolving3)
     {
@@ -1699,27 +1706,27 @@ ModulePtr check(
         {
             InternalTypeFinder finder;
 
-            finder.traverse(result->returnType);
+            finder.traverse(module->returnType);
 
-            for (const auto& [_, binding] : result->exportedTypeBindings)
+            for (const auto& [_, binding] : module->exportedTypeBindings)
                 finder.traverse(binding.type);
 
-            for (const auto& [_, ty] : result->astTypes)
+            for (const auto& [_, ty] : module->astTypes)
                 finder.traverse(ty);
 
-            for (const auto& [_, ty] : result->astExpectedTypes)
+            for (const auto& [_, ty] : module->astExpectedTypes)
                 finder.traverse(ty);
 
-            for (const auto& [_, tp] : result->astTypePacks)
+            for (const auto& [_, tp] : module->astTypePacks)
                 finder.traverse(tp);
 
-            for (const auto& [_, ty] : result->astResolvedTypes)
+            for (const auto& [_, ty] : module->astResolvedTypes)
                 finder.traverse(ty);
 
-            for (const auto& [_, ty] : result->astOverloadResolvedTypes)
+            for (const auto& [_, ty] : module->astOverloadResolvedTypes)
                 finder.traverse(ty);
 
-            for (const auto& [_, tp] : result->astResolvedTypePacks)
+            for (const auto& [_, tp] : module->astResolvedTypePacks)
                 finder.traverse(tp);
         }
     }
@@ -1735,10 +1742,10 @@ ModulePtr check(
     // Notably, we would first need to get to a place where TypeChecker2 is
     // never in the position of dealing with a FreeType.  They should all be
     // bound to something by the time constraints are solved.
-    freeze(result->internalTypes);
-    freeze(result->interfaceTypes);
+    freeze(module->internalTypes);
+    freeze(module->interfaceTypes);
 
-    return result;
+    return module;
 }
 
 ModulePtr Frontend::check(

--- a/Analysis/src/Module.cpp
+++ b/Analysis/src/Module.cpp
@@ -276,7 +276,6 @@ struct ClonePublicInterface : Substitution
             else if (auto gtp = getMutable<GenericTypePack>(clonedTp))
                 gtp->scope = nullptr;
             return clonedTp;
-
         }
         else
         {
@@ -400,7 +399,7 @@ void Module::clonePublicInterface_DEPRECATED(NotNull<BuiltinTypes> builtinTypes,
             Location{}, // Not amazing but the best we can do.
             name,
             InternalError{"An internal type is escaping this module; please report this bug at "
-                "https://github.com/luau-lang/luau/issues"}
+                          "https://github.com/luau-lang/luau/issues"}
         );
     }
 
@@ -451,7 +450,7 @@ void Module::clonePublicInterface(NotNull<BuiltinTypes> builtinTypes, InternalEr
             Location{}, // Not amazing but the best we can do.
             name,
             InternalError{"An internal type is escaping this module; please report this bug at "
-                "https://github.com/luau-lang/luau/issues"}
+                          "https://github.com/luau-lang/luau/issues"}
         );
     }
 

--- a/Analysis/src/TypeInfer.cpp
+++ b/Analysis/src/TypeInfer.cpp
@@ -4089,12 +4089,14 @@ void TypeChecker::checkArgumentList(
             namePath = *path;
 
         auto [minParams, optMaxParams] = getParameterExtents(&state.log, paramPack);
-        state.reportError(TypeError{
-            location,
-            CountMismatch{
-                minParams, optMaxParams, std::distance(begin(argPack), end(argPack)), CountMismatch::Context::Arg, false, std::move(namePath)
+        state.reportError(
+            TypeError{
+                location,
+                CountMismatch{
+                    minParams, optMaxParams, std::distance(begin(argPack), end(argPack)), CountMismatch::Context::Arg, false, std::move(namePath)
+                }
             }
-        });
+        );
     };
 
     while (true)
@@ -4211,10 +4213,12 @@ void TypeChecker::checkArgumentList(
                     if (std::optional<std::string> path = getFunctionNameAsString(funName))
                         namePath = *path;
 
-                    state.reportError(TypeError{
-                        funName.location,
-                        CountMismatch{minParams, optMaxParams, paramIndex, CountMismatch::Context::Arg, isVariadic, std::move(namePath)}
-                    });
+                    state.reportError(
+                        TypeError{
+                            funName.location,
+                            CountMismatch{minParams, optMaxParams, paramIndex, CountMismatch::Context::Arg, isVariadic, std::move(namePath)}
+                        }
+                    );
                     return;
                 }
                 ++paramIter;
@@ -4631,12 +4635,14 @@ std::unique_ptr<WithPredicate<TypePackId>> TypeChecker::checkCallOverload(
         else
             overloadsThatDont.push_back(fn);
 
-        errors.push_back(OverloadErrorEntry{
-            std::move(state.log),
-            std::move(state.errors),
-            args->head,
-            ftv,
-        });
+        errors.push_back(
+            OverloadErrorEntry{
+                std::move(state.log),
+                std::move(state.errors),
+                args->head,
+                ftv,
+            }
+        );
     }
     else
     {

--- a/Analysis/src/TypePack.cpp
+++ b/Analysis/src/TypePack.cpp
@@ -3,8 +3,10 @@
 
 #include "Luau/Error.h"
 #include "Luau/TxnLog.h"
+#include "Luau/TypeArena.h"
 
 LUAU_FASTFLAG(LuauReturnMappedGenericPacksFromSubtyping2)
+LUAU_FASTFLAG(LuauSubtypingGenericPacksDoesntUseVariance)
 
 namespace Luau
 {
@@ -453,9 +455,13 @@ std::pair<std::vector<TypeId>, std::optional<TypePackId>> flatten(TypePackId tp,
     return {flattened, tail};
 }
 
-std::pair<std::vector<TypeId>, std::optional<TypePackId>> flatten(TypePackId tp, const DenseHashMap<TypePackId, TypePackId>& mappedGenericPacks)
+std::pair<std::vector<TypeId>, std::optional<TypePackId>> flatten_DEPRECATED(
+    TypePackId tp,
+    const DenseHashMap<TypePackId, TypePackId>& mappedGenericPacks
+)
 {
     LUAU_ASSERT(FFlag::LuauReturnMappedGenericPacksFromSubtyping2);
+    LUAU_ASSERT(!FFlag::LuauSubtypingGenericPacksDoesntUseVariance);
 
     tp = mappedGenericPacks.contains(tp) ? *mappedGenericPacks.find(tp) : tp;
 
@@ -536,6 +542,31 @@ LUAU_NOINLINE Unifiable::Bound<TypePackId>* emplaceTypePack<BoundTypePack>(TypeP
 {
     LUAU_ASSERT(ty != follow(tyArg));
     return &ty->ty.emplace<BoundTypePack>(tyArg);
+}
+
+TypePackId sliceTypePack(
+    const size_t sliceIndex,
+    const TypePackId toBeSliced,
+    std::vector<TypeId>& head,
+    const std::optional<TypePackId> tail,
+    const NotNull<BuiltinTypes> builtinTypes,
+    const NotNull<TypeArena> arena
+)
+{
+    LUAU_ASSERT(FFlag::LuauSubtypingGenericPacksDoesntUseVariance);
+
+    if (sliceIndex == 0)
+        return toBeSliced;
+    else if (sliceIndex == head.size())
+        return tail.value_or(builtinTypes->emptyTypePack);
+    else
+    {
+        auto superHeadIter = begin(head);
+        for (size_t i = 0; i < sliceIndex; ++i)
+            ++superHeadIter;
+        std::vector<TypeId> headSlice(std::move(superHeadIter), end(head));
+        return arena->addTypePack(std::move(headSlice), tail);
+    }
 }
 
 } // namespace Luau

--- a/Analysis/src/Unifier.cpp
+++ b/Analysis/src/Unifier.cpp
@@ -2807,10 +2807,12 @@ void Unifier::checkChildUnifierTypeMismatch(const ErrorVec& innerErrors, const s
     if (auto e = hasUnificationTooComplex(innerErrors))
         reportError(*e);
     else if (!innerErrors.empty())
-        reportError(TypeError{
-            location,
-            TypeMismatch{wantedType, givenType, format("Property '%s' is not compatible.", prop.c_str()), innerErrors.front(), mismatchContext()}
-        });
+        reportError(
+            TypeError{
+                location,
+                TypeMismatch{wantedType, givenType, format("Property '%s' is not compatible.", prop.c_str()), innerErrors.front(), mismatchContext()}
+            }
+        );
 }
 
 void Unifier::ice(const std::string& message, const Location& location)

--- a/Ast/include/Luau/Parser.h
+++ b/Ast/include/Luau/Parser.h
@@ -400,8 +400,12 @@ private:
     // `astErrorLocation` is associated with the AstTypeError created
     // It can be useful to have different error locations so that the parse error can include the next lexeme, while the AstTypeError can precisely
     // define the location (possibly of zero size) where a type annotation is expected.
-    AstTypeError* reportMissingTypeError(const Location& parseErrorLocation, const Location& astErrorLocation, const char* format, ...)
-        LUAU_PRINTF_ATTR(4, 5);
+    AstTypeError* reportMissingTypeError(
+        const Location& parseErrorLocation,
+        const Location& astErrorLocation,
+        const char* format,
+        ...
+    ) LUAU_PRINTF_ATTR(4, 5);
 
     AstExpr* reportFunctionArgsError(AstExpr* func, bool self);
     void reportAmbiguousCallError();

--- a/Ast/src/Parser.cpp
+++ b/Ast/src/Parser.cpp
@@ -1452,9 +1452,11 @@ AstStat* Parser::parseDeclaration(const Location& start, const AstArray<AstAttr*
 
                     if (chars && !containsNull)
                     {
-                        props.push_back(AstDeclaredExternTypeProperty{
-                            AstName(chars->data), Location(nameBegin, nameEnd), type, false, Location(begin.location, lexer.previousLocation())
-                        });
+                        props.push_back(
+                            AstDeclaredExternTypeProperty{
+                                AstName(chars->data), Location(nameBegin, nameEnd), type, false, Location(begin.location, lexer.previousLocation())
+                            }
+                        );
                     }
                     else
                     {
@@ -1485,9 +1487,9 @@ AstStat* Parser::parseDeclaration(const Location& start, const AstArray<AstAttr*
 
                 expectAndConsume(':', "property type annotation");
                 AstType* propType = parseType();
-                props.push_back(AstDeclaredExternTypeProperty{
-                    propName->name, propName->location, propType, false, Location(propStart, lexer.previousLocation())
-                });
+                props.push_back(
+                    AstDeclaredExternTypeProperty{propName->name, propName->location, propType, false, Location(propStart, lexer.previousLocation())}
+                );
             }
         }
 
@@ -2118,16 +2120,18 @@ AstType* Parser::parseTableType(bool inDeclarationContext)
                 {
                     props.push_back(AstTableProp{AstName(chars->data), begin.location, type, access, accessLocation});
                     if (options.storeCstData)
-                        cstItems.push_back(CstTypeTable::Item{
-                            CstTypeTable::Item::Kind::StringProperty,
-                            begin.location.begin,
-                            indexerClosePosition,
-                            colonPosition,
-                            tableSeparator(),
-                            lexer.current().location.begin,
-                            allocator.alloc<CstExprConstantString>(sourceString, style, blockDepth),
-                            stringPosition
-                        });
+                        cstItems.push_back(
+                            CstTypeTable::Item{
+                                CstTypeTable::Item::Kind::StringProperty,
+                                begin.location.begin,
+                                indexerClosePosition,
+                                colonPosition,
+                                tableSeparator(),
+                                lexer.current().location.begin,
+                                allocator.alloc<CstExprConstantString>(sourceString, style, blockDepth),
+                                stringPosition
+                            }
+                        );
                 }
                 else
                     report(begin.location, "String literal contains malformed escape sequence or \\0");
@@ -2148,14 +2152,16 @@ AstType* Parser::parseTableType(bool inDeclarationContext)
                     auto tableIndexerResult = parseTableIndexer(access, accessLocation, begin);
                     indexer = tableIndexerResult.node;
                     if (options.storeCstData)
-                        cstItems.push_back(CstTypeTable::Item{
-                            CstTypeTable::Item::Kind::Indexer,
-                            tableIndexerResult.indexerOpenPosition,
-                            tableIndexerResult.indexerClosePosition,
-                            tableIndexerResult.colonPosition,
-                            tableSeparator(),
-                            lexer.current().location.begin,
-                        });
+                        cstItems.push_back(
+                            CstTypeTable::Item{
+                                CstTypeTable::Item::Kind::Indexer,
+                                tableIndexerResult.indexerOpenPosition,
+                                tableIndexerResult.indexerClosePosition,
+                                tableIndexerResult.colonPosition,
+                                tableSeparator(),
+                                lexer.current().location.begin,
+                            }
+                        );
                 }
             }
         }
@@ -2184,14 +2190,16 @@ AstType* Parser::parseTableType(bool inDeclarationContext)
 
             props.push_back(AstTableProp{name->name, name->location, type, access, accessLocation});
             if (options.storeCstData)
-                cstItems.push_back(CstTypeTable::Item{
-                    CstTypeTable::Item::Kind::Property,
-                    Position{0, 0},
-                    Position{0, 0},
-                    colonPosition,
-                    tableSeparator(),
-                    lexer.current().location.begin
-                });
+                cstItems.push_back(
+                    CstTypeTable::Item{
+                        CstTypeTable::Item::Kind::Property,
+                        Position{0, 0},
+                        Position{0, 0},
+                        colonPosition,
+                        tableSeparator(),
+                        lexer.current().location.begin
+                    }
+                );
         }
 
         if (lexer.current().type == ',' || lexer.current().type == ';')
@@ -3859,9 +3867,8 @@ AstExpr* Parser::parseString()
             style = AstExprConstantString::QuotedRaw;
             break;
         case Lexeme::QuotedString:
-            style = lexer.current().getQuoteStyle() == Lexeme::QuoteStyle::Single
-                        ? AstExprConstantString::QuotedSingle
-                        : AstExprConstantString::QuotedSimple;
+            style = lexer.current().getQuoteStyle() == Lexeme::QuoteStyle::Single ? AstExprConstantString::QuotedSingle
+                                                                                  : AstExprConstantString::QuotedSimple;
             break;
         default:
             LUAU_ASSERT(false && "Invalid string type");

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -230,6 +230,7 @@ if(LUAU_BUILD_CLI)
 
     target_link_libraries(Luau.Repl.CLI PRIVATE osthreads)
     target_link_libraries(Luau.Analyze.CLI PRIVATE osthreads)
+    target_link_libraries(Luau.Ast.CLI PRIVATE osthreads)
 
     target_link_libraries(Luau.Analyze.CLI PRIVATE Luau.Analysis Luau.CLI.lib Luau.RequireNavigator)
 

--- a/CodeGen/include/Luau/IrData.h
+++ b/CodeGen/include/Luau/IrData.h
@@ -1058,6 +1058,7 @@ struct IrFunction
     std::vector<BytecodeMapping> bcMapping;
     uint32_t entryBlock = 0;
     uint32_t entryLocation = 0;
+    uint32_t endLocation = 0;
 
     // For each instruction, an operand that can be used to recompute the value
     std::vector<IrOp> valueRestoreOps;

--- a/CodeGen/src/CodeGenContext.h
+++ b/CodeGen/src/CodeGenContext.h
@@ -70,8 +70,10 @@ class StandaloneCodeGenContext final : public BaseCodeGenContext
 public:
     StandaloneCodeGenContext(size_t blockSize, size_t maxTotalSize, AllocationCallback* allocationCallback, void* allocationCallbackContext);
 
-    [[nodiscard]] virtual std::optional<ModuleBindResult> tryBindExistingModule(const ModuleId& moduleId, const std::vector<Proto*>& moduleProtos)
-        override;
+    [[nodiscard]] virtual std::optional<ModuleBindResult> tryBindExistingModule(
+        const ModuleId& moduleId,
+        const std::vector<Proto*>& moduleProtos
+    ) override;
 
     [[nodiscard]] virtual ModuleBindResult bindModule(
         const std::optional<ModuleId>& moduleId,
@@ -94,8 +96,10 @@ class SharedCodeGenContext final : public BaseCodeGenContext
 public:
     SharedCodeGenContext(size_t blockSize, size_t maxTotalSize, AllocationCallback* allocationCallback, void* allocationCallbackContext);
 
-    [[nodiscard]] virtual std::optional<ModuleBindResult> tryBindExistingModule(const ModuleId& moduleId, const std::vector<Proto*>& moduleProtos)
-        override;
+    [[nodiscard]] virtual std::optional<ModuleBindResult> tryBindExistingModule(
+        const ModuleId& moduleId,
+        const std::vector<Proto*>& moduleProtos
+    ) override;
 
     [[nodiscard]] virtual ModuleBindResult bindModule(
         const std::optional<ModuleId>& moduleId,

--- a/CodeGen/src/CodeGenLower.h
+++ b/CodeGen/src/CodeGenLower.h
@@ -112,6 +112,7 @@ inline bool lowerImpl(
 
     // Make sure entry block is first
     CODEGEN_ASSERT(sortedBlocks[0] == 0);
+    CODEGEN_ASSERT(function.entryBlock == 0);
 
     for (size_t i = 0; i < sortedBlocks.size(); ++i)
     {
@@ -123,6 +124,7 @@ inline bool lowerImpl(
 
         CODEGEN_ASSERT(block.start != ~0u);
         CODEGEN_ASSERT(block.finish != ~0u);
+        CODEGEN_ASSERT(!seenFallback || block.kind == IrBlockKind::Fallback);
 
         // If we want to skip fallback code IR/asm, we'll record when those blocks start once we see them
         if (block.kind == IrBlockKind::Fallback && !seenFallback)

--- a/CodeGen/src/IrLoweringA64.cpp
+++ b/CodeGen/src/IrLoweringA64.cpp
@@ -12,7 +12,9 @@
 #include "lstate.h"
 #include "lgc.h"
 
+LUAU_FASTFLAG(LuauCodeGenUnassignedBcTargetAbort)
 LUAU_FASTFLAG(LuauCodeGenDirectBtest)
+LUAU_FASTFLAG(LuauCodeGenRegAutoSpillA64)
 
 namespace Luau
 {
@@ -255,7 +257,7 @@ IrLoweringA64::IrLoweringA64(AssemblyBuilderA64& build, ModuleHelpers& helpers, 
     , helpers(helpers)
     , function(function)
     , stats(stats)
-    , regs(function, stats, {{x0, x15}, {x16, x17}, {q0, q7}, {q16, q31}})
+    , regs(build, function, stats, {{x0, x15}, {x16, x17}, {q0, q7}, {q16, q31}})
     , valueTracker(function)
     , exitHandlerMap(~0u)
 {
@@ -264,13 +266,16 @@ IrLoweringA64::IrLoweringA64(AssemblyBuilderA64& build, ModuleHelpers& helpers, 
         [](void* context, IrInst& inst)
         {
             IrLoweringA64* self = static_cast<IrLoweringA64*>(context);
-            self->regs.restoreReg(self->build, inst);
+            self->regs.restoreReg(inst);
         }
     );
 }
 
 void IrLoweringA64::lowerInst(IrInst& inst, uint32_t index, const IrBlock& next)
 {
+    if (FFlag::LuauCodeGenRegAutoSpillA64)
+        regs.currInstIdx = index;
+
     valueTracker.beforeInstLowering(inst);
 
     switch (inst.cmd)
@@ -848,7 +853,7 @@ void IrLoweringA64::lowerInst(IrInst& inst, uint32_t index, const IrBlock& next)
     {
         IrCondition cond = conditionOp(inst.c);
 
-        regs.spill(build, index);
+        regs.spill(index);
         build.mov(x0, rState);
         build.add(x1, rBase, uint16_t(vmRegOp(inst.a) * sizeof(TValue)));
         build.add(x2, rBase, uint16_t(vmRegOp(inst.b) * sizeof(TValue)));
@@ -1025,7 +1030,7 @@ void IrLoweringA64::lowerInst(IrInst& inst, uint32_t index, const IrBlock& next)
     case IrCmd::TABLE_LEN:
     {
         RegisterA64 reg = regOp(inst.a); // note: we need to call regOp before spill so that we don't do redundant reloads
-        regs.spill(build, index, {reg});
+        regs.spill(index, {reg});
         build.mov(x0, reg);
         build.ldr(x1, mem(rNativeContext, offsetof(NativeContext, luaH_getn)));
         build.blr(x1);
@@ -1047,7 +1052,7 @@ void IrLoweringA64::lowerInst(IrInst& inst, uint32_t index, const IrBlock& next)
         RegisterA64 key = regOp(inst.b);
         RegisterA64 temp = regs.allocTemp(KindA64::w);
 
-        regs.spill(build, index, {table, key});
+        regs.spill(index, {table, key});
 
         if (w1 != key)
         {
@@ -1069,7 +1074,7 @@ void IrLoweringA64::lowerInst(IrInst& inst, uint32_t index, const IrBlock& next)
     }
     case IrCmd::NEW_TABLE:
     {
-        regs.spill(build, index);
+        regs.spill(index);
         build.mov(x0, rState);
         build.mov(x1, uintOp(inst.a));
         build.mov(x2, uintOp(inst.b));
@@ -1081,7 +1086,7 @@ void IrLoweringA64::lowerInst(IrInst& inst, uint32_t index, const IrBlock& next)
     case IrCmd::DUP_TABLE:
     {
         RegisterA64 reg = regOp(inst.a); // note: we need to call regOp before spill so that we don't do redundant reloads
-        regs.spill(build, index, {reg});
+        regs.spill(index, {reg});
         build.mov(x1, reg);
         build.mov(x0, rState);
         build.ldr(x2, mem(rNativeContext, offsetof(NativeContext, luaH_clone)));
@@ -1122,7 +1127,7 @@ void IrLoweringA64::lowerInst(IrInst& inst, uint32_t index, const IrBlock& next)
         build.tst(temp2, 1 << intOp(inst.b));             // can't use tbz/tbnz because their jump offsets are too short
         build.b(ConditionA64::NotEqual, labelOp(inst.c)); // Equal = Zero after tst; tmcache caches *absence* of metamethods
 
-        regs.spill(build, index, {temp1});
+        regs.spill(index, {temp1});
         build.mov(x0, temp1);
         build.mov(w1, intOp(inst.b));
         build.ldr(x2, mem(rGlobalState, offsetof(global_State, tmname) + intOp(inst.b) * sizeof(TString*)));
@@ -1136,7 +1141,7 @@ void IrLoweringA64::lowerInst(IrInst& inst, uint32_t index, const IrBlock& next)
     }
     case IrCmd::NEW_USERDATA:
     {
-        regs.spill(build, index);
+        regs.spill(index);
         build.mov(x0, rState);
         build.mov(x1, intOp(inst.a));
         build.mov(x2, intOp(inst.b));
@@ -1250,7 +1255,7 @@ void IrLoweringA64::lowerInst(IrInst& inst, uint32_t index, const IrBlock& next)
         break;
     }
     case IrCmd::FASTCALL:
-        regs.spill(build, index);
+        regs.spill(index);
 
         error |= !emitBuiltin(build, function, regs, uintOp(inst.a), vmRegOp(inst.b), vmRegOp(inst.c), intOp(inst.d));
         break;
@@ -1258,7 +1263,7 @@ void IrLoweringA64::lowerInst(IrInst& inst, uint32_t index, const IrBlock& next)
     {
         // We might need a temporary and we have to preserve it over the spill
         RegisterA64 temp = regs.allocTemp(KindA64::q);
-        regs.spill(build, index, {temp});
+        regs.spill(index, {temp});
 
         build.mov(x0, rState);
         build.add(x1, rBase, uint16_t(vmRegOp(inst.b) * sizeof(TValue)));
@@ -1311,7 +1316,7 @@ void IrLoweringA64::lowerInst(IrInst& inst, uint32_t index, const IrBlock& next)
         build.b(ConditionA64::Less, labelOp(inst.b));
         break;
     case IrCmd::DO_ARITH:
-        regs.spill(build, index);
+        regs.spill(index);
         build.mov(x0, rState);
         build.add(x1, rBase, uint16_t(vmRegOp(inst.a) * sizeof(TValue)));
 
@@ -1361,7 +1366,7 @@ void IrLoweringA64::lowerInst(IrInst& inst, uint32_t index, const IrBlock& next)
         emitUpdateBase(build);
         break;
     case IrCmd::DO_LEN:
-        regs.spill(build, index);
+        regs.spill(index);
         build.mov(x0, rState);
         build.add(x1, rBase, uint16_t(vmRegOp(inst.a) * sizeof(TValue)));
         build.add(x2, rBase, uint16_t(vmRegOp(inst.b) * sizeof(TValue)));
@@ -1371,7 +1376,7 @@ void IrLoweringA64::lowerInst(IrInst& inst, uint32_t index, const IrBlock& next)
         emitUpdateBase(build);
         break;
     case IrCmd::GET_TABLE:
-        regs.spill(build, index);
+        regs.spill(index);
         build.mov(x0, rState);
         build.add(x1, rBase, uint16_t(vmRegOp(inst.b) * sizeof(TValue)));
 
@@ -1393,7 +1398,7 @@ void IrLoweringA64::lowerInst(IrInst& inst, uint32_t index, const IrBlock& next)
         emitUpdateBase(build);
         break;
     case IrCmd::SET_TABLE:
-        regs.spill(build, index);
+        regs.spill(index);
         build.mov(x0, rState);
         build.add(x1, rBase, uint16_t(vmRegOp(inst.b) * sizeof(TValue)));
 
@@ -1415,7 +1420,7 @@ void IrLoweringA64::lowerInst(IrInst& inst, uint32_t index, const IrBlock& next)
         emitUpdateBase(build);
         break;
     case IrCmd::GET_IMPORT:
-        regs.spill(build, index);
+        regs.spill(index);
         // luaV_getimport(L, cl->env, k, ra, aux, /* propagatenil= */ false)
         build.mov(x0, rState);
         build.ldr(x1, mem(rClosure, offsetof(Closure, env)));
@@ -1430,7 +1435,7 @@ void IrLoweringA64::lowerInst(IrInst& inst, uint32_t index, const IrBlock& next)
         break;
     case IrCmd::GET_CACHED_IMPORT:
     {
-        regs.spill(build, index);
+        regs.spill(index);
 
         Label skip, exit;
 
@@ -1469,7 +1474,7 @@ void IrLoweringA64::lowerInst(IrInst& inst, uint32_t index, const IrBlock& next)
         break;
     }
     case IrCmd::CONCAT:
-        regs.spill(build, index);
+        regs.spill(index);
         build.mov(x0, rState);
         build.mov(w1, uintOp(inst.b));
         build.mov(w2, vmRegOp(inst.a) + uintOp(inst.b) - 1);
@@ -1520,7 +1525,7 @@ void IrLoweringA64::lowerInst(IrInst& inst, uint32_t index, const IrBlock& next)
             Label skip;
             checkObjectBarrierConditions(build, temp1, temp2, inst.b, inst.c.kind == IrOpKind::Undef ? -1 : tagOp(inst.c), skip);
 
-            size_t spills = regs.spill(build, index, {temp1});
+            size_t spills = regs.spill(index, {temp1});
 
             build.mov(x1, temp1);
             build.mov(x0, rState);
@@ -1528,7 +1533,7 @@ void IrLoweringA64::lowerInst(IrInst& inst, uint32_t index, const IrBlock& next)
             build.ldr(x3, mem(rNativeContext, offsetof(NativeContext, luaC_barrierf)));
             build.blr(x3);
 
-            regs.restore(build, spills); // need to restore before skip so that registers are in a consistent state
+            regs.restore(spills); // need to restore before skip so that registers are in a consistent state
 
             // note: no emitUpdateBase necessary because luaC_ barriers do not reallocate stack
             build.setLabel(skip);
@@ -1782,7 +1787,7 @@ void IrLoweringA64::lowerInst(IrInst& inst, uint32_t index, const IrBlock& next)
     }
     case IrCmd::INTERRUPT:
     {
-        regs.spill(build, index);
+        regs.spill(index);
 
         Label self;
 
@@ -1805,7 +1810,7 @@ void IrLoweringA64::lowerInst(IrInst& inst, uint32_t index, const IrBlock& next)
         build.cmp(temp1, temp2);
         build.b(ConditionA64::UnsignedGreater, skip);
 
-        size_t spills = regs.spill(build, index);
+        size_t spills = regs.spill(index);
 
         build.mov(x0, rState);
         build.mov(w1, 1);
@@ -1814,7 +1819,7 @@ void IrLoweringA64::lowerInst(IrInst& inst, uint32_t index, const IrBlock& next)
 
         emitUpdateBase(build);
 
-        regs.restore(build, spills); // need to restore before skip so that registers are in a consistent state
+        regs.restore(spills); // need to restore before skip so that registers are in a consistent state
 
         build.setLabel(skip);
         break;
@@ -1827,14 +1832,14 @@ void IrLoweringA64::lowerInst(IrInst& inst, uint32_t index, const IrBlock& next)
         checkObjectBarrierConditions(build, regOp(inst.a), temp, inst.b, inst.c.kind == IrOpKind::Undef ? -1 : tagOp(inst.c), skip);
 
         RegisterA64 reg = regOp(inst.a); // note: we need to call regOp before spill so that we don't do redundant reloads
-        size_t spills = regs.spill(build, index, {reg});
+        size_t spills = regs.spill(index, {reg});
         build.mov(x1, reg);
         build.mov(x0, rState);
         build.ldr(x2, mem(rBase, vmRegOp(inst.b) * sizeof(TValue) + offsetof(TValue, value)));
         build.ldr(x3, mem(rNativeContext, offsetof(NativeContext, luaC_barrierf)));
         build.blr(x3);
 
-        regs.restore(build, spills); // need to restore before skip so that registers are in a consistent state
+        regs.restore(spills); // need to restore before skip so that registers are in a consistent state
 
         // note: no emitUpdateBase necessary because luaC_ barriers do not reallocate stack
         build.setLabel(skip);
@@ -1850,14 +1855,14 @@ void IrLoweringA64::lowerInst(IrInst& inst, uint32_t index, const IrBlock& next)
         build.tbz(temp, BLACKBIT, skip);
 
         RegisterA64 reg = regOp(inst.a); // note: we need to call regOp before spill so that we don't do redundant reloads
-        size_t spills = regs.spill(build, index, {reg});
+        size_t spills = regs.spill(index, {reg});
         build.mov(x1, reg);
         build.mov(x0, rState);
         build.add(x2, x1, uint16_t(offsetof(LuaTable, gclist)));
         build.ldr(x3, mem(rNativeContext, offsetof(NativeContext, luaC_barrierback)));
         build.blr(x3);
 
-        regs.restore(build, spills); // need to restore before skip so that registers are in a consistent state
+        regs.restore(spills); // need to restore before skip so that registers are in a consistent state
 
         // note: no emitUpdateBase necessary because luaC_ barriers do not reallocate stack
         build.setLabel(skip);
@@ -1872,14 +1877,14 @@ void IrLoweringA64::lowerInst(IrInst& inst, uint32_t index, const IrBlock& next)
 
         RegisterA64 reg = regOp(inst.a); // note: we need to call regOp before spill so that we don't do redundant reloads
         AddressA64 addr = tempAddr(inst.b, offsetof(TValue, value));
-        size_t spills = regs.spill(build, index, {reg});
+        size_t spills = regs.spill(index, {reg});
         build.mov(x1, reg);
         build.mov(x0, rState);
         build.ldr(x2, addr);
         build.ldr(x3, mem(rNativeContext, offsetof(NativeContext, luaC_barriertable)));
         build.blr(x3);
 
-        regs.restore(build, spills); // need to restore before skip so that registers are in a consistent state
+        regs.restore(spills); // need to restore before skip so that registers are in a consistent state
 
         // note: no emitUpdateBase necessary because luaC_ barriers do not reallocate stack
         build.setLabel(skip);
@@ -1911,13 +1916,13 @@ void IrLoweringA64::lowerInst(IrInst& inst, uint32_t index, const IrBlock& next)
         build.cmp(temp2, temp1);
         build.b(ConditionA64::UnsignedGreater, skip);
 
-        size_t spills = regs.spill(build, index, {temp2});
+        size_t spills = regs.spill(index, {temp2});
         build.mov(x1, temp2);
         build.mov(x0, rState);
         build.ldr(x2, mem(rNativeContext, offsetof(NativeContext, luaF_close)));
         build.blr(x2);
 
-        regs.restore(build, spills); // need to restore before skip so that registers are in a consistent state
+        regs.restore(spills); // need to restore before skip so that registers are in a consistent state
 
         build.setLabel(skip);
         break;
@@ -1926,11 +1931,11 @@ void IrLoweringA64::lowerInst(IrInst& inst, uint32_t index, const IrBlock& next)
         // no-op
         break;
     case IrCmd::SETLIST:
-        regs.spill(build, index);
+        regs.spill(index);
         emitFallback(build, offsetof(NativeContext, executeSETLIST), uintOp(inst.a));
         break;
     case IrCmd::CALL:
-        regs.spill(build, index);
+        regs.spill(index);
         // argtop = (nparams == LUA_MULTRET) ? L->top : ra + 1 + nparams;
         if (intOp(inst.b) == LUA_MULTRET)
             build.ldr(x2, mem(rState, offsetof(lua_State, top)));
@@ -1950,7 +1955,7 @@ void IrLoweringA64::lowerInst(IrInst& inst, uint32_t index, const IrBlock& next)
         build.cbnz(x0, helpers.continueCall);
         break;
     case IrCmd::RETURN:
-        regs.spill(build, index);
+        regs.spill(index);
 
         if (function.variadic)
         {
@@ -2019,7 +2024,7 @@ void IrLoweringA64::lowerInst(IrInst& inst, uint32_t index, const IrBlock& next)
         break;
     case IrCmd::FORGLOOP:
         // register layout: ra + 1 = table, ra + 2 = internal index, ra + 3 .. ra + aux = iteration variables
-        regs.spill(build, index);
+        regs.spill(index);
         // clear extra variables since we might have more than two
         if (intOp(inst.b) > 2)
         {
@@ -2039,7 +2044,7 @@ void IrLoweringA64::lowerInst(IrInst& inst, uint32_t index, const IrBlock& next)
         jumpOrFallthrough(blockOp(inst.d), next);
         break;
     case IrCmd::FORGLOOP_FALLBACK:
-        regs.spill(build, index);
+        regs.spill(index);
         build.mov(x0, rState);
         build.mov(w1, vmRegOp(inst.a));
         build.mov(w2, intOp(inst.b));
@@ -2050,7 +2055,7 @@ void IrLoweringA64::lowerInst(IrInst& inst, uint32_t index, const IrBlock& next)
         jumpOrFallthrough(blockOp(inst.d), next);
         break;
     case IrCmd::FORGPREP_XNEXT_FALLBACK:
-        regs.spill(build, index);
+        regs.spill(index);
         build.mov(x0, rState);
         build.add(x1, rBase, uint16_t(vmRegOp(inst.b) * sizeof(TValue)));
         build.mov(w2, uintOp(inst.a) + 1);
@@ -2083,14 +2088,14 @@ void IrLoweringA64::lowerInst(IrInst& inst, uint32_t index, const IrBlock& next)
         CODEGEN_ASSERT(inst.b.kind == IrOpKind::VmReg);
         CODEGEN_ASSERT(inst.c.kind == IrOpKind::VmConst);
 
-        regs.spill(build, index);
+        regs.spill(index);
         emitFallback(build, offsetof(NativeContext, executeGETGLOBAL), uintOp(inst.a));
         break;
     case IrCmd::FALLBACK_SETGLOBAL:
         CODEGEN_ASSERT(inst.b.kind == IrOpKind::VmReg);
         CODEGEN_ASSERT(inst.c.kind == IrOpKind::VmConst);
 
-        regs.spill(build, index);
+        regs.spill(index);
         emitFallback(build, offsetof(NativeContext, executeSETGLOBAL), uintOp(inst.a));
         break;
     case IrCmd::FALLBACK_GETTABLEKS:
@@ -2098,7 +2103,7 @@ void IrLoweringA64::lowerInst(IrInst& inst, uint32_t index, const IrBlock& next)
         CODEGEN_ASSERT(inst.c.kind == IrOpKind::VmReg);
         CODEGEN_ASSERT(inst.d.kind == IrOpKind::VmConst);
 
-        regs.spill(build, index);
+        regs.spill(index);
         emitFallback(build, offsetof(NativeContext, executeGETTABLEKS), uintOp(inst.a));
         break;
     case IrCmd::FALLBACK_SETTABLEKS:
@@ -2106,7 +2111,7 @@ void IrLoweringA64::lowerInst(IrInst& inst, uint32_t index, const IrBlock& next)
         CODEGEN_ASSERT(inst.c.kind == IrOpKind::VmReg);
         CODEGEN_ASSERT(inst.d.kind == IrOpKind::VmConst);
 
-        regs.spill(build, index);
+        regs.spill(index);
         emitFallback(build, offsetof(NativeContext, executeSETTABLEKS), uintOp(inst.a));
         break;
     case IrCmd::FALLBACK_NAMECALL:
@@ -2114,20 +2119,20 @@ void IrLoweringA64::lowerInst(IrInst& inst, uint32_t index, const IrBlock& next)
         CODEGEN_ASSERT(inst.c.kind == IrOpKind::VmReg);
         CODEGEN_ASSERT(inst.d.kind == IrOpKind::VmConst);
 
-        regs.spill(build, index);
+        regs.spill(index);
         emitFallback(build, offsetof(NativeContext, executeNAMECALL), uintOp(inst.a));
         break;
     case IrCmd::FALLBACK_PREPVARARGS:
         CODEGEN_ASSERT(inst.b.kind == IrOpKind::Constant);
 
-        regs.spill(build, index);
+        regs.spill(index);
         emitFallback(build, offsetof(NativeContext, executePREPVARARGS), uintOp(inst.a));
         break;
     case IrCmd::FALLBACK_GETVARARGS:
         CODEGEN_ASSERT(inst.b.kind == IrOpKind::VmReg);
         CODEGEN_ASSERT(inst.c.kind == IrOpKind::Constant);
 
-        regs.spill(build, index);
+        regs.spill(index);
         build.mov(x0, rState);
 
         if (intOp(inst.c) == LUA_MULTRET)
@@ -2155,7 +2160,7 @@ void IrLoweringA64::lowerInst(IrInst& inst, uint32_t index, const IrBlock& next)
     {
         RegisterA64 reg = regOp(inst.b); // note: we need to call regOp before spill so that we don't do redundant reloads
 
-        regs.spill(build, index, {reg});
+        regs.spill(index, {reg});
         build.mov(x2, reg);
 
         build.mov(x0, rState);
@@ -2175,11 +2180,11 @@ void IrLoweringA64::lowerInst(IrInst& inst, uint32_t index, const IrBlock& next)
         CODEGEN_ASSERT(inst.b.kind == IrOpKind::VmReg);
         CODEGEN_ASSERT(inst.c.kind == IrOpKind::VmConst);
 
-        regs.spill(build, index);
+        regs.spill(index);
         emitFallback(build, offsetof(NativeContext, executeDUPCLOSURE), uintOp(inst.a));
         break;
     case IrCmd::FALLBACK_FORGPREP:
-        regs.spill(build, index);
+        regs.spill(index);
         emitFallback(build, offsetof(NativeContext, executeFORGPREP), uintOp(inst.a));
         jumpOrFallthrough(blockOp(inst.c), next);
         break;
@@ -2337,7 +2342,7 @@ void IrLoweringA64::lowerInst(IrInst& inst, uint32_t index, const IrBlock& next)
             RegisterA64 temp1 = tempDouble(inst.b);
             RegisterA64 temp2 = isInt ? tempInt(inst.c) : tempDouble(inst.c);
             RegisterA64 temp3 = isInt ? noreg : regs.allocTemp(KindA64::d); // note: spill() frees all registers so we need to avoid alloc after spill
-            regs.spill(build, index, {temp1, temp2});
+            regs.spill(index, {temp1, temp2});
 
             if (isInt)
             {
@@ -2359,7 +2364,7 @@ void IrLoweringA64::lowerInst(IrInst& inst, uint32_t index, const IrBlock& next)
         else
         {
             RegisterA64 temp1 = tempDouble(inst.b);
-            regs.spill(build, index, {temp1});
+            regs.spill(index, {temp1});
             build.fmov(d0, temp1);
         }
 
@@ -2386,7 +2391,7 @@ void IrLoweringA64::lowerInst(IrInst& inst, uint32_t index, const IrBlock& next)
     }
     case IrCmd::GET_TYPEOF:
     {
-        regs.spill(build, index);
+        regs.spill(index);
         build.mov(x0, rState);
         build.add(x1, rBase, uint16_t(vmRegOp(inst.a) * sizeof(TValue)));
         build.ldr(x2, mem(rNativeContext, offsetof(NativeContext, luaT_objtypenamestr)));
@@ -2398,7 +2403,7 @@ void IrLoweringA64::lowerInst(IrInst& inst, uint32_t index, const IrBlock& next)
 
     case IrCmd::FINDUPVAL:
     {
-        regs.spill(build, index);
+        regs.spill(index);
         build.mov(x0, rState);
         build.add(x1, rBase, uint16_t(vmRegOp(inst.a) * sizeof(TValue)));
         build.ldr(x2, mem(rNativeContext, offsetof(NativeContext, luaF_findupval)));
@@ -2525,6 +2530,9 @@ void IrLoweringA64::lowerInst(IrInst& inst, uint32_t index, const IrBlock& next)
 
     valueTracker.afterInstLowering(inst, index);
 
+    if (FFlag::LuauCodeGenRegAutoSpillA64)
+        regs.currInstIdx = kInvalidInstIdx;
+
     regs.freeLastUseRegs(inst, index);
     regs.freeTempRegs();
 }
@@ -2566,6 +2574,13 @@ void IrLoweringA64::finishFunction()
 
         build.mov(x0, handler.pcpos * sizeof(Instruction));
         build.b(helpers.updatePcAndContinueInVm);
+    }
+
+    if (FFlag::LuauCodeGenUnassignedBcTargetAbort)
+    {
+        // An undefined instruction is placed after the function to be used as an aborting jump offset
+        function.endLocation = build.setLabel().location;
+        build.udf();
     }
 
     if (stats)
@@ -2780,7 +2795,7 @@ RegisterA64 IrLoweringA64::regOp(IrOp op)
     IrInst& inst = function.instOp(op);
 
     if (inst.spilled || inst.needsReload)
-        regs.restoreReg(build, inst);
+        regs.restoreReg(inst);
 
     CODEGEN_ASSERT(inst.regA64 != noreg);
     return inst.regA64;

--- a/CodeGen/src/IrRegAllocX64.cpp
+++ b/CodeGen/src/IrRegAllocX64.cpp
@@ -6,6 +6,8 @@
 
 #include "EmitCommonX64.h"
 
+LUAU_FASTFLAG(LuauCodeGenRegAutoSpillA64)
+
 namespace Luau
 {
 namespace CodeGen
@@ -393,6 +395,12 @@ OperandX64 IrRegAllocX64::getRestoreAddress(const IrInst& inst, IrOp restoreOp)
 
 uint32_t IrRegAllocX64::findInstructionWithFurthestNextUse(const std::array<uint32_t, 16>& regInstUsers) const
 {
+    if (FFlag::LuauCodeGenRegAutoSpillA64)
+    {
+        if (currInstIdx == kInvalidInstIdx)
+            return kInvalidInstIdx;
+    }
+
     uint32_t furthestUseTarget = kInvalidInstIdx;
     uint32_t furthestUseLocation = 0;
 

--- a/CodeGen/src/OptimizeConstProp.cpp
+++ b/CodeGen/src/OptimizeConstProp.cpp
@@ -504,7 +504,7 @@ struct ConstPropState
 
     // Heap changes might affect table state
     std::vector<NumberedInstruction> getSlotNodeCache; // Additionally, pcpos argument might be different
-    std::vector<uint32_t> checkSlotMatchCache; // Additionally, fallback block argument might be different
+    std::vector<uint32_t> checkSlotMatchCache;         // Additionally, fallback block argument might be different
 
     std::vector<uint32_t> getArrAddrCache;
     std::vector<uint32_t> checkArraySizeCache; // Additionally, fallback block argument might be different

--- a/Common/include/Luau/DenseHash.h
+++ b/Common/include/Luau/DenseHash.h
@@ -1,6 +1,7 @@
 // This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
 #pragma once
 
+#include "Luau/HashUtil.h"
 #include "Luau/Common.h"
 
 #include <stddef.h>
@@ -12,20 +13,9 @@
 namespace Luau
 {
 
-struct DenseHashPointer
-{
-    size_t operator()(const void* key) const
-    {
-        return (uintptr_t(key) >> 4) ^ (uintptr_t(key) >> 9);
-    }
-};
-
 // Internal implementation of DenseHashSet and DenseHashMap
 namespace detail
 {
-
-template<typename T>
-using DenseHashDefault = std::conditional_t<std::is_pointer_v<T>, DenseHashPointer, std::hash<T>>;
 
 template<typename Key, typename Item, typename MutableItem, typename ItemInterface, typename Hash, typename Eq>
 class DenseHashTable

--- a/Common/include/Luau/HashUtil.h
+++ b/Common/include/Luau/HashUtil.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include "Luau/Common.h"
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include <functional>
+#include <type_traits>
+#include <utility>
+
+namespace Luau
+{
+
+struct DenseHashPointer
+{
+    size_t operator()(const void* key) const
+    {
+        return (uintptr_t(key) >> 4) ^ (uintptr_t(key) >> 9);
+    }
+};
+
+namespace detail
+{
+
+template<typename T>
+using DenseHashDefault = std::conditional_t<std::is_pointer_v<T>, DenseHashPointer, std::hash<T>>;
+
+} // namespace detail
+
+inline void hashCombine(size_t& seed, size_t hash)
+{
+    // Golden Ratio constant used for better hash scattering
+    // See https://softwareengineering.stackexchange.com/a/402543
+    seed ^= hash + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+}
+
+template<typename T1, typename T2, typename H1 = detail::DenseHashDefault<T1>, typename H2 = detail::DenseHashDefault<T2>>
+struct PairHash
+{
+    std::size_t operator()(const std::pair<T1, T2>& p) const noexcept
+    {
+        std::size_t seed = 0;
+        hashCombine(seed, h1(p.first));
+        hashCombine(seed, h2(p.second));
+        return seed;
+    }
+
+private:
+    H1 h1;
+    H2 h2;
+};
+
+} // namespace Luau

--- a/EqSat/include/Luau/LanguageHash.h
+++ b/EqSat/include/Luau/LanguageHash.h
@@ -1,6 +1,8 @@
 // This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
 #pragma once
 
+#include "Luau/HashUtil.h"
+
 #include <cstddef>
 #include <functional>
 #include <unordered_set>
@@ -22,13 +24,6 @@ template<typename T>
 size_t languageHash(const T& lang)
 {
     return LanguageHash<T>{}(lang);
-}
-
-inline void hashCombine(size_t& seed, size_t hash)
-{
-    // Golden Ratio constant used for better hash scattering
-    // See https://softwareengineering.stackexchange.com/a/402543
-    seed ^= hash + 0x9e3779b9 + (seed << 6) + (seed >> 2);
 }
 
 template<typename T, size_t I>

--- a/Sources.cmake
+++ b/Sources.cmake
@@ -7,6 +7,7 @@ if(NOT ${CMAKE_VERSION} VERSION_LESS "3.19")
         Common/include/Luau/BytecodeUtils.h
         Common/include/Luau/DenseHash.h
         Common/include/Luau/ExperimentalFlags.h
+        Common/include/Luau/HashUtil.h
         Common/include/Luau/Variant.h
         Common/include/Luau/VecDeque.h
     )
@@ -172,6 +173,7 @@ target_sources(Luau.Analysis PRIVATE
     Analysis/include/Luau/ApplyTypeFunction.h
     Analysis/include/Luau/AstJsonEncoder.h
     Analysis/include/Luau/AstQuery.h
+    Analysis/include/Luau/AstUtils.h
     Analysis/include/Luau/Autocomplete.h
     Analysis/include/Luau/AutocompleteTypes.h
     Analysis/include/Luau/BuiltinDefinitions.h
@@ -257,6 +259,7 @@ target_sources(Luau.Analysis PRIVATE
     Analysis/src/ApplyTypeFunction.cpp
     Analysis/src/AstJsonEncoder.cpp
     Analysis/src/AstQuery.cpp
+    Analysis/src/AstUtils.cpp
     Analysis/src/Autocomplete.cpp
     Analysis/src/AutocompleteCore.cpp
     Analysis/src/BuiltinDefinitions.cpp

--- a/VM/src/lstrlib.cpp
+++ b/VM/src/lstrlib.cpp
@@ -477,7 +477,7 @@ init: // using goto's to optimize tail recursion
                 {
                     p += 4;
                     goto init; // return match(ms, s, p + 4);
-                }              // else fail (s == NULL)
+                } // else fail (s == NULL)
                 break;
             }
             case 'f':
@@ -555,7 +555,7 @@ init: // using goto's to optimize tail recursion
                 case '+':             // 1 or more repetitions
                     s++;              // 1 match already done
                     LUAU_FALLTHROUGH; // go through
-                case '*': // 0 or more repetitions
+                case '*':             // 0 or more repetitions
                     s = max_expand(ms, s, p, ep);
                     break;
                 case '-': // 0 or more repetitions (minimum)

--- a/VM/src/lutf8lib.cpp
+++ b/VM/src/lutf8lib.cpp
@@ -134,9 +134,9 @@ static int luaO_utf8esc(char* buff, unsigned long x)
         do
         { // add continuation bytes
             buff[UTF8BUFFSZ - (n++)] = cast_to(char, 0x80 | (x & 0x3f));
-            x >>= 6;                                           // remove added bits
-            mfb >>= 1;                                         // now there is one less bit available in first byte
-        } while (x > mfb);                                     // still needs continuation byte?
+            x >>= 6;   // remove added bits
+            mfb >>= 1; // now there is one less bit available in first byte
+        } while (x > mfb); // still needs continuation byte?
         buff[UTF8BUFFSZ - n] = cast_to(char, (~mfb << 1) | x); // add first byte
     }
     return n;

--- a/extern/doctest.h
+++ b/extern/doctest.h
@@ -3465,7 +3465,7 @@ using ticks_t = timer_large_integer::type;
         MultiLaneAtomic<int> numAssertsCurrentTest_atomic;
         MultiLaneAtomic<int> numAssertsFailedCurrentTest_atomic;
 
-        std::vector<std::vector<String>> filters = decltype(filters)(9); // 9 different filters
+        std::vector<std::vector<String>> filters = decltype(filters)(10); // 10 different filters
 
         std::vector<IReporter*> reporters_currently_used;
 
@@ -6562,6 +6562,8 @@ void Context::parseArgs(int argc, const char* const* argv, bool withDefaults) {
     parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "sce=",                p->filters[7]);
     parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "reporters=",          p->filters[8]);
     parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "r=",                  p->filters[8]);
+    parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "test-path=",          p->filters[9]);
+    parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "tp=",                 p->filters[9]);
     // clang-format on
 
     int    intRes = 0;
@@ -6859,6 +6861,8 @@ int Context::run() {
         if(!matchesAny(tc.m_name, p->filters[4], true, p->case_sensitive))
             skip_me = true;
         if(matchesAny(tc.m_name, p->filters[5], false, p->case_sensitive))
+            skip_me = true;
+        if(!matchesAny((String(tc.m_test_suite) + "/" + String(tc.m_name)).c_str(), p->filters[9], true, p->case_sensitive))
             skip_me = true;
 
         if(!skip_me)

--- a/tests/AstJsonEncoder.test.cpp
+++ b/tests/AstJsonEncoder.test.cpp
@@ -105,8 +105,7 @@ TEST_CASE("encode_AstStatBlock")
 
     CHECK(
         toJson(&block) ==
-        (R"({"type":"AstStatBlock","location":"0,0 - 0,0","hasEnd":true,"body":[{"type":"AstStatLocal","location":"0,0 - 0,0","vars":[{"luauType":null,"name":"a_local","type":"AstLocal","location":"0,0 - 0,0"}],"values":[]}]})"
-        )
+        (R"({"type":"AstStatBlock","location":"0,0 - 0,0","hasEnd":true,"body":[{"type":"AstStatLocal","location":"0,0 - 0,0","vars":[{"luauType":null,"name":"a_local","type":"AstLocal","location":"0,0 - 0,0"}],"values":[]}]})")
     );
 }
 

--- a/tests/Autocomplete.test.cpp
+++ b/tests/Autocomplete.test.cpp
@@ -3992,8 +3992,8 @@ TEST_CASE_FIXTURE(ACFixture, "string_completion_outside_quotes")
         local x = require(@1"@2"@3)
     )");
 
-    StringCompletionCallback callback = [](std::string, std::optional<const ExternType*>, std::optional<std::string> contents
-                                        ) -> std::optional<AutocompleteEntryMap>
+    StringCompletionCallback callback =
+        [](std::string, std::optional<const ExternType*>, std::optional<std::string> contents) -> std::optional<AutocompleteEntryMap>
     {
         Luau::AutocompleteEntryMap results = {{"test", Luau::AutocompleteEntry{Luau::AutocompleteEntryKind::String, std::nullopt, false, false}}};
         return results;

--- a/tests/ClassFixture.cpp
+++ b/tests/ClassFixture.cpp
@@ -111,10 +111,12 @@ Frontend& ExternTypeFixture::getFrontend()
     getMutable<TableType>(vector2MetaType)->props = {
         {"__add", {makeFunction(arena, nullopt, {vector2InstanceType, vector2InstanceType}, {vector2InstanceType})}},
         {"__mul",
-         {arena.addType(IntersectionType{{
-             makeFunction(arena, vector2InstanceType, {vector2InstanceType}, {vector2InstanceType}),
-             makeFunction(arena, vector2InstanceType, {getBuiltins()->numberType}, {vector2InstanceType}),
-         }})}}
+         {arena.addType(
+             IntersectionType{{
+                 makeFunction(arena, vector2InstanceType, {vector2InstanceType}, {vector2InstanceType}),
+                 makeFunction(arena, vector2InstanceType, {getBuiltins()->numberType}, {vector2InstanceType}),
+             }}
+         )}}
     };
     globals.globalScope->exportedTypeBindings["Vector2"] = TypeFun{{}, vector2InstanceType};
     addGlobalBinding(globals, "Vector2", vector2Type, "@test");

--- a/tests/CodeAllocator.test.cpp
+++ b/tests/CodeAllocator.test.cpp
@@ -736,7 +736,8 @@ TEST_CASE("GeneratedCodeExecutionWithThrowOutsideTheGateX64")
     uint8_t* nativeData1;
     size_t sizeNativeData1;
     uint8_t* nativeEntry1;
-    REQUIRE(allocator.allocate(build.data.data(), build.data.size(), build.code.data(), build.code.size(), nativeData1, sizeNativeData1, nativeEntry1)
+    REQUIRE(
+        allocator.allocate(build.data.data(), build.data.size(), build.code.data(), build.code.size(), nativeData1, sizeNativeData1, nativeEntry1)
     );
     REQUIRE(nativeEntry1);
 

--- a/tests/Compiler.test.cpp
+++ b/tests/Compiler.test.cpp
@@ -2087,8 +2087,10 @@ until (function() return rr end)() < 0.5
 
     // unless that upvalue is from an outer scope
     CHECK_EQ(
-        "\n" + compileFunction0("local stop = false stop = true function test() repeat local r = math.random() if r > 0.5 then "
-                                "continue end r = r + 0.3 until stop or r < 0.5 end"),
+        "\n" + compileFunction0(
+                   "local stop = false stop = true function test() repeat local r = math.random() if r > 0.5 then "
+                   "continue end r = r + 0.3 until stop or r < 0.5 end"
+               ),
         R"(
 L0: GETIMPORT R0 2 [math.random]
 CALL R0 0 1

--- a/tests/Conformance.test.cpp
+++ b/tests/Conformance.test.cpp
@@ -44,6 +44,7 @@ LUAU_FASTFLAG(LuauTypeCheckerVectorLerp)
 LUAU_FASTFLAG(LuauCodeGenVectorLerp)
 LUAU_DYNAMIC_FASTFLAG(LuauXpcallContNoYield)
 LUAU_FASTFLAG(LuauCodeGenBetterBytecodeAnalysis)
+LUAU_FASTFLAG(LuauCodeGenRegAutoSpillA64)
 
 static lua_CompileOptions defaultOptions()
 {
@@ -3149,6 +3150,7 @@ TEST_CASE("SafeEnv")
 TEST_CASE("Native")
 {
     ScopedFastFlag luauCodeGenDirectBtest{FFlag::LuauCodeGenDirectBtest, true};
+    ScopedFastFlag luauCodeGenRegAutoSpillA64{FFlag::LuauCodeGenRegAutoSpillA64, true};
 
     // This tests requires code to run natively, otherwise all 'is_native' checks will fail
     if (!codegen || !luau_codegen_supported())

--- a/tests/ConstraintGeneratorFixture.cpp
+++ b/tests/ConstraintGeneratorFixture.cpp
@@ -56,7 +56,7 @@ void ConstraintGeneratorFixture::solve(const std::string& code)
         NotNull{rootScope},
         constraints,
         NotNull{&cg->scopeToFunction},
-        "MainModule",
+        mainModule,
         NotNull(&moduleResolver),
         {},
         &logger,

--- a/tests/EqSatSimplification.test.cpp
+++ b/tests/EqSatSimplification.test.cpp
@@ -163,9 +163,10 @@ TEST_CASE_FIXTURE(ESFixture, "never & string")
 TEST_CASE_FIXTURE(ESFixture, "string & (unknown | never)")
 {
     CHECK(
-        "string" == simplifyStr(arena->addType(IntersectionType{
-                        {getBuiltins()->stringType, arena->addType(UnionType{{getBuiltins()->unknownType, getBuiltins()->neverType}})}
-                    }))
+        "string" ==
+        simplifyStr(arena->addType(
+            IntersectionType{{getBuiltins()->stringType, arena->addType(UnionType{{getBuiltins()->unknownType, getBuiltins()->neverType}})}}
+        ))
     );
 }
 
@@ -217,28 +218,32 @@ TEST_CASE_FIXTURE(ESFixture, "\"hello\" | string")
 TEST_CASE_FIXTURE(ESFixture, "\"hello\" | \"world\" | \"hello\"")
 {
     CHECK(
-        "\"hello\" | \"world\"" == simplifyStr(arena->addType(UnionType{{
-                                       arena->addType(SingletonType{StringSingleton{"hello"}}),
-                                       arena->addType(SingletonType{StringSingleton{"world"}}),
-                                       arena->addType(SingletonType{StringSingleton{"hello"}}),
-                                   }}))
+        "\"hello\" | \"world\"" == simplifyStr(arena->addType(
+                                       UnionType{{
+                                           arena->addType(SingletonType{StringSingleton{"hello"}}),
+                                           arena->addType(SingletonType{StringSingleton{"world"}}),
+                                           arena->addType(SingletonType{StringSingleton{"hello"}}),
+                                       }}
+                                   ))
     );
 }
 
 TEST_CASE_FIXTURE(ESFixture, "nil | boolean | number | string | thread | function | table | class | buffer")
 {
     CHECK(
-        "unknown" == simplifyStr(arena->addType(UnionType{{
-                         getBuiltins()->nilType,
-                         getBuiltins()->booleanType,
-                         getBuiltins()->numberType,
-                         getBuiltins()->stringType,
-                         getBuiltins()->threadType,
-                         getBuiltins()->functionType,
-                         getBuiltins()->tableType,
-                         getBuiltins()->externType,
-                         getBuiltins()->bufferType,
-                     }}))
+        "unknown" == simplifyStr(arena->addType(
+                         UnionType{{
+                             getBuiltins()->nilType,
+                             getBuiltins()->booleanType,
+                             getBuiltins()->numberType,
+                             getBuiltins()->stringType,
+                             getBuiltins()->threadType,
+                             getBuiltins()->functionType,
+                             getBuiltins()->tableType,
+                             getBuiltins()->externType,
+                             getBuiltins()->bufferType,
+                         }}
+                     ))
     );
 }
 
@@ -285,12 +290,14 @@ TEST_CASE_FIXTURE(ESFixture, "never | Parent | Unrelated")
 TEST_CASE_FIXTURE(ESFixture, "never | Parent | (number & string) | Unrelated")
 {
     CHECK(
-        "Parent | Unrelated" == simplifyStr(arena->addType(UnionType{
-                                    {getBuiltins()->neverType,
-                                     parentClass,
-                                     arena->addType(IntersectionType{{getBuiltins()->numberType, getBuiltins()->stringType}}),
-                                     unrelatedClass}
-                                }))
+        "Parent | Unrelated" == simplifyStr(arena->addType(
+                                    UnionType{
+                                        {getBuiltins()->neverType,
+                                         parentClass,
+                                         arena->addType(IntersectionType{{getBuiltins()->numberType, getBuiltins()->stringType}}),
+                                         unrelatedClass}
+                                    }
+                                ))
     );
 }
 
@@ -306,16 +313,18 @@ TEST_CASE_FIXTURE(ESFixture, "boolean & true")
 
 TEST_CASE_FIXTURE(ESFixture, "boolean & (true | number | string | thread | function | table | class | buffer)")
 {
-    TypeId truthy = arena->addType(UnionType{{
-        getBuiltins()->trueType,
-        getBuiltins()->numberType,
-        getBuiltins()->stringType,
-        getBuiltins()->threadType,
-        getBuiltins()->functionType,
-        getBuiltins()->tableType,
-        getBuiltins()->externType,
-        getBuiltins()->bufferType,
-    }});
+    TypeId truthy = arena->addType(
+        UnionType{{
+            getBuiltins()->trueType,
+            getBuiltins()->numberType,
+            getBuiltins()->stringType,
+            getBuiltins()->threadType,
+            getBuiltins()->functionType,
+            getBuiltins()->tableType,
+            getBuiltins()->externType,
+            getBuiltins()->bufferType,
+        }}
+    );
 
     CHECK("true" == simplifyStr(arena->addType(IntersectionType{{getBuiltins()->booleanType, truthy}})));
 }
@@ -387,9 +396,9 @@ TEST_CASE_FIXTURE(ESFixture, "add<number, number>")
 TEST_CASE_FIXTURE(ESFixture, "union<number, number>")
 {
     CHECK(
-        "number" ==
-        simplifyStr(arena->addType(TypeFunctionInstanceType{builtinTypeFunctions().unionFunc, {getBuiltins()->numberType, getBuiltins()->numberType}})
-        )
+        "number" == simplifyStr(arena->addType(
+                        TypeFunctionInstanceType{builtinTypeFunctions().unionFunc, {getBuiltins()->numberType, getBuiltins()->numberType}}
+                    ))
     );
 }
 
@@ -421,9 +430,11 @@ TEST_CASE_FIXTURE(ESFixture, "blocked & ~number & function")
 
 TEST_CASE_FIXTURE(ESFixture, "(number | boolean | string | nil | table) & (false | nil)")
 {
-    const TypeId t1 = arena->addType(UnionType{
-        {getBuiltins()->numberType, getBuiltins()->booleanType, getBuiltins()->stringType, getBuiltins()->nilType, getBuiltins()->tableType}
-    });
+    const TypeId t1 = arena->addType(
+        UnionType{
+            {getBuiltins()->numberType, getBuiltins()->booleanType, getBuiltins()->stringType, getBuiltins()->nilType, getBuiltins()->tableType}
+        }
+    );
 
     CHECK("false?" == simplifyStr(arena->addType(IntersectionType{{t1, getBuiltins()->falsyType}})));
 }

--- a/tests/Generalization.test.cpp
+++ b/tests/Generalization.test.cpp
@@ -166,10 +166,12 @@ TEST_CASE_FIXTURE(GeneralizationFixture, "functions_containing_cyclic_tables_can
 {
     TypeId selfTy = arena.addType(BlockedType{});
 
-    TypeId methodTy = arena.addType(FunctionType{
-        arena.addTypePack({selfTy}),
-        arena.addTypePack({builtinTypes.numberType}),
-    });
+    TypeId methodTy = arena.addType(
+        FunctionType{
+            arena.addTypePack({selfTy}),
+            arena.addTypePack({builtinTypes.numberType}),
+        }
+    );
 
     asMutable(selfTy)->ty.emplace<TableType>(
         TableType::Props{{"count", builtinTypes.numberType}, {"method", methodTy}}, std::nullopt, TypeLevel{}, TableState::Sealed

--- a/tests/InferPolarity.test.cpp
+++ b/tests/InferPolarity.test.cpp
@@ -24,13 +24,15 @@ TEST_CASE_FIXTURE(Fixture, "T where T = { m: <a>(a) -> T }")
     TypeId tType = arena.addType(BlockedType{});
     TypeId aType = arena.addType(GenericType{globalScope.get(), "a"});
 
-    TypeId mType = arena.addType(FunctionType{
-        TypeLevel{},
-        /* generics */ {aType},
-        /* genericPacks */ {},
-        /* argPack */ arena.addTypePack({aType}),
-        /* retPack */ arena.addTypePack({tType})
-    });
+    TypeId mType = arena.addType(
+        FunctionType{
+            TypeLevel{},
+            /* generics */ {aType},
+            /* genericPacks */ {},
+            /* argPack */ arena.addTypePack({aType}),
+            /* retPack */ arena.addTypePack({tType})
+        }
+    );
 
     emplaceType<TableType>(
         asMutable(tType),
@@ -66,13 +68,15 @@ TEST_CASE_FIXTURE(Fixture, "<a, b>({ read x: a, write x: b }) -> ()")
     ttv.state = TableState::Sealed;
     ttv.props["x"] = Property::create({aType}, {bType});
 
-    TypeId mType = arena.addType(FunctionType{
-        TypeLevel{},
-        /* generics */ {aType, bType},
-        /* genericPacks */ {},
-        /* argPack */ arena.addTypePack({arena.addType(std::move(ttv))}),
-        /* retPack */ builtinTypes->emptyTypePack,
-    });
+    TypeId mType = arena.addType(
+        FunctionType{
+            TypeLevel{},
+            /* generics */ {aType, bType},
+            /* genericPacks */ {},
+            /* argPack */ arena.addTypePack({arena.addType(std::move(ttv))}),
+            /* retPack */ builtinTypes->emptyTypePack,
+        }
+    );
 
     inferGenericPolarities(NotNull{&arena}, NotNull{globalScope.get()}, mType);
 

--- a/tests/Instantiation2.test.cpp
+++ b/tests/Instantiation2.test.cpp
@@ -20,12 +20,12 @@ TEST_CASE_FIXTURE(Fixture, "weird_cyclic_instantiation")
 
     TypeId genericT = arena.addType(GenericType{"T"});
 
-    TypeId idTy = arena.addType(FunctionType{
-        /* generics */ {genericT},
-        /* genericPacks */ {},
-        /* argTypes */ arena.addTypePack({genericT}),
-        /* retTypes */ arena.addTypePack({genericT})
-    });
+    TypeId idTy = arena.addType(
+        FunctionType{/* generics */ {genericT},
+                     /* genericPacks */ {},
+                     /* argTypes */ arena.addTypePack({genericT}),
+                     /* retTypes */ arena.addTypePack({genericT})}
+    );
 
     DenseHashMap<TypeId, TypeId> genericSubstitutions{nullptr};
     DenseHashMap<TypePackId, TypePackId> genericPackSubstitutions{nullptr};

--- a/tests/Linter.test.cpp
+++ b/tests/Linter.test.cpp
@@ -1986,7 +1986,9 @@ Account:deposit(200.00)
 )");
 
         REQUIRE(1 == result.warnings.size());
-        checkDeprecatedWarning(result.warnings[0], Position(8, 0), Position(8, 15), "Member 'Account.deposit' is deprecated, use 'credit' instead. It sounds cool");
+        checkDeprecatedWarning(
+            result.warnings[0], Position(8, 0), Position(8, 15), "Member 'Account.deposit' is deprecated, use 'credit' instead. It sounds cool"
+        );
     }
 
     // @deprecated works for methods with a compound expression class name
@@ -2007,7 +2009,9 @@ end
 )");
 
         REQUIRE(1 == result.warnings.size());
-        checkDeprecatedWarning(result.warnings[0], Position(12, 0), Position(12, 22), "Member 'deposit' is deprecated, use 'credit' instead. It sounds cool");
+        checkDeprecatedWarning(
+            result.warnings[0], Position(12, 0), Position(12, 22), "Member 'deposit' is deprecated, use 'credit' instead. It sounds cool"
+        );
     }
 
     {

--- a/tests/NonStrictTypeChecker.test.cpp
+++ b/tests/NonStrictTypeChecker.test.cpp
@@ -65,9 +65,7 @@ using namespace Luau;
 struct NonStrictTypeCheckerFixture : Fixture
 {
 
-    NonStrictTypeCheckerFixture()
-    {
-    }
+    NonStrictTypeCheckerFixture() {}
 
     CheckResult checkNonStrict(const std::string& code)
     {

--- a/tests/Normalize.test.cpp
+++ b/tests/Normalize.test.cpp
@@ -458,9 +458,7 @@ struct NormalizeFixture : Fixture
     InternalErrorReporter iceHandler;
     UnifierSharedState unifierState{&iceHandler};
 
-    NormalizeFixture()
-    {
-    }
+    NormalizeFixture() {}
 
     std::shared_ptr<const NormalizedType> toNormalizedType(const std::string& annotation, int expectedErrors = 0)
     {
@@ -1084,10 +1082,12 @@ TEST_CASE_FIXTURE(NormalizeFixture, "truthy_table_property_and_optional_table_wi
     TypeId t1 = arena.addType(TableType{TableType::Props{{"x", getBuiltins()->truthyType}}, std::nullopt, TypeLevel{}, TableState::Sealed});
 
     // { x: number? }?
-    TypeId t2 = arena.addType(UnionType{
-        {arena.addType(TableType{TableType::Props{{"x", getBuiltins()->optionalNumberType}}, std::nullopt, TypeLevel{}, TableState::Sealed}),
-         getBuiltins()->nilType}
-    });
+    TypeId t2 = arena.addType(
+        UnionType{
+            {arena.addType(TableType{TableType::Props{{"x", getBuiltins()->optionalNumberType}}, std::nullopt, TypeLevel{}, TableState::Sealed}),
+             getBuiltins()->nilType}
+        }
+    );
 
     TypeId intersection = arena.addType(IntersectionType{{t2, t1}});
 

--- a/tests/Parser.test.cpp
+++ b/tests/Parser.test.cpp
@@ -3814,9 +3814,7 @@ TEST_CASE_FIXTURE(Fixture, "do_not_hang_on_incomplete_attribute_list")
 function hello(x, y)
     return x + y
 end)");
-    checkFirstErrorForAttributes(
-        result.errors, 1, Location(Position(1, 0), Position(1, 3)), "Attribute list cannot be empty"
-    );
+    checkFirstErrorForAttributes(result.errors, 1, Location(Position(1, 0), Position(1, 3)), "Attribute list cannot be empty");
 
     result = tryParse(R"(@[)");
 
@@ -3836,9 +3834,7 @@ end)");
         local function foo() end
     )");
 
-    checkFirstErrorForAttributes(
-        result.errors, 1, Location(Position(1, 8), Position(1, 13)), "Expected ']' (to close '@[' at line 1), got 'local'"
-    );
+    checkFirstErrorForAttributes(result.errors, 1, Location(Position(1, 8), Position(1, 13)), "Expected ']' (to close '@[' at line 1), got 'local'");
 }
 
 TEST_CASE_FIXTURE(Fixture, "parse_attribute_for_function_expression")

--- a/tests/TypeFunction.test.cpp
+++ b/tests/TypeFunction.test.cpp
@@ -29,34 +29,33 @@ struct TypeFunctionFixture : Fixture
     TypeFunctionFixture()
         : Fixture(false)
     {
-        swapFunction = TypeFunction{
-            /* name */ "Swap",
-            /* reducer */
-            [](TypeId instance, const std::vector<TypeId>& tys, const std::vector<TypePackId>& tps, NotNull<TypeFunctionContext> ctx
-            ) -> TypeFunctionReductionResult<TypeId>
-            {
-                LUAU_ASSERT(tys.size() == 1);
-                TypeId param = follow(tys.at(0));
+        swapFunction =
+            TypeFunction{/* name */ "Swap",
+                         /* reducer */
+                         [](TypeId instance, const std::vector<TypeId>& tys, const std::vector<TypePackId>& tps, NotNull<TypeFunctionContext> ctx)
+                             -> TypeFunctionReductionResult<TypeId>
+                         {
+                             LUAU_ASSERT(tys.size() == 1);
+                             TypeId param = follow(tys.at(0));
 
-                if (isString(param))
-                {
-                    return TypeFunctionReductionResult<TypeId>{ctx->builtins->numberType, Reduction::MaybeOk, {}, {}};
-                }
-                else if (isNumber(param))
-                {
-                    return TypeFunctionReductionResult<TypeId>{ctx->builtins->stringType, Reduction::MaybeOk, {}, {}};
-                }
-                else if (is<BlockedType>(param) || is<PendingExpansionType>(param) || is<TypeFunctionInstanceType>(param) ||
-                         (ctx->solver && ctx->solver->hasUnresolvedConstraints(param)))
-                {
-                    return TypeFunctionReductionResult<TypeId>{std::nullopt, Reduction::MaybeOk, {param}, {}};
-                }
-                else
-                {
-                    return TypeFunctionReductionResult<TypeId>{std::nullopt, Reduction::Erroneous, {}, {}};
-                }
-            }
-        };
+                             if (isString(param))
+                             {
+                                 return TypeFunctionReductionResult<TypeId>{ctx->builtins->numberType, Reduction::MaybeOk, {}, {}};
+                             }
+                             else if (isNumber(param))
+                             {
+                                 return TypeFunctionReductionResult<TypeId>{ctx->builtins->stringType, Reduction::MaybeOk, {}, {}};
+                             }
+                             else if (is<BlockedType>(param) || is<PendingExpansionType>(param) || is<TypeFunctionInstanceType>(param) ||
+                                      (ctx->solver && ctx->solver->hasUnresolvedConstraints(param)))
+                             {
+                                 return TypeFunctionReductionResult<TypeId>{std::nullopt, Reduction::MaybeOk, {param}, {}};
+                             }
+                             else
+                             {
+                                 return TypeFunctionReductionResult<TypeId>{std::nullopt, Reduction::Erroneous, {}, {}};
+                             }
+                         }};
 
         unfreeze(getFrontend().globals.globalTypes);
         TypeId t = getFrontend().globals.globalTypes.addType(GenericType{"T"});
@@ -1895,13 +1894,15 @@ TEST_CASE_FIXTURE(TFFixture, "reduce_degenerate_refinement")
     };
 
     TypeId root = arena->addType(BlockedType{});
-    TypeId refinement = arena->addType(TypeFunctionInstanceType{
-        builtinTypeFunctions.refineFunc,
-        {
-            root,
-            builtinTypes_.unknownType,
+    TypeId refinement = arena->addType(
+        TypeFunctionInstanceType{
+            builtinTypeFunctions.refineFunc,
+            {
+                root,
+                builtinTypes_.unknownType,
+            }
         }
-    });
+    );
 
     emplaceType<BoundType>(asMutable(root), refinement);
     reduceTypeFunctions(refinement, Location{}, tfc, true);

--- a/tests/TypeInfer.aliases.test.cpp
+++ b/tests/TypeInfer.aliases.test.cpp
@@ -11,6 +11,8 @@ using namespace Luau;
 
 LUAU_FASTFLAG(LuauSolverV2)
 LUAU_FASTFLAG(LuauSolverAgnosticStringification)
+LUAU_FASTFLAG(LuauInitializeDefaultGenericParamsAtProgramPoint)
+LUAU_FASTFLAG(LuauAddErrorCaseForIncompatibleTypePacks)
 
 TEST_SUITE_BEGIN("TypeAliases");
 
@@ -76,29 +78,27 @@ TEST_CASE_FIXTURE(Fixture, "cannot_steal_hoisted_type_alias")
     if (FFlag::LuauSolverV2)
     {
         CHECK(
-            result.errors[0] ==
-            TypeError{
-                Location{{1, 21}, {1, 26}},
-                getMainSourceModule()->name,
-                TypeMismatch{
-                    getBuiltins()->numberType,
-                    getBuiltins()->stringType,
-                },
-            }
+            result.errors[0] == TypeError{
+                                    Location{{1, 21}, {1, 26}},
+                                    getMainSourceModule()->name,
+                                    TypeMismatch{
+                                        getBuiltins()->numberType,
+                                        getBuiltins()->stringType,
+                                    },
+                                }
         );
     }
     else
     {
         CHECK(
-            result.errors[0] ==
-            TypeError{
-                Location{{1, 8}, {1, 26}},
-                getMainSourceModule()->name,
-                TypeMismatch{
-                    getBuiltins()->numberType,
-                    getBuiltins()->stringType,
-                },
-            }
+            result.errors[0] == TypeError{
+                                    Location{{1, 8}, {1, 26}},
+                                    getMainSourceModule()->name,
+                                    TypeMismatch{
+                                        getBuiltins()->numberType,
+                                        getBuiltins()->stringType,
+                                    },
+                                }
         );
     }
 }
@@ -1110,14 +1110,16 @@ type Foo<T> = Foo<T>
 
 TEST_CASE_FIXTURE(Fixture, "recursive_type_alias_bad_pack_use_warns")
 {
-    if (!FFlag::LuauSolverV2)
-        return;
+    ScopedFastFlag sffs[] = {{FFlag::LuauSolverV2, true}, {FFlag::LuauAddErrorCaseForIncompatibleTypePacks, true}};
 
     CheckResult result = check(R"(
 type Foo<T> = Foo<T...>
 )");
 
-    LUAU_REQUIRE_ERROR_COUNT(4, result);
+    LUAU_REQUIRE_ERROR_COUNT(5, result);
+    LUAU_CHECK_ERROR(result, GenericError);
+    CHECK_EQ(toString(result.errors[4]), "Generic type 'Foo<T>' expects 1 type argument, but none are specified");
+
     auto occursCheckFailed = get<OccursCheckFailed>(result.errors[1]);
     REQUIRE(occursCheckFailed);
 
@@ -1281,6 +1283,74 @@ TEST_CASE_FIXTURE(Fixture, "fuzzer_more_cursed_aliases")
 export type t138 = t0<t138>
 export type t0<t0,t10,t10,t109> = t0
     )"));
+}
+
+TEST_CASE_FIXTURE(Fixture, "evaluating_generic_default_type_shouldnt_ice")
+{
+    ScopedFastFlag sff{FFlag::LuauInitializeDefaultGenericParamsAtProgramPoint, true};
+
+    auto result = check(R"(
+local A = {}
+type B<T = typeof(A)> = unknown
+)");
+
+    if (FFlag::LuauSolverV2)
+        LUAU_REQUIRE_NO_ERRORS(result);
+    else
+    {
+        LUAU_REQUIRE_ERROR_COUNT(1, result);
+        LUAU_CHECK_ERROR(result, UnknownSymbol);
+    }
+}
+
+TEST_CASE_FIXTURE(Fixture, "evaluating_generic_default_type_pack_shouldnt_ice")
+{
+    ScopedFastFlag sff{FFlag::LuauInitializeDefaultGenericParamsAtProgramPoint, true};
+
+    auto result = check(R"(
+local A = {}
+type B<T... = ...typeof(A)> = unknown
+)");
+
+    if (FFlag::LuauSolverV2)
+        LUAU_REQUIRE_NO_ERRORS(result);
+    else
+    {
+        LUAU_REQUIRE_ERROR_COUNT(1, result);
+        LUAU_CHECK_ERROR(result, UnknownSymbol);
+    }
+}
+
+TEST_CASE_FIXTURE(Fixture, "evaluating_generic_default_type_for_symbol_before_definition_is_an_error")
+{
+    ScopedFastFlag sff[] = {
+        {FFlag::LuauSolverV2, true},
+        {FFlag::LuauInitializeDefaultGenericParamsAtProgramPoint, true},
+    };
+
+    auto result = check(R"(
+type B<T = typeof(A)> = unknown
+local A = {}
+)");
+
+    LUAU_REQUIRE_ERROR_COUNT(1, result);
+    LUAU_CHECK_ERROR(result, UnknownSymbol);
+}
+
+TEST_CASE_FIXTURE(Fixture, "evaluating_generic_default_type_pack_for_symbol_before_definition_is_an_error")
+{
+    ScopedFastFlag sff[] = {
+        {FFlag::LuauSolverV2, true},
+        {FFlag::LuauInitializeDefaultGenericParamsAtProgramPoint, true},
+    };
+
+    auto result = check(R"(
+type B<T... = ...typeof(A)> = unknown
+local A = {}
+)");
+
+    LUAU_REQUIRE_ERROR_COUNT(1, result);
+    LUAU_CHECK_ERROR(result, UnknownSymbol);
 }
 
 

--- a/tests/TypeInfer.annotations.test.cpp
+++ b/tests/TypeInfer.annotations.test.cpp
@@ -229,15 +229,14 @@ TEST_CASE_FIXTURE(Fixture, "unknown_type_reference_generates_error")
 
     LUAU_REQUIRE_ERROR_COUNT(1, result);
     CHECK(
-        result.errors[0] ==
-        TypeError{
-            Location{{1, 17}, {1, 28}},
-            getMainSourceModule()->name,
-            UnknownSymbol{
-                "IDoNotExist",
-                UnknownSymbol::Context::Type,
-            },
-        }
+        result.errors[0] == TypeError{
+                                Location{{1, 17}, {1, 28}},
+                                getMainSourceModule()->name,
+                                UnknownSymbol{
+                                    "IDoNotExist",
+                                    UnknownSymbol::Context::Type,
+                                },
+                            }
     );
 }
 

--- a/tests/TypeInfer.generics.test.cpp
+++ b/tests/TypeInfer.generics.test.cpp
@@ -17,6 +17,7 @@ LUAU_FASTFLAG(LuauContainsAnyGenericFollowBeforeChecking)
 LUAU_FASTFLAG(LuauSubtypingGenericsDoesntUseVariance)
 LUAU_FASTFLAG(LuauSubtypingReportGenericBoundMismatches)
 LUAU_FASTFLAG(LuauSolverAgnosticStringification)
+LUAU_FASTFLAG(LuauSubtypingGenericPacksDoesntUseVariance)
 
 using namespace Luau;
 
@@ -1136,10 +1137,10 @@ end
 -- A... = ((B...) -> number, B...))
 -- B... = (number)
 -- A... = ((number) -> number, number)
-wrapper(foo, test2, 3)
-wrapper(foo, test2, 3, 3)
-wrapper(foo, test2)
-wrapper(foo, test2, "3")
+wrapper(foo, test2, 3) -- ok
+wrapper(foo, test2, 3, 3) -- not ok (too many args)
+wrapper(foo, test2) -- not ok (not enough args)
+wrapper(foo, test2, "3") -- not ok (type mismatch, string instead of number)
     )");
 
     LUAU_REQUIRE_ERROR_COUNT(3, result);
@@ -1512,19 +1513,23 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "do_not_infer_generic_functions")
     if (FFlag::LuauSolverV2)
     {
         result = check(R"(
-            local function sum<a>(x: a, y: a, f: (a, a) -> a) return f(x, y) end
+            local function sum<T>(x: T, y: T, z: (T, T) -> T) return z(x, y) end
 
             local function sumrec(f: typeof(sum))
-                return sum(2, 3, function<X>(a: X, b: X): add<X, X> return a + b end)
+                return sum(2, 3, function<X>(g: X, h: X): add<X, X> return g + h end)
             end
 
             local b = sumrec(sum) -- ok
-            local c = sumrec(function(x, y, f) return f(x, y) end) -- type binders are not inferred
+            local c = sumrec(
+                function(d, e, f)
+                    return f(d, e)
+                end
+            ) -- type binders are not inferred
         )");
 
-        CHECK("add<X, X> | number" == toString(requireType("b")));  // FIXME CLI-161128
-        CHECK("<a>(a, a, (a, a) -> a) -> a" == toString(requireType("sum")));
-        CHECK("<a>(a, a, (a, a) -> a) -> a" == toString(requireTypeAtPosition({7, 29})));
+        CHECK("add<X, X> | number" == toString(requireType("b"))); // FIXME CLI-161128
+        CHECK("<T>(T, T, (T, T) -> T) -> T" == toString(requireType("sum")));
+        CHECK("<T>(T, T, (T, T) -> T) -> T" == toString(requireTypeAtPosition({7, 29})));
         LUAU_REQUIRE_ERROR_COUNT(1, result); // FIXME CLI-161128
         CHECK(get<ExplicitFunctionAnnotationRecommended>(result.errors[0]));
     }
@@ -1895,6 +1900,133 @@ end
     )");
 }
 
+TEST_CASE_FIXTURE(BuiltinsFixture, "generic_packs_in_contravariant_position")
+{
+    ScopedFastFlag sff{FFlag::LuauSubtypingGenericPacksDoesntUseVariance, true};
+
+    CheckResult result = check(R"(
+function f<A>(foo: (A) -> ()): () end
+function g<B...>(...: B...): () end
+f(g)
+    )");
+
+    LUAU_REQUIRE_NO_ERRORS(result);
+}
+
+TEST_CASE_FIXTURE(BuiltinsFixture, "generic_packs_in_contravariant_position_2")
+{
+    ScopedFastFlag sff{FFlag::LuauSubtypingGenericPacksDoesntUseVariance, true};
+
+    CheckResult result = check(R"(
+function f(foo: (number) -> (number)): () end
+type T = <A...>(A...) -> A...
+local t: T
+f(t)
+    )");
+
+    LUAU_REQUIRE_NO_ERRORS(result);
+}
+
+TEST_CASE_FIXTURE(BuiltinsFixture, "generic_packs_in_contravariant_position_3")
+{
+    ScopedFastFlag sff{FFlag::LuauSubtypingGenericPacksDoesntUseVariance, true};
+
+    CheckResult result = check(R"(
+function f(foo: <B...>(B...) -> B...): () end
+type T = <A...>(A...) -> A...
+local t: T
+f(t)
+    )");
+
+    LUAU_REQUIRE_NO_ERRORS(result);
+}
+
+TEST_CASE_FIXTURE(BuiltinsFixture, "generic_packs_in_contravariant_position_4")
+{
+    ScopedFastFlag sff1{FFlag::LuauSolverV2, true};
+    ScopedFastFlag sff2{FFlag::LuauSubtypingGenericPacksDoesntUseVariance, true};
+
+    CheckResult result = check(R"(
+function f(foo: <A...>(A...) -> A...): () end
+type T = <B..., C...>(B...) -> C...
+local t: T
+f(t)
+    )");
+
+    LUAU_REQUIRE_NO_ERRORS(result);
+}
+
+TEST_CASE_FIXTURE(BuiltinsFixture, "generic_packs_in_contravariant_position_5")
+{
+    ScopedFastFlag sff{FFlag::LuauSubtypingGenericPacksDoesntUseVariance, true};
+
+    CheckResult result = check(R"(
+function f(foo: (number) -> number): () end
+type T = <A...>(A...) -> number
+local t: T
+f(t)
+    )");
+
+    LUAU_REQUIRE_NO_ERRORS(result);
+}
+
+TEST_CASE_FIXTURE(BuiltinsFixture, "generic_packs_in_contravariant_position_6")
+{
+    ScopedFastFlag sff{FFlag::LuauSubtypingGenericPacksDoesntUseVariance, true};
+
+    CheckResult result = check(R"(
+function f(foo: (...number) -> number): () end
+type T = <A...>(A...) -> number
+local t: T
+f(t)
+    )");
+
+    LUAU_REQUIRE_NO_ERRORS(result);
+}
+
+TEST_CASE_FIXTURE(BuiltinsFixture, "generic_packs_in_contravariant_position_7")
+{
+    ScopedFastFlag sff{FFlag::LuauSubtypingGenericPacksDoesntUseVariance, true};
+
+    CheckResult result = check(R"(
+function f(foo: () -> ()): () end
+type T = <A...>() -> A...
+local t: T
+f(t)
+    )");
+
+    LUAU_REQUIRE_NO_ERRORS(result);
+}
+
+TEST_CASE_FIXTURE(BuiltinsFixture, "generic_packs_in_contravariant_position_8")
+{
+    ScopedFastFlag sff{FFlag::LuauSubtypingGenericPacksDoesntUseVariance, true};
+
+    CheckResult result = check(R"(
+function f(foo: () -> ()): () end
+type T = <A...>(A...) -> A...
+local t: T
+f(t)
+    )");
+
+    LUAU_REQUIRE_NO_ERRORS(result);
+}
+
+TEST_CASE_FIXTURE(BuiltinsFixture, "nested_generic_packs")
+{
+    ScopedFastFlag sff{FFlag::LuauSolverV2, true};
+    ScopedFastFlag sff1{FFlag::LuauSubtypingGenericPacksDoesntUseVariance, true};
+
+    CheckResult result = check(R"(
+type T = <A...>(A...) -> (<A...>(A...) -> ())
+type U = (string) -> ((number) -> ())
+local t: T
+local u: U = t
+    )");
+
+    LUAU_REQUIRE_NO_ERRORS(result);
+}
+
 TEST_CASE_FIXTURE(Fixture, "ensure_that_invalid_generic_instantiations_error")
 {
     ScopedFastFlag _[] = {{FFlag::LuauSubtypingGenericsDoesntUseVariance, true}, {FFlag::LuauSubtypingReportGenericBoundMismatches, true}};
@@ -1931,6 +2063,22 @@ TEST_CASE_FIXTURE(Fixture, "ensure_that_invalid_generic_instantiations_error_1")
         CHECK(get<GenericBoundsMismatch>(res.errors[0]));
     else
         CHECK(get<TypeMismatch>(res.errors[0]));
+}
+
+TEST_CASE_FIXTURE(BuiltinsFixture, "xpcall_should_work_with_generics")
+{
+    ScopedFastFlag _{FFlag::LuauSubtypingGenericPacksDoesntUseVariance, true};
+
+    CheckResult result = check(R"(
+--!strict
+local v: (number) -> (number) = nil :: any
+
+local x = 3
+
+xpcall(v, print, x)
+    )");
+
+    LUAU_REQUIRE_NO_ERRORS(result);
 }
 
 TEST_SUITE_END();

--- a/tests/TypeInfer.intersectionTypes.test.cpp
+++ b/tests/TypeInfer.intersectionTypes.test.cpp
@@ -12,6 +12,7 @@ using namespace Luau;
 LUAU_FASTFLAG(LuauSolverV2)
 LUAU_FASTFLAG(LuauReturnMappedGenericPacksFromSubtyping2)
 LUAU_FASTFLAG(LuauSolverAgnosticStringification)
+LUAU_FASTFLAG(LuauSubtypingGenericPacksDoesntUseVariance)
 
 TEST_SUITE_BEGIN("IntersectionTypes");
 
@@ -855,17 +856,29 @@ could not be converted into
 
 TEST_CASE_FIXTURE(Fixture, "overloaded_functions_mentioning_generic_packs")
 {
+    ScopedFastFlag sff{FFlag::LuauSubtypingGenericPacksDoesntUseVariance, true};
+
     CheckResult result = check(R"(
         function f<a...,b...>()
             function g(x : ((number?, a...) -> (number?, b...)) & ((string?, a...) -> (string?, b...)))
-                local y : ((nil, a...) -> (nil, b...)) = x -- OK
+                local y : ((nil, a...) -> (nil, b...)) = x -- OK in the old solver, not OK in the new
                 local z : ((nil, b...) -> (nil, a...)) = x -- Not OK
+                local w : ((number?, a...) -> (number?, b...)) = x -- OK in both solvers
             end
         end
     )");
-
     if (FFlag::LuauSolverV2)
     {
+        LUAU_REQUIRE_ERROR_COUNT(2, result);
+        const TypeMismatch* tm1 = get<TypeMismatch>(result.errors[0]);
+        CHECK(tm1);
+        CHECK_EQ(toString(tm1->wantedType), "(nil, a...) -> (nil, b...)");
+        CHECK_EQ(toString(tm1->givenType), "((number?, a...) -> (number?, b...)) & ((string?, a...) -> (string?, b...))");
+        const TypeMismatch* tm2 = get<TypeMismatch>(result.errors[1]);
+        CHECK(tm2);
+        CHECK_EQ(toString(tm2->wantedType), "(nil, b...) -> (nil, a...)");
+        CHECK_EQ(toString(tm2->givenType), "((number?, a...) -> (number?, b...)) & ((string?, a...) -> (string?, b...))");
+
         const std::string expected1 =
             "Type\n\t"
             "'((number?, a...) -> (number?, b...)) & ((string?, a...) -> (string?, b...))'"
@@ -883,10 +896,18 @@ TEST_CASE_FIXTURE(Fixture, "overloaded_functions_mentioning_generic_packs")
             "\ncould not be converted into\n\t"
             "'(nil, b...) -> (nil, a...)'; \n"
             "this is because \n\t"
+            " * in the 1st component of the intersection, the function returns a tail of `b...` and it returns a tail of `a...`, and `b...` is not a "
+            "subtype of `a...`\n\t"
             " * in the 1st component of the intersection, the function returns the 1st entry in the type pack which has the 1st component of the "
             "union as `number` and it returns the 1st entry in the type pack is `nil`, and `number` is not a subtype of `nil`\n\t"
+            " * in the 1st component of the intersection, the function takes a tail of `a...` and it takes a tail of `b...`, and `a...` is not a "
+            "supertype of `b...`\n\t"
+            " * in the 2nd component of the intersection, the function returns a tail of `b...` and it returns a tail of `a...`, and `b...` is not a "
+            "subtype of `a...`\n\t"
             " * in the 2nd component of the intersection, the function returns the 1st entry in the type pack which has the 1st component of the "
-            "union as `string` and it returns the 1st entry in the type pack is `nil`, and `string` is not a subtype of `nil`";
+            "union as `string` and it returns the 1st entry in the type pack is `nil`, and `string` is not a subtype of `nil`\n\t"
+            " * in the 2nd component of the intersection, the function takes a tail of `a...` and it takes a tail of `b...`, and `a...` is not a "
+            "supertype of `b...`";
 
         CHECK_EQ(expected1, toString(result.errors[0]));
         CHECK_EQ(expected2, toString(result.errors[1]));
@@ -1102,6 +1123,8 @@ TEST_CASE_FIXTURE(Fixture, "overloadeded_functions_with_weird_typepacks_1")
 
 TEST_CASE_FIXTURE(Fixture, "overloadeded_functions_with_weird_typepacks_2")
 {
+    ScopedFastFlag _{FFlag::LuauSubtypingGenericPacksDoesntUseVariance, true};
+
     CheckResult result = check(R"(
         function f<a...,b...>()
             function g(x : ((a...) -> ()) & ((b...) -> ()))
@@ -1113,7 +1136,11 @@ TEST_CASE_FIXTURE(Fixture, "overloadeded_functions_with_weird_typepacks_2")
 
     if (FFlag::LuauSolverV2)
     {
-        LUAU_REQUIRE_NO_ERRORS(result);
+        LUAU_REQUIRE_ERROR_COUNT(1, result);
+        const TypeMismatch* tm = get<TypeMismatch>(result.errors[0]);
+        CHECK(tm);
+        CHECK_EQ(toString(tm->wantedType), "() -> ()");
+        CHECK_EQ(toString(tm->givenType), "((a...) -> ()) & ((b...) -> ())");
     }
     else
     {
@@ -1127,6 +1154,9 @@ TEST_CASE_FIXTURE(Fixture, "overloadeded_functions_with_weird_typepacks_2")
 
 TEST_CASE_FIXTURE(Fixture, "overloadeded_functions_with_weird_typepacks_3")
 {
+    ScopedFastFlag sff1{FFlag::LuauSubtypingGenericPacksDoesntUseVariance, true};
+    ScopedFastFlag sff2{FFlag::LuauReturnMappedGenericPacksFromSubtyping2, true};
+
     CheckResult result = check(R"(
         function f<a...>()
             function g(x : (() -> a...) & (() -> (number?,a...)))
@@ -1138,7 +1168,11 @@ TEST_CASE_FIXTURE(Fixture, "overloadeded_functions_with_weird_typepacks_3")
 
     if (FFlag::LuauSolverV2)
     {
-        LUAU_REQUIRE_NO_ERRORS(result);
+        LUAU_REQUIRE_ERROR_COUNT(1, result);
+        const TypeMismatch* tm = get<TypeMismatch>(result.errors[0]);
+        CHECK(tm);
+        CHECK_EQ(toString(tm->wantedType), "() -> number");
+        CHECK_EQ(toString(tm->givenType), "(() -> (a...)) & (() -> (number?, a...))");
     }
     else
     {
@@ -1154,6 +1188,7 @@ could not be converted into
 TEST_CASE_FIXTURE(Fixture, "overloadeded_functions_with_weird_typepacks_4")
 {
     ScopedFastFlag _{FFlag::LuauReturnMappedGenericPacksFromSubtyping2, true};
+    ScopedFastFlag sff{FFlag::LuauSubtypingGenericPacksDoesntUseVariance, true};
 
     CheckResult result = check(R"(
         function f<a...>()
@@ -1168,17 +1203,24 @@ TEST_CASE_FIXTURE(Fixture, "overloadeded_functions_with_weird_typepacks_4")
 
     if (FFlag::LuauSolverV2)
     {
-        // TODO: CLI-159120 - this error message is bogus
+        const TypeMismatch* tm = get<TypeMismatch>(result.errors[0]);
+        CHECK(tm);
+        CHECK_EQ(toString(tm->wantedType), "(number?) -> ()");
+        CHECK_EQ(toString(tm->givenType), "((a...) -> ()) & ((number, a...) -> number)");
         const std::string expected =
             "Type\n\t"
             "'((a...) -> ()) & ((number, a...) -> number)'"
             "\ncould not be converted into\n\t"
-            "'((a...) -> ()) & ((number, a...) -> number)'; \n"
+            "'(number?) -> ()'; \n"
             "this is because \n\t"
-            " * in the 1st component of the intersection, the function returns is `()` in the former type and `number` in "
-            "the latter type, and `()` is not a subtype of `number`\n\t"
-            " * in the 2nd component of the intersection, the function takes a tail of `number, a...` and in the 1st component of "
-            "the intersection, the function takes a tail of `number, a...`, and `number, a...` is not a supertype of `number, a...`";
+            " * in the 1st component of the intersection, the function takes a tail of `a...` and it takes the portion of the type pack starting at "
+            "index 0 to the end`number?`, and `a...` is not a supertype of `number?`\n\t"
+            " * in the 2nd component of the intersection, the function returns is `number` and it returns `()`, and `number` is not a subtype of "
+            "`()`\n\t"
+            " * in the 2nd component of the intersection, the function takes a tail of `a...` and it takes `number?`, and `a...` is not a supertype "
+            "of `number?`\n\t"
+            " * in the 2nd component of the intersection, the function takes the 1st entry in the type pack which is `number` and it takes the 1st "
+            "entry in the type pack has the 2nd component of the union as `nil`, and `number` is not a supertype of `nil`";
         CHECK(expected == toString(result.errors[0]));
     }
     else

--- a/tests/TypeInfer.loops.test.cpp
+++ b/tests/TypeInfer.loops.test.cpp
@@ -16,6 +16,8 @@ using namespace Luau;
 
 LUAU_FASTFLAG(LuauSolverV2)
 LUAU_FASTFLAG(LuauSolverAgnosticStringification)
+LUAU_FASTFLAG(LuauNoScopeShallNotSubsumeAll)
+LUAU_FASTFLAG(LuauEagerGeneralization4)
 
 TEST_SUITE_BEGIN("TypeInferLoops");
 
@@ -758,6 +760,11 @@ TEST_CASE_FIXTURE(Fixture, "fuzz_fail_missing_instantitation_follow")
 
 TEST_CASE_FIXTURE(BuiltinsFixture, "for_in_with_generic_next")
 {
+    ScopedFastFlag sff[] = {
+        {FFlag::LuauNoScopeShallNotSubsumeAll, true},
+        {FFlag::LuauEagerGeneralization4, true},
+    };
+
     CheckResult result = check(R"(
         for k: number, v: number in next, {1, 2, 3} do
         end
@@ -865,11 +872,10 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "loop_iter_metamethod_not_enough_returns")
 
     LUAU_REQUIRE_ERROR_COUNT(1, result);
     CHECK(
-        result.errors[0] ==
-        TypeError{
-            Location{{2, 36}, {2, 37}},
-            GenericError{"__iter must return at least one value"},
-        }
+        result.errors[0] == TypeError{
+                                Location{{2, 36}, {2, 37}},
+                                GenericError{"__iter must return at least one value"},
+                            }
     );
 }
 

--- a/tests/TypeInfer.modules.test.cpp
+++ b/tests/TypeInfer.modules.test.cpp
@@ -893,10 +893,7 @@ return function(): { X: _luau_blocked_type, Y: _luau_blocked_type } return nil :
 
 TEST_CASE_FIXTURE(BuiltinsFixture, "scrub_unsealed_tables")
 {
-    ScopedFastFlag sffs[] = {
-        {FFlag::LuauSolverV2, true},
-        {FFlag::LuauLimitDynamicConstraintSolving3, true}
-    };
+    ScopedFastFlag sffs[] = {{FFlag::LuauSolverV2, true}, {FFlag::LuauLimitDynamicConstraintSolving3, true}};
 
     ScopedFastInt sfi{FInt::LuauSolverConstraintLimit, 5};
 

--- a/tests/TypeInfer.operators.test.cpp
+++ b/tests/TypeInfer.operators.test.cpp
@@ -18,6 +18,7 @@ using namespace Luau;
 
 LUAU_FASTFLAG(LuauSolverV2)
 LUAU_FASTFLAG(LuauNoScopeShallNotSubsumeAll)
+LUAU_FASTFLAG(LuauTrackUniqueness)
 LUAU_FASTFLAG(LuauEagerGeneralization4)
 LUAU_FASTFLAG(LuauSolverAgnosticStringification)
 
@@ -1455,8 +1456,12 @@ end
     )");
 
     // FIXME(CLI-165431): fixing subtyping revealed an overload selection problems
-    if (FFlag::LuauSolverV2 && FFlag::LuauNoScopeShallNotSubsumeAll)
+    if (FFlag::LuauSolverV2 && FFlag::LuauNoScopeShallNotSubsumeAll && FFlag::LuauTrackUniqueness)
+        LUAU_REQUIRE_NO_ERRORS(result);
+    else if (FFlag::LuauSolverV2 && FFlag::LuauNoScopeShallNotSubsumeAll)
+    {
         LUAU_REQUIRE_ERROR_COUNT(2, result);
+    }
     else
         LUAU_REQUIRE_NO_ERRORS(result);
 }

--- a/tests/TypeInfer.refinements.test.cpp
+++ b/tests/TypeInfer.refinements.test.cpp
@@ -719,7 +719,7 @@ TEST_CASE_FIXTURE(Fixture, "free_type_is_equal_to_an_lvalue")
     }
     else
     {
-        CHECK_EQ(toString(requireTypeAtPosition({3, 33})), "a"); // a == b
+        CHECK_EQ(toString(requireTypeAtPosition({3, 33})), "a");       // a == b
         CHECK_EQ(toString(requireTypeAtPosition({3, 36})), "string?"); // a == b
     }
 }
@@ -737,7 +737,7 @@ TEST_CASE_FIXTURE(Fixture, "unknown_lvalue_is_not_synonymous_with_other_on_not_e
 
     LUAU_REQUIRE_NO_ERRORS(result);
 
-    CHECK_EQ(toString(requireTypeAtPosition({3, 33})), "any"); // a ~= b
+    CHECK_EQ(toString(requireTypeAtPosition({3, 33})), "any");            // a ~= b
     CHECK_EQ(toString(requireTypeAtPosition({3, 36})), "{ x: number }?"); // a ~= b
 }
 
@@ -871,8 +871,8 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "typeguard_narrows_for_table")
 
     LUAU_REQUIRE_NO_ERRORS(result);
 
-    CHECK_EQ("{ x: number } | { y: boolean }", toString(requireTypeAtPosition({3, 28})));         // type(x) == "table"
-    CHECK_EQ("string", toString(requireTypeAtPosition({5, 28})));                                 // type(x) ~= "table"
+    CHECK_EQ("{ x: number } | { y: boolean }", toString(requireTypeAtPosition({3, 28}))); // type(x) == "table"
+    CHECK_EQ("string", toString(requireTypeAtPosition({5, 28})));                         // type(x) ~= "table"
 }
 
 TEST_CASE_FIXTURE(BuiltinsFixture, "typeguard_narrows_for_functions")

--- a/tests/TypeInfer.typePacks.test.cpp
+++ b/tests/TypeInfer.typePacks.test.cpp
@@ -14,6 +14,8 @@ LUAU_FASTFLAG(LuauSolverV2)
 LUAU_FASTFLAG(LuauInstantiateInSubtyping)
 LUAU_FASTFLAG(LuauEagerGeneralization4)
 LUAU_FASTFLAG(LuauSolverAgnosticStringification)
+LUAU_FASTFLAG(LuauRemoveGenericErrorForParams)
+LUAU_FASTFLAG(LuauAddErrorCaseForIncompatibleTypePacks)
 
 TEST_SUITE_BEGIN("TypePackTests");
 
@@ -606,14 +608,6 @@ type Other<S...> = Packed<number, S...>
     CHECK_EQ(toString(result.errors[0]), "Generic type 'Packed<T, U>' expects 2 type arguments, but only 1 is specified");
 
     result = check(R"(
-type Packed<T...> = (T...) -> T...
-local a: Packed
-    )");
-
-    LUAU_REQUIRE_ERROR_COUNT(1, result);
-    CHECK_EQ(toString(result.errors[0]), "Type parameter list is required");
-
-    result = check(R"(
 type Packed<T..., U...> = (T...) -> (U...)
 type Other = Packed<>
     )");
@@ -628,6 +622,22 @@ type Other = Packed<number, string>
 
     LUAU_REQUIRE_ERROR_COUNT(1, result);
     CHECK_EQ(toString(result.errors[0]), "Generic type 'Packed<T..., U...>' expects 2 type pack arguments, but only 1 is specified");
+}
+
+TEST_CASE_FIXTURE(Fixture, "type_alias_instantiated_but_missing_parameter_list")
+{
+    ScopedFastFlag sff{FFlag::LuauRemoveGenericErrorForParams, true};
+
+    CheckResult result = check(R"(
+type Packed<T...> = (T...) -> T...
+local a: Packed
+    )");
+
+    LUAU_REQUIRE_ERROR_COUNT(1, result);
+    if (FFlag::LuauSolverV2)
+        CHECK_EQ(toString(result.errors[0]), "Generic type 'Packed<T...>' expects 1 type pack argument, but none are specified");
+    else
+        CHECK_EQ(toString(result.errors[0]), "Type parameter list is required");
 }
 
 TEST_CASE_FIXTURE(Fixture, "type_alias_default_type_explicit")
@@ -792,7 +802,7 @@ TEST_CASE_FIXTURE(Fixture, "type_alias_default_type_errors2")
 
 TEST_CASE_FIXTURE(Fixture, "type_alias_default_type_errors3")
 {
-    DOES_NOT_PASS_NEW_SOLVER_GUARD();
+    ScopedFastFlag sff{FFlag::LuauAddErrorCaseForIncompatibleTypePacks, true};
 
     CheckResult result = check(R"(
         type Y<T = string, U... = ...string> = { a: (T) -> U... }
@@ -800,12 +810,15 @@ TEST_CASE_FIXTURE(Fixture, "type_alias_default_type_errors3")
     )");
 
     LUAU_REQUIRE_ERROR_COUNT(1, result);
-    CHECK_EQ(toString(result.errors[0]), "Generic type 'Y<T, U...>' expects at least 1 type argument, but none are specified");
+    if (FFlag::LuauSolverV2)
+        CHECK_EQ(toString(result.errors[0]), "Type parameters must come before type pack parameters");
+    else
+        CHECK_EQ(toString(result.errors[0]), "Generic type 'Y<T, U...>' expects at least 1 type argument, but none are specified");
 }
 
 TEST_CASE_FIXTURE(Fixture, "type_alias_default_type_errors4")
 {
-    DOES_NOT_PASS_NEW_SOLVER_GUARD();
+    ScopedFastFlag sff{FFlag::LuauRemoveGenericErrorForParams, true};
 
     CheckResult result = check(R"(
         type Packed<T> = (T) -> T
@@ -813,7 +826,10 @@ TEST_CASE_FIXTURE(Fixture, "type_alias_default_type_errors4")
     )");
 
     LUAU_REQUIRE_ERROR_COUNT(1, result);
-    CHECK_EQ(toString(result.errors[0]), "Type parameter list is required");
+    if (FFlag::LuauSolverV2)
+        CHECK_EQ(toString(result.errors[0]), "Generic type 'Packed<T>' expects 1 type argument, but none are specified");
+    else
+        CHECK_EQ(toString(result.errors[0]), "Type parameter list is required");
 }
 
 TEST_CASE_FIXTURE(Fixture, "type_alias_default_type_errors5")

--- a/tests/TypeInfer.unionTypes.test.cpp
+++ b/tests/TypeInfer.unionTypes.test.cpp
@@ -629,13 +629,15 @@ TEST_CASE_FIXTURE(Fixture, "indexing_into_a_cyclic_union_doesnt_crash")
     UnionType u;
 
     u.options.push_back(badCyclicUnionTy);
-    u.options.push_back(arena.addType(TableType{
-        {},
-        TableIndexer{getBuiltins()->numberType, getBuiltins()->numberType},
-        TypeLevel{},
-        getFrontend().globals.globalScope.get(),
-        TableState::Sealed
-    }));
+    u.options.push_back(arena.addType(
+        TableType{
+            {},
+            TableIndexer{getBuiltins()->numberType, getBuiltins()->numberType},
+            TypeLevel{},
+            getFrontend().globals.globalScope.get(),
+            TableState::Sealed
+        }
+    ));
 
     asMutable(badCyclicUnionTy)->ty.emplace<UnionType>(std::move(u));
 

--- a/tests/conformance/native.luau
+++ b/tests/conformance/native.luau
@@ -525,12 +525,12 @@ assert(extramath3(2) == "number")
 assert(extramath3("2") == "number")
 
 local function scopedrestorefailurea(format: string, b: buffer): (string, buffer)
-	local H1F, H2F, H3F, H4F = buffer.readu32(b, 0), buffer.readu32(b, 8), buffer.readu32(b, 16), buffer.readu32(b, 24)
-	local H5F, H6F, _, _ = buffer.readu32(b, 32), buffer.readu32(b, 40), buffer.readu32(b, 48), buffer.readu32(b, 56)
-	local H1B, H2B, H3B, H4B = buffer.readu32(b, 4), buffer.readu32(b, 12), buffer.readu32(b, 20), buffer.readu32(b, 28)
-	local H5B, H6B, _, _ = buffer.readu32(b, 36), buffer.readu32(b, 44), buffer.readu32(b, 52), buffer.readu32(b, 60)
+  local H1F, H2F, H3F, H4F = buffer.readu32(b, 0), buffer.readu32(b, 8), buffer.readu32(b, 16), buffer.readu32(b, 24)
+  local H5F, H6F, _, _ = buffer.readu32(b, 32), buffer.readu32(b, 40), buffer.readu32(b, 48), buffer.readu32(b, 56)
+  local H1B, H2B, H3B, H4B = buffer.readu32(b, 4), buffer.readu32(b, 12), buffer.readu32(b, 20), buffer.readu32(b, 28)
+  local H5B, H6B, _, _ = buffer.readu32(b, 36), buffer.readu32(b, 44), buffer.readu32(b, 52), buffer.readu32(b, 60)
 
-	return string.format(format, H1F, H1B, H2F, H2B, H3F, H3B, H4F, H4B, H5F, H5B, H6F, H6B), b
+  return string.format(format, H1F, H1B, H2F, H2B, H3F, H3B, H4F, H4B, H5F, H5B, H6F, H6B), b
 end
 
 local function scopedrestorefailureb()
@@ -604,5 +604,33 @@ local function slotcachelimit2(foo, size)
 end
 
 slotcachelimit2(function(a) return -a end, vector.create(1, 2, 3))
+
+local function forcedregisterspill1(x, y, z)
+  local c1, c2, c3, c4, c5, c6, c7, c8, c9, c10 = (x + 1), (x + 2), (x + 3), (x + 4), (x + 5), (x + 6), (x + 7), (x + 8), (x + 9), (x + 10)
+  local d1, d2, d3, d4, d5, d6, d7, d8, d9, d10 = (y + 1), (y + 2), (y + 3), (y + 4), (y + 5), (y + 6), (y + 7), (y + 8), (y + 9), (y + 10)
+  local e1, e2, e3, e4, e5, e6, e7, e8, e9, e10 = (z * 1), (z * 2), (z * 3), (z * 4), (z * 5), (z * 6), (z * 7), (z * 8), (z * 9), (z * 10)
+
+  -- force store of all those values for a call and then bring all those registers back from VM slot spills
+  local t = {
+    c1 + c2 + c3 + c4 + c5 + c6 + c7 + c8 + c9 + c10 + (x + 1) + (x + 2) + (x + 3) + (x + 4) + (x + 5) + (x + 6) + (x + 7) + (x + 8) + (x + 9) + (x + 10),
+    d1 + d2 + d3 + d4 + d5 + d6 + d7 + d8 + d9 + d10 + (y + 1) + (y + 2) + (y + 3) + (y + 4) + (y + 5) + (y + 6) + (y + 7) + (y + 8) + (y + 9) + (y + 10),
+    e1 + e2 + e3 + e4 + e5 + e6 + e7 + e8 + e9 + e10 + (z * 1) + (z * 2) + (z * 3) + (z * 4) + (z * 5) + (z * 6) + (z * 7) + (z * 8) + (z * 9) + (z * 10),
+  }
+
+  -- bring them back once more time
+  local s1 = c1 + c2 + c3 + c4 + c5 + c6 + c7 + c8 + c9 + c10 + (x + 1) + (x + 2) + (x + 3) + (x + 4) + (x + 5) + (x + 6) + (x + 7) + (x + 8) + (x + 9) + (x + 10)
+  local s2 = d1 + d2 + d3 + d4 + d5 + d6 + d7 + d8 + d9 + d10 + (y + 1) + (y + 2) + (y + 3) + (y + 4) + (y + 5) + (y + 6) + (y + 7) + (y + 8) + (y + 9) + (y + 10)
+  local s3 = e1 + e2 + e3 + e4 + e5 + e6 + e7 + e8 + e9 + e10 + (z * 1) + (z * 2) + (z * 3) + (z * 4) + (z * 5) + (z * 6) + (z * 7) + (z * 8) + (z * 9) + (z * 10)
+
+  -- have not fallen back
+  assert(is_native())
+  return s1, s2, s3, t
+end
+
+do
+  local a, b, c, t = forcedregisterspill1(2, 20, 10)
+  assert(a == 150 and b == 510 and c == 1100)
+  assert(t[1] == 150 and t[2] == 510 and t[3] == 1100)
+end
 
 return('OK')

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -428,9 +428,14 @@ int main(int argc, char** argv)
     doctest::String filter;
     if (doctest::parseOption(argc, argv, "--run_test", &filter) && filter[0] == '=')
     {
-        if (doctest::parseOption(argc, argv, "--run_tests_in_file"))
+        if (doctest::parseOption(argc, argv, "--run_suites_in_file"))
         {
-            fprintf(stderr, "ERROR: Cannot pass both --run_test and --run_tests_in_file\n");
+            fprintf(stderr, "ERROR: Cannot pass both --run_test and --run_suites_in_file\n");
+            return 1;
+        }
+        if (doctest::parseOption(argc, argv, "--run_cases_in_file"))
+        {
+            fprintf(stderr, "ERROR: Cannot pass both --run_test and --run_cases_in_file\n");
             return 1;
         }
         const char* f = filter.c_str() + 1;
@@ -447,13 +452,26 @@ int main(int argc, char** argv)
         }
     }
 
-    doctest::String filter_path;
-    if (doctest::parseOption(argc, argv, "--run_tests_in_file", &filter_path) && filter_path[0] == '=')
+    doctest::String suite_filter_path;
+    if (doctest::parseOption(argc, argv, "--run_suites_in_file", &suite_filter_path) && suite_filter_path[0] == '=')
     {
-        filter_path = filter_path.substr(1, filter_path.size() - 1);
-        std::ifstream filter_stream(filter_path.c_str());
-        std::string case_list((std::istreambuf_iterator<char>(filter_stream)), std::istreambuf_iterator<char>());
-        context.addFilter("test-case", case_list.c_str());
+        const char* filter_file = suite_filter_path.c_str() + 1;
+        std::ifstream filter_stream(filter_file);
+        std::stringstream buffer;
+        buffer << filter_stream.rdbuf();
+        std::string suite_list = buffer.str();
+        context.addFilter("test-suite", suite_list.c_str());
+    }
+
+    doctest::String case_filter_path;
+    if (doctest::parseOption(argc, argv, "--run_cases_in_file", &case_filter_path) && case_filter_path[0] == '=')
+    {
+        const char* filter_file = case_filter_path.c_str() + 1;
+        std::ifstream filter_stream(filter_file);
+        std::stringstream buffer;
+        buffer << filter_stream.rdbuf();
+        std::string case_list = buffer.str();
+        context.addFilter("test-path", case_list.c_str());
     }
 
     // These callbacks register unit tests that need runtime support to be


### PR DESCRIPTION
# New Type Solver
* Improve the error message for an uninstantiated type alias, as in:
```luau
type Packed<T...> = (T...) -> T...
local a: Packed -- Now has a single, specific, error
```
* Improve refinements of extern types against table types, ensuring the extern part is dropped less often, as in:
```luau
local function update(foo: Instance)
    assert(foo.Name == "bubbles")
    -- Previously might have been `{ read Name: "bubbles" }`, 
    -- will now be `Instance & { read Name: "bubbles" }`
    return foo 
end
```
* Resolve an internal complier exception when attempting to use `typeof` inside the generic type default of an alias. Fixes #1462.
* No longer throw an internal compiler exception for exceptionally large ASTs, though a `CodeTooComplex` error will still be raised.
* Broadly rework generic pack subtyping to allow code like the following to type check without errors:
```luau
function f(foo: (number) -> number): () end
type T = <A...>(A...) -> number
local t: T
-- OK, as a function that takes some generic pack of arguments can receive a `number` as well.
f(t)
```
* Report an error when a type pack is provided to a generic alias that can receive a type _and_ a type pack, as in:
```luau
type Y<T = string, U... = ...string> = { a: (T) -> U... }
-- Now errors as you must provide a type before the pack.
local a: Y<...number>
```
* Fix an instance of generics leaking when returning a function from another function with explicitly defined generics. Fixes #1971.
* Cache `HasPropConstraint`s such that for every pair of subject type and desired property, we only emit a single constraint and blocked type; this incidentally fixes some bugs around inferring the types of properties on `self`.
* Table types associated with table literals are now tracked specially to make type checking more permissive, such as in:
```luau
type Foo = { name: string?, flag: boolean? }
local arr: {Foo} = {}
local function foo(arg: {name: string}?)
    local name = if arg and arg.name then arg.name else nil
    -- Previously would error as bidirectional inference would not
    -- kick in as often.
    table.insert(arr, {
        name = name or "",
        flag = name ~= nil and name ~= "",
    })
end
```

# Native Codegen
* Lowering to arm64 for some local heavy functions will now succeed whereas prior they failed due to running out of registers for live values.

--- 
Co-authored-by: Andy Friesen <afriesen@roblox.com>
Co-authored-by: Annie Tang <annietang@roblox.com>
Co-authored-by: Hunter Goldstein <hgoldstein@roblox.com>
Co-authored-by: Sora Kanosue <skanosue@roblox.com>
Co-authored-by: Vighnesh Vijay <vvijay@roblox.com>
Co-authored-by: Vyacheslav Egorov <vegorov@roblox.com>