### PR TITLE
Add branch for Emscripten to clock

### DIFF
--- a/VM/src/lperf.cpp
+++ b/VM/src/lperf.cpp
@@ -17,6 +17,9 @@
 #include <mach/mach_time.h>
 #endif
 
+#ifdef __EMSCRIPTEN__
+#include <emscripten/emscripten.h>
+#endif
 
 #include <time.h>
 
@@ -32,6 +35,8 @@ static double clock_period()
     return double(result.numer) / double(result.denom) * 1e-9;
 #elif defined(__linux__) || defined(__FreeBSD__)
     return 1e-9;
+#elif defined(__EMSCRIPTEN__)
+    return 1e-3;
 #else
     return 1.0 / double(CLOCKS_PER_SEC);
 #endif
@@ -49,6 +54,8 @@ static double clock_timestamp()
     timespec now;
     clock_gettime(CLOCK_MONOTONIC, &now);
     return now.tv_sec * 1e9 + now.tv_nsec;
+#elif defined(__EMSCRIPTEN__)
+    return emscripten_get_now();
 #else
     return double(clock());
 #endif


### PR DESCRIPTION
I had problem of getting 0 from lua_clock when using Emscripten. This pull request adds a define check for when using Emscripten  and uses [emscripten_get_now](https://emscripten.org/docs/api_reference/emscripten.h.html#c.emscripten_get_now).