### PR TITLE
Remove require-by-string test involving malicious .config.luau file

### DIFF
--- a/tests/RequireByString.test.cpp
+++ b/tests/RequireByString.test.cpp
@@ -715,13 +715,6 @@ TEST_CASE_FIXTURE(ReplWithPathFixture, "AliasNotParsedIfConfigsAmbiguous")
     assertOutputContainsAll({"false", "could not resolve alias \"dep\" (ambiguous configuration file)"});
 }
 
-TEST_CASE_FIXTURE(ReplWithPathFixture, "AliasNotParsedIfLuauConfigTimesOut" * doctest::timeout(5))
-{
-    std::string path = getLuauDirectory(PathType::Relative) + "/tests/require/config_tests/config_luau_timeout/requirer";
-    runProtectedRequire(path);
-    assertOutputContainsAll({"false", "configuration execution timed out"});
-}
-
 TEST_CASE_FIXTURE(ReplWithPathFixture, "CannotRequireConfigLuau")
 {
     std::string path = getLuauDirectory(PathType::Relative) + "/tests/require/config_tests/config_cannot_be_required/requirer";

--- a/tests/require/config_tests/config_luau_timeout/.config.luau
+++ b/tests/require/config_tests/config_luau_timeout/.config.luau
@@ -1,2 +1,0 @@
--- Infinite loop
-while true do end

--- a/tests/require/config_tests/config_luau_timeout/requirer.luau
+++ b/tests/require/config_tests/config_luau_timeout/requirer.luau
@@ -1,1 +1,0 @@
-return require("@dep")


### PR DESCRIPTION
### Problem

This `.config.luau` file has caused issues for luau-lsp, which led us to remove a similar test from Lute: https://github.com/luau-lang/lute/pull/548.

After removing it in Lute, we were still observing the issue, so we initially thought it wasn't actually caused by `.config.luau`. Turns out that the Luau repo that gets pinned into the Lute repo had its own malicious `.config.luau` file (this one), which was still causing luau-lsp to hang.

### Solution

This PR just deletes this test and its test files altogether. We still have a lower-level test for the interrupt functionality in `Config.test.cpp` called `ConfigLuauTest/interrupt_execution`, so I think it's fine to omit the full end-to-end require-by-string test in this case.

We could alternatively test this inside of an embedded VFS instead of the actual filesystem, but this would require a decent amount of work to set up in our require-by-string unit tests.