### PR TITLE
Update lstate.h

### DIFF
--- a/VM/src/lstate.h
+++ b/VM/src/lstate.h
@@ -175,7 +175,7 @@ typedef struct global_State
     GCObject* grayagain; // list of objects to be traversed atomically
     GCObject* weak;      // list of weak tables (to be cleared)
 
-    size_t GCthreshold;                       // when totalbytes > GCthreshold, run GC step
+    size_t GCthreshold;                       // when totalbytes >= GCthreshold, run GC step
     size_t totalbytes;                        // number of bytes currently allocated
 
     int gcgoal;                               // see LUAI_GCGOAL


### PR DESCRIPTION
It is currently specified that the gc step is ran if totalbytes > GCthreshold, if we look for example at luaC_needsGC we can clearly see the condition is "L->global->totalbytes >= L->global->GCthreshold"