### PR TITLE
Infra: validate version format before creating draft release

### DIFF
--- a/.github/workflows/new-release.yml
+++ b/.github/workflows/new-release.yml
@@ -16,6 +16,12 @@ jobs:
     outputs:
       upload_url: ${{ steps.create_release.outputs.upload_url }}
     steps:
+      - name: validate version format
+        run: |
+          if [[ ! "${{ github.event.inputs.version }}" == *"."* ]]; then
+            echo "Error: Version must contain a '.'"
+            exit 1
+          fi
       - name: create release
         id: create_release
         uses: actions/create-release@v1


### PR DESCRIPTION
This should help us catch the (somewhat common) case where a release gets tagged `xyz` instead of `0.xyz`.