### PR TITLE
Update lbitlib.cpp

### DIFF
--- a/VM/src/lbitlib.cpp
+++ b/VM/src/lbitlib.cpp
@@ -181,15 +181,16 @@ static int b_replace(lua_State* L)
 static int b_countlz(lua_State* L)
 {
     b_uint v = luaL_checkunsigned(L, 1);
-
-    b_uint r = NBITS;
-    for (int i = 0; i < NBITS; ++i)
-        if (v & (1u << (NBITS - 1 - i)))
-        {
-            r = i;
-            break;
-        }
-
+    #if defined(_MSC_VER)
+        unsigned long index;
+        b_uint r = _BitScanReverse(&index, v) ? NBITS - 1 - index : NBITS;
+    #elif defined(__GNUC__) || defined(__clang__)
+        b_uint r = v ? __builtin_clz(v) : NBITS;
+    #else
+        b_uint r = NBITS;
+        for (int i = 0; i < NBITS; ++i)
+            if (v & (1u << (NBITS - 1 - i))) { r = i; break; }
+    #endif
     lua_pushunsigned(L, r);
     return 1;
 }
@@ -197,15 +198,16 @@ static int b_countlz(lua_State* L)
 static int b_countrz(lua_State* L)
 {
     b_uint v = luaL_checkunsigned(L, 1);
-
-    b_uint r = NBITS;
-    for (int i = 0; i < NBITS; ++i)
-        if (v & (1u << i))
-        {
-            r = i;
-            break;
-        }
-
+    #if defined(_MSC_VER)
+        unsigned long index;
+        b_uint r = _BitScanForward(&index, v) ? index : NBITS;
+    #elif defined(__GNUC__) || defined(__clang__)
+        b_uint r = v ? __builtin_ctz(v) : NBITS;
+    #else
+        b_uint r = NBITS;
+        for (int i = 0; i < NBITS; ++i)
+            if (v & (1u << i)) { r = i; break; }
+    #endif
     lua_pushunsigned(L, r);
     return 1;
 }


### PR DESCRIPTION
The functions b_countlz and b_countrz were modified to use compiler-provided intrinsics instead of manual loops for counting leading and trailing zeros in an unsigned integer.

Replaced manual bit-scanning loops in b_countlz and b_countrz with compiler intrinsics (_BitScanReverse/_BitScanForward on MSVC, __builtin_clz/__builtin_ctz on GCC/Clang) for O(1) hardware-accelerated leading/trailing zero counting, with a loop fallback for unsupported compilers.

The change improves performance by using CPU instructions that count leading or trailing zeros directly, replacing the slower loop that checked each bit one by one. It maintains consistency because if the compiler does not support these instructions, it still uses a loop to produce the correct result. It also correctly handles the edge case where the input is zero, returning the full bit width as expected.