### PR TITLE
Fix comparison issue with `api_update_top`

### DIFF
--- a/VM/src/lapi.cpp
+++ b/VM/src/lapi.cpp
@@ -56,7 +56,7 @@ const char* luau_ident = "$Luau: Copyright (C) 2019-2024 Roblox Corporation $\n"
 
 #define api_update_top(L, p) \
     { \
-        api_check(L, p >= L->base && p < L->ci->top); \
+        api_check(L, p >= L->base && p <= L->ci->top); \
         L->top = p; \
     }
 


### PR DESCRIPTION
Fixes a comparison issue with `api_update_top` (`<` instead of `<=`), causing an error to be thrown if the macro attempts to update `L->top` to the same value of `L->ci->top`. More details and a reproduction of the issue is in the attached issue.

Closes #2053