### PR TITLE
Allow two-argument explicit constructor for RequireAlias

### DIFF
--- a/Analysis/include/Luau/FileResolver.h
+++ b/Analysis/include/Luau/FileResolver.h
@@ -41,6 +41,12 @@ struct RequireAlias
     {
     }
 
+    explicit RequireAlias(std::string alias, std::vector<std::string> tags)
+        : alias(std::move(alias))
+        , tags(std::move(tags))
+    {
+    }
+
     std::string alias; // Unprefixed alias name (no leading `@`).
     std::vector<std::string> tags = {};
 };


### PR DESCRIPTION
The latest sync to 703 (https://github.com/luau-lang/luau/pull/2146) added an explicit constructor to `Luau::RequireAlias`. However, this is only a single argument constructor for the alias, and does not handle setting the tags.

This broke luau-lsp compilation of code that did `Luau::RequireAlias{alias, {"tagname"}}`, and now our only option is to first construct the RequireAlias into a separate local, and then set the tags afterwards, then pass the require alias to where we were using it originally.

```
/Users/runner/work/luau-lsp/luau-lsp/src/platform/StringRequireSuggester.cpp:79:30: error: no matching constructor for initialization of 'Luau::RequireAlias'
   79 |         results.emplace_back(Luau::RequireAlias{aliasInfo.originalCase, {"Alias"}});
      |                              ^                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/runner/work/luau-lsp/luau-lsp/luau/Analysis/include/Luau/FileResolver.h:39:14: note: candidate constructor not viable: requires single argument 'alias', but 2 arguments were provided
   39 |     explicit RequireAlias(std::string alias)
      |              ^            ~~~~~~~~~~~~~~~~~
```

For simplicity, this PR adds a two-argument explicit constructor to also set the tags