### PR TITLE
Infra: Improve create release step with regex matching

### DIFF
--- a/.github/workflows/new-release.yml
+++ b/.github/workflows/new-release.yml
@@ -18,8 +18,8 @@ jobs:
     steps:
       - name: validate version format
         run: |
-          if [[ ! "${{ github.event.inputs.version }}" == *"."* ]]; then
-            echo "Error: Version must contain a '.'"
+          if [[ ! "${{ github.event.inputs.version }}" =~ ^0\.[0-9]{3,}$ ]]; then
+            echo "Error: Version must be in the format 0.XYZ"
             exit 1
           fi
       - name: create release


### PR DESCRIPTION
Bash apparently supports regex with the `=~` operator, so we can have a more robust check here. This will only accept version strings that are in the format `0.<version>` where `<version>` is a number with 3 or more digits.