### PR TITLE
CMake version bump from 3.10 to 3.13

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ if(EXT_PLATFORM_STRING)
     return()
 endif()
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.13)
 
 option(LUAU_BUILD_CLI "Build CLI" ON)
 option(LUAU_BUILD_TESTS "Build tests" ON)


### PR DESCRIPTION
Starting from CMake 3.13 the `option()` command honors normal variables.
https://cmake.org/cmake/help/latest/policy/CMP0077.html
This makes setting Luau options easier when including Luau with `add_subdirectory()`. 
Setting options before 3.13:
```cmake
set(LUAU_BUILD_CLI OFF CACHE BOOL "Build CLI" FORCE)
```
Setting options after 3.13:
```cmake
set(LUAU_BUILD_CLI OFF)
```
The later is way less obscure.