### PR TITLE
Expose `luaL_traceback` from Lua C API

### DIFF
--- a/VM/include/lualib.h
+++ b/VM/include/lualib.h
@@ -61,6 +61,8 @@ LUALIB_API const char* luaL_typename(lua_State* L, int idx);
 // wrapper for making calls from yieldable C functions
 LUALIB_API int luaL_callyieldable(lua_State* L, int nargs, int nresults);
 
+LUALIB_API void luaL_traceback(lua_State* L, lua_State* L1, const char* msg, int level);
+
 /*
 ** ===============================================================
 ** some useful macros

--- a/VM/src/ldblib.cpp
+++ b/VM/src/ldblib.cpp
@@ -126,46 +126,7 @@ static int db_traceback(lua_State* L)
     int level = luaL_optinteger(L, arg + 2, (L == L1) ? 1 : 0);
     luaL_argcheck(L, level >= 0, arg + 2, "level can't be negative");
 
-    luaL_Strbuf buf;
-    luaL_buffinit(L, &buf);
-
-    if (msg)
-    {
-        luaL_addstring(&buf, msg);
-        luaL_addstring(&buf, "\n");
-    }
-
-    lua_Debug ar;
-    for (int i = level; lua_getinfo(L1, i, "sln", &ar); ++i)
-    {
-        if (strcmp(ar.what, "C") == 0)
-            continue;
-
-        if (ar.source)
-            luaL_addstring(&buf, ar.short_src);
-
-        if (ar.currentline > 0)
-        {
-            char line[32]; // manual conversion for performance
-            char* lineend = line + sizeof(line);
-            char* lineptr = lineend;
-            for (unsigned int r = ar.currentline; r > 0; r /= 10)
-                *--lineptr = '0' + (r % 10);
-
-            luaL_addchar(&buf, ':');
-            luaL_addlstring(&buf, lineptr, lineend - lineptr);
-        }
-
-        if (ar.name)
-        {
-            luaL_addstring(&buf, " function ");
-            luaL_addstring(&buf, ar.name);
-        }
-
-        luaL_addchar(&buf, '\n');
-    }
-
-    luaL_pushresult(&buf);
+    luaL_traceback(L, L1, msg, level);
     return 1;
 }
 


### PR DESCRIPTION
[`luaL_traceback`](https://www.lua.org/manual/5.5/manual.html#luaL_traceback) was added in Lua 5.2. It's essentially a programmatic version of `debug.traceback`:

> Creates and pushes a traceback of the stack L1. If msg is not NULL it is appended at the beginning of the traceback. The level parameter tells at which level to start the traceback. 

Although Luau is derived from 5.1, adding this 5.2 API makes it easier to use/embed.