### PR TITLE
Fix `types.newtable` type

### DIFF
--- a/Analysis/src/EmbeddedBuiltinDefinitions.cpp
+++ b/Analysis/src/EmbeddedBuiltinDefinitions.cpp
@@ -418,7 +418,7 @@ declare types: {
     negationof: @checked (arg: type) -> type,
     unionof: @checked (...type) -> type,
     intersectionof: @checked (...type) -> type,
-    newtable: @checked (props: {[type]: type} | {[type]: { read: type, write: type } } | nil, indexer: { index: type, readresult: type, writeresult: type }?, metatable: type?) -> type,
+    newtable: @checked (props: {[type]: type} | {[type]: { read: type?, write: type? } } | nil, indexer: { index: type, readresult: type, writeresult: type? }?, metatable: type?) -> type,
     newfunction: @checked (parameters: { head: {type}?, tail: type? }?, returns: { head: {type}?, tail: type? }?, generics: {type}?) -> type,
     copy: @checked (arg: type) -> type,
 }


### PR DESCRIPTION
I'm not sure if this can be fixed by simply modifying `Analysis/src/EmbeddedBuiltinDefinitions.cpp`, but the value type in the props parameter of `types.newtable` must be optional because it allows read OR write fields (currently both are required). Also, I modified the second parameter's `writerresult`, as it shouldn't be required.

I discovered an issue while using the user-defined type function types api with [luau-lsp](https://github.com/JohnnyMorganz/luau-lsp). I filed a PR because it seemed to be a simple type error.

Also, in the [luau docs](https://luau.org/typecheck#types-library-functions), the types.newtable type differed from the `newtable` type in `EmbeddedBuiltinDefinitions.cpp`.

<img width="1504" height="186" alt="image" src="https://github.com/user-attachments/assets/9d529ca4-d933-49cc-9041-afbbe7d3a61a" />
