### PR TITLE
Sync to upstream/release/704

### DIFF
--- a/Analysis/include/Luau/Constraint.h
+++ b/Analysis/include/Luau/Constraint.h
@@ -279,7 +279,7 @@ struct SimplifyConstraint
 // push_function_type_constraint expectedFunctionType => functionType
 //
 // Attempt to "push" the types of `expectedFunctionType` into `functionType`,
-// assuming that `expr` is a lambda who's ungeneralized type is `functionType`.
+// assuming that `expr` is a lambda who's un-generalized type is `functionType`.
 // Similar to `FunctionCheckConstraint`. For example:
 //
 //  local Foo = {} :: { bar : (number) -> () }

--- a/Analysis/include/Luau/ConstraintGenerator.h
+++ b/Analysis/include/Luau/ConstraintGenerator.h
@@ -178,6 +178,8 @@ private:
 
     std::vector<TypeId> unionsToSimplify;
 
+    Polarity polarity = Polarity::None;
+
     DenseHashMap<std::pair<TypeId, std::string>, TypeId, PairHash<TypeId, std::string>> propIndexPairsSeen{{nullptr, ""}};
 
     // Used to keep track of when we are inside a large table and should
@@ -397,7 +399,13 @@ public:
      * @param inTypeArguments whether we are resolving a type that's contained within type arguments, `<...>`.
      * @return the type of the AST annotation.
      **/
-    TypeId resolveType(const ScopePtr& scope, AstType* ty, bool inTypeArguments, bool replaceErrorWithFresh = false);
+    TypeId resolveType(
+        const ScopePtr& scope,
+        AstType* ty,
+        bool inTypeArguments,
+        bool replaceErrorWithFresh = false,
+        Polarity initialPolarity = Polarity::Positive
+    );
 
 private:
     // resolveType() is recursive, but we only want to invoke
@@ -412,9 +420,15 @@ private:
      * @param inTypeArguments whether we are resolving a type that's contained within type arguments, `<...>`.
      * @return the type pack of the AST annotation.
      **/
-    TypePackId resolveTypePack(const ScopePtr& scope, AstTypePack* tp, bool inTypeArguments, bool replaceErrorWithFresh = false);
+    TypePackId resolveTypePack(
+        const ScopePtr& scope,
+        AstTypePack* tp,
+        bool inTypeArguments,
+        bool replaceErrorWithFresh = false,
+        Polarity initialPolarity = Polarity::Positive
+    );
 
-    // Inner hepler for resolveTypePack
+    // Inner helper for resolveTypePack
     TypePackId resolveTypePack_(const ScopePtr& scope, AstTypePack* tp, bool inTypeArguments, bool replaceErrorWithFresh = false);
 
     /**
@@ -424,7 +438,13 @@ private:
      * @param inTypeArguments whether we are resolving a type that's contained within type arguments, `<...>`.
      * @return the type pack of the AST annotation.
      **/
-    TypePackId resolveTypePack(const ScopePtr& scope, const AstTypeList& list, bool inTypeArguments, bool replaceErrorWithFresh = false);
+    TypePackId resolveTypePack(
+        const ScopePtr& scope,
+        const AstTypeList& list,
+        bool inTypeArguments,
+        bool replaceErrorWithFresh = false,
+        Polarity initialPolarity = Polarity::Positive
+    );
 
     /**
      * Creates generic types given a list of AST definitions, resolving default

--- a/Analysis/include/Luau/ConstraintSolver.h
+++ b/Analysis/include/Luau/ConstraintSolver.h
@@ -459,9 +459,6 @@ public:
 
     TypeId simplifyIntersection(NotNull<Scope> scope, Location location, TypeId left, TypeId right);
 
-    // Clip with LuauSimplifyIntersectionNoTreeSet
-    TypeId simplifyIntersection_DEPRECATED(NotNull<Scope> scope, Location location, std::set<TypeId> parts);
-
     TypeId simplifyIntersection(NotNull<Scope> scope, Location location, TypeIds parts);
 
     TypeId simplifyUnion(NotNull<Scope> scope, Location location, TypeId left, TypeId right);

--- a/Analysis/include/Luau/InferPolarity.h
+++ b/Analysis/include/Luau/InferPolarity.h
@@ -4,13 +4,16 @@
 #include "Luau/NotNull.h"
 #include "Luau/TypeFwd.h"
 
+
+// Clip this file (and InferPolarity.cpp) with LuauStorePolarityInline
+
 namespace Luau
 {
 
 struct Scope;
 struct TypeArena;
 
-void inferGenericPolarities(NotNull<TypeArena> arena, NotNull<Scope> scope, TypeId ty);
-void inferGenericPolarities(NotNull<TypeArena> arena, NotNull<Scope> scope, TypePackId tp);
+void inferGenericPolarities_DEPRECATED(NotNull<TypeArena> arena, NotNull<Scope> scope, TypeId ty);
+void inferGenericPolarities_DEPRECATED(NotNull<TypeArena> arena, NotNull<Scope> scope, TypePackId tp);
 
 } // namespace Luau

--- a/Analysis/include/Luau/Normalize.h
+++ b/Analysis/include/Luau/Normalize.h
@@ -277,7 +277,7 @@ struct NormalizedType
     /// Returns true if this type should result in error suppressing behavior.
     bool shouldSuppressErrors() const;
 
-    /// Returns true if this type contains the primitve top table type, `table`.
+    /// Returns true if this type contains the primitive top table type, `table`.
     bool hasTopTable() const;
 
     /// Returns true if this type is `nil` or `nil | *error-type*`

--- a/Analysis/include/Luau/NotNull.h
+++ b/Analysis/include/Luau/NotNull.h
@@ -20,7 +20,7 @@ namespace Luau
  * Pointer arithmetic, increment, decrement, and array indexing are all
  * forbidden.
  *
- * An implicit coersion from NotNull<T> to T* is afforded, as are the pointer
+ * An implicit coercion from NotNull<T> to T* is afforded, as are the pointer
  * indirection and member access operators. (*p and p->prop)
  *
  * The explicit delete statement is permitted (but not recommended) on a

--- a/Analysis/include/Luau/OverloadResolution.h
+++ b/Analysis/include/Luau/OverloadResolution.h
@@ -194,22 +194,12 @@ private:
     );
 
 public:
-    // We want to clip this with LuauNewOverloadResolver2, but there are other
-    // call sites such as `solveFunctionCall`.
+    // Clip this with LuauBuiltinTypeFunctionsUseNewOverloadResolution
     std::pair<Analysis, TypeId> selectOverload_DEPRECATED(
         TypeId ty,
         TypePackId args,
         NotNull<DenseHashSet<TypeId>> uniqueTypes,
         bool useFreeTypeBounds
-    );
-
-    // Clip with LuauNewOverloadResolver2
-    void resolve_DEPRECATED(
-        TypeId fnTy,
-        const TypePack* args,
-        AstExpr* selfExpr,
-        const std::vector<AstExpr*>* argExprs,
-        NotNull<DenseHashSet<TypeId>> uniqueTypes
     );
 
 private:
@@ -221,7 +211,6 @@ private:
         NotNull<DenseHashSet<TypeId>> uniqueTypes,
         bool callMetamethodOk = true
     );
-    static bool isLiteral(AstExpr* expr);
     LUAU_NOINLINE
     std::pair<Analysis, ErrorVec> checkOverload_(
         TypeId fnTy,

--- a/Analysis/include/Luau/Scope.h
+++ b/Analysis/include/Luau/Scope.h
@@ -102,9 +102,19 @@ struct Scope
     std::optional<std::vector<TypeId>> interiorFreeTypes;
     std::optional<std::vector<TypePackId>> interiorFreeTypePacks;
 
+    // Currently, Luau has a very strict restriction on recursive uses of
+    // type aliases (see: https://github.com/luau-lang/luau/pull/68). We keep
+    // a mapping of type aliases that violate this restriction to the location
+    // that marked said trigger.
+    //
+    // CLI-183875: Surely this can be an AstName?
+    DenseHashMap<std::string, Location> invalidTypeAliases{{}};
+    std::optional<Location> isInvalidTypeAlias(const std::string& name) const;
+
+    // Clip with LuauReworkInfiniteTypeFinder
     // A set of type alias names that are invalid because they violate the recursion restrictions of type aliases.
-    DenseHashSet<std::string> invalidTypeAliasNames{""};
-    bool isInvalidTypeAliasName(const std::string& name) const;
+    DenseHashSet<std::string> invalidTypeAliasNames_DEPRECATED{""};
+    bool isInvalidTypeAliasName_DEPRECATED(const std::string& name) const;
 
     NotNull<Scope> findNarrowestScopeContaining(Location);
 };

--- a/Analysis/include/Luau/Simplify.h
+++ b/Analysis/include/Luau/Simplify.h
@@ -24,9 +24,6 @@ struct SimplifyResult
 
 SimplifyResult simplifyIntersection(NotNull<BuiltinTypes> builtinTypes, NotNull<TypeArena> arena, TypeId left, TypeId right);
 
-// Clip with LuauSimplifyIntersectionNoTreeSet
-SimplifyResult simplifyIntersection_DEPRECATED(NotNull<BuiltinTypes> builtinTypes, NotNull<TypeArena> arena, std::set<TypeId> parts);
-
 SimplifyResult simplifyIntersection(NotNull<BuiltinTypes> builtinTypes, NotNull<TypeArena> arena, TypeIds parts);
 
 SimplifyResult simplifyUnion(NotNull<BuiltinTypes> builtinTypes, NotNull<TypeArena> arena, TypeId left, TypeId right);

--- a/Analysis/include/Luau/StructuralTypeEquality.h
+++ b/Analysis/include/Luau/StructuralTypeEquality.h
@@ -1,0 +1,18 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+#pragma once
+
+#include "Luau/TypeFwd.h"
+
+#include <set>
+#include <utility>
+
+namespace Luau
+{
+
+using SeenSet = std::set<std::pair<const void*, const void*>>;
+
+bool areEqual(SeenSet& seen, const Type& lhs, const Type& rhs);
+bool areEqual(SeenSet& seen, const TypePackVar& lhs, const TypePackVar& rhs);
+bool areEqual(SeenSet& seen, TypeId lhs, TypeId rhs);
+
+}

--- a/Analysis/include/Luau/Subtyping.h
+++ b/Analysis/include/Luau/Subtyping.h
@@ -263,10 +263,10 @@ private:
     SubtypingResult isCovariantWith(SubtypingEnvironment& env, TypeId subTy, TypeId superTy, NotNull<Scope> scope);
 
     template<typename SubTy, typename SuperTy>
-    SubtypingResult isContravariantWith(SubtypingEnvironment& env, SubTy&& subTy, SuperTy&& superTy, NotNull<Scope> scope);
+    SubtypingResult isContravariantWith(SubtypingEnvironment& env, SubTy subTy, SuperTy superTy, NotNull<Scope> scope);
 
     template<typename SubTy, typename SuperTy>
-    SubtypingResult isInvariantWith(SubtypingEnvironment& env, SubTy&& subTy, SuperTy&& superTy, NotNull<Scope> scope);
+    SubtypingResult isInvariantWith(SubtypingEnvironment& env, SubTy subTy, SuperTy superTy, NotNull<Scope> scope);
 
     template<typename SubTy, typename SuperTy>
     SubtypingResult isCovariantWith(SubtypingEnvironment& env, const TryPair<const SubTy*, const SuperTy*>& pair, NotNull<Scope> scope);
@@ -439,7 +439,7 @@ private:
     SubtypingResult isTailCovariantWithTail(SubtypingEnvironment& env, NotNull<Scope> scope, TypePackId subTp, const GenericTypePack* sub, Nothing);
     SubtypingResult isTailCovariantWithTail(SubtypingEnvironment& env, NotNull<Scope> scope, Nothing, TypePackId superTp, const GenericTypePack* super);
 
-    bool bindGeneric(SubtypingEnvironment& env, TypeId subTp, TypeId superTp);
+    bool bindGeneric(SubtypingEnvironment& env, TypeId subTy, TypeId superTy) const;
 
     template<typename T, typename Container>
     TypeId makeAggregateType(const Container& container, TypeId orElse);

--- a/Analysis/include/Luau/TableLiteralInference.h
+++ b/Analysis/include/Luau/TableLiteralInference.h
@@ -25,7 +25,8 @@ struct PushTypeResult
     std::vector<IncompleteInference> incompleteTypes;
 };
 
-PushTypeResult pushTypeInto(
+// Clip with LuauPushTypeConstraintLambdas3
+PushTypeResult pushTypeInto_DEPRECATED(
     NotNull<DenseHashMap<const AstExpr*, TypeId>> astTypes,
     NotNull<DenseHashMap<const AstExpr*, TypeId>> astExpectedTypes,
     NotNull<ConstraintSolver> solver,
@@ -35,5 +36,18 @@ PushTypeResult pushTypeInto(
     TypeId expectedType,
     const AstExpr* expr
 );
+
+PushTypeResult pushTypeInto(
+    NotNull<DenseHashMap<const AstExpr*, TypeId>> astTypes,
+    NotNull<DenseHashMap<const AstExpr*, TypeId>> astExpectedTypes,
+    NotNull<ConstraintSolver> solver,
+    NotNull<const Constraint> constraint,
+    NotNull<DenseHashSet<const void*>> genericTypesAndPacks,
+    NotNull<Unifier2> unifier,
+    NotNull<Subtyping> subtyping,
+    TypeId expectedType,
+    const AstExpr* expr
+);
+
 
 }; // namespace Luau

--- a/Analysis/include/Luau/Type.h
+++ b/Analysis/include/Luau/Type.h
@@ -105,11 +105,13 @@ struct GenericType
     GenericType();
 
     explicit GenericType(TypeLevel level);
-    explicit GenericType(const Name& name, Polarity polarity = Polarity::Unknown);
-    explicit GenericType(Scope* scope, Polarity polarity = Polarity::Unknown);
+    explicit GenericType(const Name& name, Polarity polarity);
+    explicit GenericType(Scope* scope, Polarity polarity);
 
     GenericType(TypeLevel level, const Name& name);
     GenericType(Scope* scope, const Name& name);
+
+    GenericType(Scope* scope, Name name, Polarity polarity);
 
     int index;
     TypeLevel level;
@@ -215,7 +217,7 @@ struct StringSingleton
     }
 };
 
-// No type for float singletons, partly because === isn't any equalivalence on floats
+// No type for float singletons, partly because === isn't any equivalence on floats
 // (NaN != NaN).
 
 using SingletonVariant = Luau::Variant<BooleanSingleton, StringSingleton>;
@@ -828,7 +830,7 @@ struct Type final
     {
     }
 
-    // Re-assignes the content of the type, but doesn't change the owning arena and can't make type persistent.
+    // Re-assigns the content of the type, but doesn't change the owning arena and can't make type persistent.
     void reassign(const Type& rhs)
     {
         ty = rhs.ty;
@@ -924,9 +926,6 @@ struct TypeFun
 
     bool operator==(const TypeFun& rhs) const;
 };
-
-using SeenSet = std::set<std::pair<const void*, const void*>>;
-bool areEqual(SeenSet& seen, const Type& lhs, const Type& rhs);
 
 enum class FollowOption
 {

--- a/Analysis/include/Luau/TypeFunctionRuntime.h
+++ b/Analysis/include/Luau/TypeFunctionRuntime.h
@@ -324,6 +324,9 @@ TypeFunctionRuntime* getTypeFunctionRuntime(lua_State* L);
 TypeFunctionType* allocateTypeFunctionType(lua_State* L, TypeFunctionTypeVariant type);
 TypeFunctionTypePackVar* allocateTypeFunctionTypePack(lua_State* L, TypeFunctionTypePackVariant type);
 
+void pushType(lua_State* L, TypeFunctionTypeId type);
+void pushTypePack(lua_State* L, TypeFunctionTypePackId tp);
+
 void allocTypeUserData(lua_State* L, TypeFunctionTypeVariant type);
 
 bool isTypeUserData(lua_State* L, int idx);

--- a/Analysis/include/Luau/TypeInfer.h
+++ b/Analysis/include/Luau/TypeInfer.h
@@ -335,7 +335,7 @@ public:
     void merge(RefinementMap& l, const RefinementMap& r);
 
     // Produce an "emergency backup type" for recovery from type errors.
-    // This comes in two flavours, depening on whether or not we can make a good guess
+    // This comes in two flavours, depending on whether or not we can make a good guess
     // for an error recovery type.
     TypeId errorRecoveryType(TypeId guess);
     TypePackId errorRecoveryTypePack(TypePackId guess);

--- a/Analysis/include/Luau/TypePack.h
+++ b/Analysis/include/Luau/TypePack.h
@@ -47,6 +47,8 @@ struct GenericTypePack
     explicit GenericTypePack(Scope* scope, Polarity polarity = Polarity::Unknown);
     GenericTypePack(TypeLevel level, const Name& name);
     GenericTypePack(Scope* scope, const Name& name);
+    GenericTypePack(Scope* scope, Name name, Polarity polarity);
+    explicit GenericTypePack(Polarity polarity);
 
     int index;
     TypeLevel level;
@@ -116,7 +118,7 @@ struct TypePackVar
 
     TypePackVar& operator=(const TypePackVar& rhs);
 
-    // Re-assignes the content of the pack, but doesn't change the owning arena and can't make pack persistent.
+    // Re-assigns the content of the pack, but doesn't change the owning arena and can't make pack persistent.
     void reassign(const TypePackVar& rhs)
     {
         ty = rhs.ty;
@@ -188,10 +190,6 @@ TypePackIterator end(TypePackId tp);
 
 TypePackId getTail(TypePackId tp);
 
-using SeenSet = std::set<std::pair<const void*, const void*>>;
-
-bool areEqual(SeenSet& seen, const TypePackVar& lhs, const TypePackVar& rhs);
-
 TypePackId follow(TypePackId tp);
 TypePackId follow(TypePackId t, const void* context, TypePackId (*mapper)(const void*, TypePackId));
 
@@ -232,7 +230,7 @@ bool isEmpty(TypePackId tp);
 std::pair<std::vector<TypeId>, std::optional<TypePackId>> flatten(TypePackId tp);
 std::pair<std::vector<TypeId>, std::optional<TypePackId>> flatten(TypePackId tp, const TxnLog& log);
 
-/// Returs true if the type pack arose from a function that is declared to be variadic.
+/// Returns true if the type pack arose from a function that is declared to be variadic.
 /// Returns *false* for function argument packs that are inferred to be safe to oversaturate!
 bool isVariadic(TypePackId tp);
 bool isVariadic(TypePackId tp, const TxnLog& log);

--- a/Analysis/include/Luau/TypeUtils.h
+++ b/Analysis/include/Luau/TypeUtils.h
@@ -273,7 +273,7 @@ std::vector<TypeId> findBlockedArgTypesIn(AstExprCall* expr, NotNull<DenseHashMa
 /**
  * Given a scope and a free type, find the closest parent that has a present
  * `interiorFreeTypes` and append the given type to said list. This list will
- * be generalized when the requiste `GeneralizationConstraint` is resolved.
+ * be generalized when the requisite `GeneralizationConstraint` is resolved.
  * @param scope Initial scope this free type was attached to
  * @param ty Free type to track.
  */
@@ -398,8 +398,17 @@ struct ContainsAnyGeneric final : public TypeOnceVisitor
     bool visit(TypeId ty) override;
     bool visit(TypePackId ty) override;
 
+    /**
+     * @returns if there is _any_ generic in `ty`
+     */
     static bool hasAnyGeneric(TypeId ty);
     static bool hasAnyGeneric(TypePackId tp);
 };
+
+/**
+ * @returns if `ty` contains a generic in the set `generics`.
+ */
+bool containsGeneric(TypeId ty, NotNull<DenseHashSet<const void*>> generics);
+bool containsGeneric(TypePackId ty, NotNull<DenseHashSet<const void*>> generics);
 
 } // namespace Luau

--- a/Analysis/include/Luau/UnifierSharedState.h
+++ b/Analysis/include/Luau/UnifierSharedState.h
@@ -53,19 +53,19 @@ struct UnifierSharedState
     bool reentrantTypeReduction = false;
 };
 
-struct TypeReductionRentrancyGuard final
+struct TypeReductionReentrancyGuard final
 {
-    explicit TypeReductionRentrancyGuard(NotNull<UnifierSharedState> sharedState)
+    explicit TypeReductionReentrancyGuard(NotNull<UnifierSharedState> sharedState)
         : sharedState{sharedState}
     {
         sharedState->reentrantTypeReduction = true;
     }
-    ~TypeReductionRentrancyGuard()
+    ~TypeReductionReentrancyGuard()
     {
         sharedState->reentrantTypeReduction = false;
     }
-    TypeReductionRentrancyGuard(const TypeReductionRentrancyGuard&) = delete;
-    TypeReductionRentrancyGuard(TypeReductionRentrancyGuard&&) = delete;
+    TypeReductionReentrancyGuard(const TypeReductionReentrancyGuard&) = delete;
+    TypeReductionReentrancyGuard(TypeReductionReentrancyGuard&&) = delete;
 
 private:
     NotNull<UnifierSharedState> sharedState;

--- a/Analysis/src/BuiltinDefinitions.cpp
+++ b/Analysis/src/BuiltinDefinitions.cpp
@@ -35,8 +35,8 @@ LUAU_FASTFLAG(LuauSolverV2)
 LUAU_FASTFLAGVARIABLE(LuauTableCloneClonesType4)
 LUAU_FASTFLAG(LuauUseWorkspacePropToChooseSolver)
 LUAU_FASTFLAG(LuauBuiltinTypeFunctionsArentGlobal)
-LUAU_FASTFLAG(LuauNewOverloadResolver2)
 LUAU_FASTFLAGVARIABLE(LuauCloneForIntersectionsUnions)
+LUAU_FASTFLAG(LuauStorePolarityInline)
 
 namespace Luau
 {
@@ -296,7 +296,8 @@ void addGlobalBinding(GlobalTypes& globals, const ScopePtr& scope, const std::st
 
 void addGlobalBinding(GlobalTypes& globals, const ScopePtr& scope, const std::string& name, Binding binding)
 {
-    inferGenericPolarities(NotNull{&globals.globalTypes}, NotNull{scope.get()}, binding.typeId);
+    if (!FFlag::LuauStorePolarityInline)
+        inferGenericPolarities_DEPRECATED(NotNull{&globals.globalTypes}, NotNull{scope.get()}, binding.typeId);
     scope->bindings[globals.globalNames.names->getOrAdd(name.c_str())] = binding;
 }
 
@@ -378,8 +379,10 @@ void registerBuiltinGlobals(Frontend& frontend, GlobalTypes& globals, bool typeC
     );
     LUAU_ASSERT(loadResult.success);
 
-    TypeId genericK = arena.addType(GenericType{globalScope, "K"});
-    TypeId genericV = arena.addType(GenericType{globalScope, "V"});
+    TypeId genericK =
+        FFlag::LuauStorePolarityInline ? arena.addType(GenericType{globalScope, "K", Polarity::Mixed}) : arena.addType(GenericType{globalScope, "K"});
+    TypeId genericV =
+        FFlag::LuauStorePolarityInline ? arena.addType(GenericType{globalScope, "V", Polarity::Mixed}) : arena.addType(GenericType{globalScope, "V"});
     TypeId mapOfKtoV = arena.addType(TableType{{}, TableIndexer(genericK, genericV), globals.globalScope->level, TableState::Generic});
 
     std::optional<TypeId> stringMetatableTy = getMetatable(builtinTypes->stringType, builtinTypes);
@@ -428,14 +431,16 @@ void registerBuiltinGlobals(Frontend& frontend, GlobalTypes& globals, bool typeC
     // pairs<K, V>(t: Table<K, V>) -> ((Table<K, V>, K?) -> (K, V), Table<K, V>, nil)
     addGlobalBinding(globals, "pairs", arena.addType(FunctionType{{genericK, genericV}, {}, pairsArgsTypePack, pairsReturnTypePack}), "@luau");
 
-    TypeId genericMT = arena.addType(GenericType{globalScope, "MT"});
+    TypeId genericMT = FFlag::LuauStorePolarityInline ? arena.addType(GenericType{globalScope, "MT", Polarity::Mixed})
+                                                      : arena.addType(GenericType{globalScope, "MT"});
 
     TableType tab{TableState::Generic, globals.globalScope->level};
     TypeId tabTy = arena.addType(std::move(tab));
 
     TypeId tableMetaMT = arena.addType(MetatableType{tabTy, genericMT});
 
-    TypeId genericT = arena.addType(GenericType{globalScope, "T"});
+    TypeId genericT =
+        FFlag::LuauStorePolarityInline ? arena.addType(GenericType{globalScope, "T", Polarity::Mixed}) : arena.addType(GenericType{globalScope, "T"});
 
     if (frontend.getLuauSolverMode() == SolverMode::New)
     {
@@ -493,7 +498,9 @@ void registerBuiltinGlobals(Frontend& frontend, GlobalTypes& globals, bool typeC
     if (frontend.getLuauSolverMode() == SolverMode::New)
     {
         // declare function assert<T>(value: T, errorMessage: string?): intersect<T, ~(false?)>
-        TypeId genericT = arena.addType(GenericType{globalScope, "T"});
+        TypeId genericT = FFlag::LuauStorePolarityInline ? arena.addType(GenericType{globalScope, "T", Polarity::Mixed})
+                                                         : arena.addType(GenericType{globalScope, "T"});
+
         TypeId refinedTy = arena.addType(
             TypeFunctionInstanceType{
                 NotNull{
@@ -525,14 +532,20 @@ void registerBuiltinGlobals(Frontend& frontend, GlobalTypes& globals, bool typeC
             // the top table type.  We do the best we can by modelling these
             // functions using unconstrained generics.  It's not quite right,
             // but it'll be ok for now.
-            TypeId genericTy = arena.addType(GenericType{globalScope, "T"});
+            TypeId genericTy = FFlag::LuauStorePolarityInline ? arena.addType(GenericType{globalScope, "T", Polarity::Mixed})
+                                                              : arena.addType(GenericType{globalScope, "T"});
             TypePackId thePack = arena.addTypePack({genericTy});
             TypeId idTyWithMagic = arena.addType(FunctionType{{genericTy}, {}, thePack, thePack});
             ttv->props["freeze"] = makeProperty(idTyWithMagic, "@luau/global/table.freeze");
-            inferGenericPolarities(NotNull{&globals.globalTypes}, NotNull{globalScope}, idTyWithMagic);
+
+            if (!FFlag::LuauStorePolarityInline)
+                inferGenericPolarities_DEPRECATED(NotNull{&globals.globalTypes}, NotNull{globalScope}, idTyWithMagic);
 
             TypeId idTy = arena.addType(FunctionType{{genericTy}, {}, thePack, thePack});
-            inferGenericPolarities(NotNull{&globals.globalTypes}, NotNull{globalScope}, idTy);
+
+            if (!FFlag::LuauStorePolarityInline)
+                inferGenericPolarities_DEPRECATED(NotNull{&globals.globalTypes}, NotNull{globalScope}, idTy);
+
             ttv->props["clone"] = makeProperty(idTy, "@luau/global/table.clone");
         }
         else
@@ -1719,11 +1732,7 @@ bool MagicFreeze::infer(const MagicFunctionCallContext& context)
 
     const auto& [paramTypes, paramTail] = extendTypePack(*arena, context.solver->builtinTypes, context.arguments, 1);
     if (paramTypes.empty() || context.callSite->args.size == 0)
-    {
-        if (!FFlag::LuauNewOverloadResolver2)
-            context.solver->reportError(CountMismatch{1, std::nullopt, 0}, context.callSite->argLocation);
         return false;
-    }
 
     TypeId inputType = follow(paramTypes[0]);
 

--- a/Analysis/src/BuiltinTypeFunctions.cpp
+++ b/Analysis/src/BuiltinTypeFunctions.cpp
@@ -20,14 +20,12 @@
 LUAU_DYNAMIC_FASTINT(LuauTypeFamilyApplicationCartesianProductLimit)
 LUAU_DYNAMIC_FASTINTVARIABLE(LuauStepRefineRecursionLimit, 64)
 
-LUAU_FASTFLAGVARIABLE(LuauRefineNoRefineAlways2)
-LUAU_FASTFLAGVARIABLE(LuauRefineDistributesOverUnions)
 LUAU_FASTFLAG(LuauNoMoreComparisonTypeFunctions)
 LUAU_FASTFLAG(LuauInstantiationUsesGenericPolarity2)
 LUAU_FASTFLAGVARIABLE(LuauBuiltinTypeFunctionsUseNewOverloadResolution)
 LUAU_FASTFLAGVARIABLE(LuauBuiltinTypeFunctionsArentGlobal)
-LUAU_FASTFLAGVARIABLE(LuauGetmetatableError)
 LUAU_FASTFLAGVARIABLE(LuauSetmetatableWaitForPendingTypes)
+LUAU_FASTFLAGVARIABLE(LuauTypeFunctionsUseSolveFunctionCall)
 
 namespace Luau
 {
@@ -129,6 +127,63 @@ std::optional<TypeFunctionReductionResult<TypeId>> tryDistributeTypeFunctionApp(
 
 } // namespace
 
+static std::optional<TypePackId> solveFunctionCall(NotNull<TypeFunctionContext> ctx, const Location& location, TypeId fnTy, TypePackId argsPack)
+{
+    auto resolver = std::make_unique<OverloadResolver>(
+        ctx->builtins, ctx->arena, ctx->normalizer, ctx->typeFunctionRuntime, ctx->scope, ctx->ice, ctx->limits, location
+    );
+
+    DenseHashSet<TypeId> uniqueTypes{nullptr};
+    OverloadResolution resolution = resolver->resolveOverload(fnTy, argsPack, location, NotNull{&uniqueTypes}, /* useFreeTypeBounds */ false);
+
+    if (resolution.ok.empty() && resolution.potentialOverloads.empty())
+        return std::nullopt;
+
+    SelectedOverload selected = resolution.getUnambiguousOverload();
+
+    if (!selected.overload.has_value())
+        return std::nullopt;
+
+    TypePackId retPack = ctx->arena->freshTypePack(ctx->scope);
+    TypeId prospectiveFunction = ctx->arena->addType(FunctionType{argsPack, retPack});
+
+    // FIXME: It's too bad that we have to bust out the Unifier here.  We should
+    // be able to know the set of implied constraints and generic substitutions
+    // that are implied by that overload.
+    //
+    // Given that, we should be able to compute the return pack directly.
+
+    Unifier2 unifier{ctx->arena, ctx->builtins, ctx->scope, ctx->ice};
+
+    const UnifyResult unifyResult = unifier.unify(*selected.overload, prospectiveFunction);
+
+    switch (unifyResult)
+    {
+    case Luau::UnifyResult::Ok:
+        break;
+    case Luau::UnifyResult::OccursCheckFailed:
+        return std::nullopt;
+    case Luau::UnifyResult::TooComplex:
+        return std::nullopt;
+    }
+
+    LUAU_ASSERT(FFlag::LuauInstantiationUsesGenericPolarity2);
+
+    if (!unifier.genericSubstitutions.empty() || !unifier.genericPackSubstitutions.empty())
+    {
+        Subtyping subtyping{ctx->builtins, ctx->arena, ctx->normalizer, ctx->typeFunctionRuntime, ctx->ice};
+        std::optional<TypePackId> subst = instantiate2(
+            ctx->arena, std::move(unifier.genericSubstitutions), std::move(unifier.genericPackSubstitutions), NotNull{&subtyping}, ctx->scope, retPack
+        );
+        if (!subst)
+            return std::nullopt;
+        else
+            retPack = *subst;
+    }
+
+    return retPack;
+}
+
 TypeFunctionReductionResult<TypeId> notTypeFunction(
     TypeId instance,
     const std::vector<TypeId>& typeParams,
@@ -222,26 +277,37 @@ TypeFunctionReductionResult<TypeId> lenTypeFunction(
     if (isPending(*mmType, ctx->solver))
         return {std::nullopt, Reduction::MaybeOk, {*mmType}, {}};
 
-    const FunctionType* mmFtv = get<FunctionType>(*mmType);
-    if (!mmFtv)
-        return {std::nullopt, Reduction::Erroneous, {}, {}};
+    if (FFlag::LuauTypeFunctionsUseSolveFunctionCall)
+    {
+        // We only care that we _can_ solve this function, it doesn't matter what it returns.
+        if (!solveFunctionCall(ctx, ctx->constraint ? ctx->constraint->location : Location{}, *mmType, ctx->arena->addTypePack({operandTy})))
+            return {std::nullopt, Reduction::Erroneous, {}, {}};
+    }
+    else
+    {
 
-    std::optional<TypeId> instantiatedMmType = instantiate(ctx->builtins, ctx->arena, ctx->limits, ctx->scope, *mmType);
-    if (!instantiatedMmType)
-        return {std::nullopt, Reduction::Erroneous, {}, {}};
+        const FunctionType* mmFtv = get<FunctionType>(*mmType);
+        if (!mmFtv)
+            return {std::nullopt, Reduction::Erroneous, {}, {}};
 
-    const FunctionType* instantiatedMmFtv = get<FunctionType>(*instantiatedMmType);
-    if (!instantiatedMmFtv)
-        return {ctx->builtins->errorType, Reduction::MaybeOk, {}, {}};
+        std::optional<TypeId> instantiatedMmType = instantiate(ctx->builtins, ctx->arena, ctx->limits, ctx->scope, *mmType);
+        if (!instantiatedMmType)
+            return {std::nullopt, Reduction::Erroneous, {}, {}};
 
-    TypePackId inferredArgPack = ctx->arena->addTypePack({operandTy});
-    Unifier2 u2{ctx->arena, ctx->builtins, ctx->scope, ctx->ice};
-    if (UnifyResult::Ok != u2.unify(inferredArgPack, instantiatedMmFtv->argTypes))
-        return {std::nullopt, Reduction::Erroneous, {}, {}}; // occurs check failed
+        const FunctionType* instantiatedMmFtv = get<FunctionType>(*instantiatedMmType);
+        if (!instantiatedMmFtv)
+            return {ctx->builtins->errorType, Reduction::MaybeOk, {}, {}};
 
-    Subtyping subtyping{ctx->builtins, ctx->arena, ctx->normalizer, ctx->typeFunctionRuntime, ctx->ice};
-    if (!subtyping.isSubtype(inferredArgPack, instantiatedMmFtv->argTypes, ctx->scope, {}).isSubtype)
-        return {std::nullopt, Reduction::Erroneous, {}, {}};
+        TypePackId inferredArgPack = ctx->arena->addTypePack({operandTy});
+
+        Unifier2 u2{ctx->arena, ctx->builtins, ctx->scope, ctx->ice};
+        if (UnifyResult::Ok != u2.unify(inferredArgPack, instantiatedMmFtv->argTypes))
+            return {std::nullopt, Reduction::Erroneous, {}, {}}; // occurs check failed
+
+        Subtyping subtyping{ctx->builtins, ctx->arena, ctx->normalizer, ctx->typeFunctionRuntime, ctx->ice};
+        if (!subtyping.isSubtype(inferredArgPack, instantiatedMmFtv->argTypes, ctx->scope, {}).isSubtype)
+            return {std::nullopt, Reduction::Erroneous, {}, {}};
+    }
 
     // `len` must return a `number`.
     return {ctx->builtins->numberType, Reduction::MaybeOk, {}, {}};
@@ -304,27 +370,43 @@ TypeFunctionReductionResult<TypeId> unmTypeFunction(
     if (isPending(*mmType, ctx->solver))
         return {std::nullopt, Reduction::MaybeOk, {*mmType}, {}};
 
-    const FunctionType* mmFtv = get<FunctionType>(*mmType);
-    if (!mmFtv)
-        return {std::nullopt, Reduction::Erroneous, {}, {}};
+    if (FFlag::LuauTypeFunctionsUseSolveFunctionCall)
+    {
+        auto result = solveFunctionCall(ctx, ctx->constraint ? ctx->constraint->location : Location{}, *mmType, ctx->arena->addTypePack({operandTy}));
+        if (!result)
+            return {std::nullopt, Reduction::Erroneous, {}, {}};
 
-    std::optional<TypeId> instantiatedMmType = instantiate(ctx->builtins, ctx->arena, ctx->limits, ctx->scope, *mmType);
-    if (!instantiatedMmType)
-        return {std::nullopt, Reduction::Erroneous, {}, {}};
-
-    const FunctionType* instantiatedMmFtv = get<FunctionType>(*instantiatedMmType);
-    if (!instantiatedMmFtv)
-        return {ctx->builtins->errorType, Reduction::MaybeOk, {}, {}};
-
-    TypePackId inferredArgPack = ctx->arena->addTypePack({operandTy});
-    Unifier2 u2{ctx->arena, ctx->builtins, ctx->scope, ctx->ice};
-    if (UnifyResult::Ok != u2.unify(inferredArgPack, instantiatedMmFtv->argTypes))
-        return {std::nullopt, Reduction::Erroneous, {}, {}}; // occurs check failed
-
-    if (std::optional<TypeId> ret = first(instantiatedMmFtv->retTypes))
-        return {ret, Reduction::MaybeOk, {}, {}};
+        if (auto ret = first(*result))
+            return {ret, Reduction::MaybeOk, {}, {}};
+        else
+            return {std::nullopt, Reduction::Erroneous, {}, {}};
+    }
     else
-        return {std::nullopt, Reduction::Erroneous, {}, {}};
+    {
+
+        const FunctionType* mmFtv = get<FunctionType>(*mmType);
+        if (!mmFtv)
+            return {std::nullopt, Reduction::Erroneous, {}, {}};
+
+        std::optional<TypeId> instantiatedMmType = instantiate(ctx->builtins, ctx->arena, ctx->limits, ctx->scope, *mmType);
+        if (!instantiatedMmType)
+            return {std::nullopt, Reduction::Erroneous, {}, {}};
+
+        const FunctionType* instantiatedMmFtv = get<FunctionType>(*instantiatedMmType);
+        if (!instantiatedMmFtv)
+            return {ctx->builtins->errorType, Reduction::MaybeOk, {}, {}};
+
+        TypePackId inferredArgPack = ctx->arena->addTypePack({operandTy});
+
+        Unifier2 u2{ctx->arena, ctx->builtins, ctx->scope, ctx->ice};
+        if (UnifyResult::Ok != u2.unify(inferredArgPack, instantiatedMmFtv->argTypes))
+            return {std::nullopt, Reduction::Erroneous, {}, {}}; // occurs check failed
+
+        if (std::optional<TypeId> ret = first(instantiatedMmFtv->retTypes))
+            return {ret, Reduction::MaybeOk, {}, {}};
+        else
+            return {std::nullopt, Reduction::Erroneous, {}, {}};
+    }
 }
 
 TypeFunctionContext::TypeFunctionContext(NotNull<ConstraintSolver> cs, NotNull<Scope> scope, NotNull<const Constraint> constraint)
@@ -353,61 +435,6 @@ NotNull<Constraint> TypeFunctionContext::pushConstraint(ConstraintV&& c) const
     return newConstraint;
 }
 
-static std::optional<TypePackId> solveFunctionCall(NotNull<TypeFunctionContext> ctx, const Location& location, TypeId fnTy, TypePackId argsPack)
-{
-    auto resolver = std::make_unique<OverloadResolver>(
-        ctx->builtins, ctx->arena, ctx->normalizer, ctx->typeFunctionRuntime, ctx->scope, ctx->ice, ctx->limits, location
-    );
-
-    DenseHashSet<TypeId> uniqueTypes{nullptr};
-    OverloadResolution resolution = resolver->resolveOverload(fnTy, argsPack, location, NotNull{&uniqueTypes}, /* useFreeTypeBounds */ false);
-    if (resolution.ok.empty() && resolution.potentialOverloads.empty())
-        return std::nullopt;
-
-    SelectedOverload selected = resolution.getUnambiguousOverload();
-
-    if (!selected.overload.has_value())
-        return std::nullopt;
-
-    TypePackId retPack = ctx->arena->freshTypePack(ctx->scope);
-    TypeId prospectiveFunction = ctx->arena->addType(FunctionType{argsPack, retPack});
-
-    // FIXME: It's too bad that we have to bust out the Unifier here.  We should
-    // be able to know the set of implied constraints and generic substitutions
-    // that are implied by that overload.
-    //
-    // Given that, we should be able to compute the return pack directly.
-
-    Unifier2 unifier{ctx->arena, ctx->builtins, ctx->scope, ctx->ice};
-
-    const UnifyResult unifyResult = unifier.unify(*selected.overload, prospectiveFunction);
-
-    switch (unifyResult)
-    {
-    case Luau::UnifyResult::Ok:
-        break;
-    case Luau::UnifyResult::OccursCheckFailed:
-        return std::nullopt;
-    case Luau::UnifyResult::TooComplex:
-        return std::nullopt;
-    }
-
-    LUAU_ASSERT(FFlag::LuauInstantiationUsesGenericPolarity2);
-
-    if (!unifier.genericSubstitutions.empty() || !unifier.genericPackSubstitutions.empty())
-    {
-        Subtyping subtyping{ctx->builtins, ctx->arena, ctx->normalizer, ctx->typeFunctionRuntime, ctx->ice};
-        std::optional<TypePackId> subst = instantiate2(
-            ctx->arena, std::move(unifier.genericSubstitutions), std::move(unifier.genericPackSubstitutions), NotNull{&subtyping}, ctx->scope, retPack
-        );
-        if (!subst)
-            return std::nullopt;
-        else
-            retPack = *subst;
-    }
-
-    return retPack;
-}
 
 TypeFunctionReductionResult<TypeId> numericBinopTypeFunction(
     TypeId instance,
@@ -725,32 +752,49 @@ TypeFunctionReductionResult<TypeId> concatTypeFunction(
     if (isPending(*mmType, ctx->solver))
         return {std::nullopt, Reduction::MaybeOk, {*mmType}, {}};
 
-    const FunctionType* mmFtv = get<FunctionType>(*mmType);
-    if (!mmFtv)
-        return {std::nullopt, Reduction::Erroneous, {}, {}};
+    if (FFlag::LuauTypeFunctionsUseSolveFunctionCall)
+    {
+        std::vector<TypeId> inferredArgs;
+        if (!reversed)
+            inferredArgs = {lhsTy, rhsTy};
+        else
+            inferredArgs = {rhsTy, lhsTy};
 
-    std::optional<TypeId> instantiatedMmType = instantiate(ctx->builtins, ctx->arena, ctx->limits, ctx->scope, *mmType);
-    if (!instantiatedMmType)
-        return {std::nullopt, Reduction::Erroneous, {}, {}};
-
-    const FunctionType* instantiatedMmFtv = get<FunctionType>(*instantiatedMmType);
-    if (!instantiatedMmFtv)
-        return {ctx->builtins->errorType, Reduction::MaybeOk, {}, {}};
-
-    std::vector<TypeId> inferredArgs;
-    if (!reversed)
-        inferredArgs = {lhsTy, rhsTy};
+        if (!solveFunctionCall(ctx, ctx->constraint ? ctx->constraint->location : Location{}, *mmType, ctx->arena->addTypePack(std::move(inferredArgs))))
+            return {std::nullopt, Reduction::Erroneous, {}, {}};
+    }
     else
-        inferredArgs = {rhsTy, lhsTy};
+    {
+        const FunctionType* mmFtv = get<FunctionType>(*mmType);
+        if (!mmFtv)
+            return {std::nullopt, Reduction::Erroneous, {}, {}};
 
-    TypePackId inferredArgPack = ctx->arena->addTypePack(std::move(inferredArgs));
-    Unifier2 u2{ctx->arena, ctx->builtins, ctx->scope, ctx->ice};
-    if (UnifyResult::Ok != u2.unify(inferredArgPack, instantiatedMmFtv->argTypes))
-        return {std::nullopt, Reduction::Erroneous, {}, {}}; // occurs check failed
+        std::optional<TypeId> instantiatedMmType = instantiate(ctx->builtins, ctx->arena, ctx->limits, ctx->scope, *mmType);
+        if (!instantiatedMmType)
+            return {std::nullopt, Reduction::Erroneous, {}, {}};
 
-    Subtyping subtyping{ctx->builtins, ctx->arena, ctx->normalizer, ctx->typeFunctionRuntime, ctx->ice};
-    if (!subtyping.isSubtype(inferredArgPack, instantiatedMmFtv->argTypes, ctx->scope, {}).isSubtype)
-        return {std::nullopt, Reduction::Erroneous, {}, {}};
+        const FunctionType* instantiatedMmFtv = get<FunctionType>(*instantiatedMmType);
+        if (!instantiatedMmFtv)
+            return {ctx->builtins->errorType, Reduction::MaybeOk, {}, {}};
+
+        std::vector<TypeId> inferredArgs;
+        if (!reversed)
+            inferredArgs = {lhsTy, rhsTy};
+        else
+            inferredArgs = {rhsTy, lhsTy};
+
+        TypePackId inferredArgPack = ctx->arena->addTypePack(std::move(inferredArgs));
+
+
+        Unifier2 u2{ctx->arena, ctx->builtins, ctx->scope, ctx->ice};
+        if (UnifyResult::Ok != u2.unify(inferredArgPack, instantiatedMmFtv->argTypes))
+            return {std::nullopt, Reduction::Erroneous, {}, {}}; // occurs check failed
+
+        Subtyping subtyping{ctx->builtins, ctx->arena, ctx->normalizer, ctx->typeFunctionRuntime, ctx->ice};
+        if (!subtyping.isSubtype(inferredArgPack, instantiatedMmFtv->argTypes, ctx->scope, {}).isSubtype)
+            return {std::nullopt, Reduction::Erroneous, {}, {}};
+    }
+
 
     return {ctx->builtins->stringType, Reduction::MaybeOk, {}, {}};
 }
@@ -794,7 +838,7 @@ TypeFunctionReductionResult<TypeId> andTypeFunction(
     else if (isPending(rhsTy, ctx->solver))
         return {std::nullopt, Reduction::MaybeOk, {rhsTy}, {}};
 
-    // And evalutes to a boolean if the LHS is falsey, and the RHS type if LHS is truthy.
+    // And evalutes to a boolean if the LHS is falsy, and the RHS type if LHS is truthy.
     SimplifyResult filteredLhs = simplifyIntersection(ctx->builtins, ctx->arena, lhsTy, ctx->builtins->falsyType);
     SimplifyResult overallResult = simplifyUnion(ctx->builtins, ctx->arena, rhsTy, filteredLhs.result);
     std::vector<TypeId> blockedTypes{};
@@ -940,26 +984,36 @@ static TypeFunctionReductionResult<TypeId> comparisonTypeFunction(
     if (isPending(*mmType, ctx->solver))
         return {std::nullopt, Reduction::MaybeOk, {*mmType}, {}};
 
-    const FunctionType* mmFtv = get<FunctionType>(*mmType);
-    if (!mmFtv)
-        return {std::nullopt, Reduction::Erroneous, {}, {}};
+    if (FFlag::LuauTypeFunctionsUseSolveFunctionCall)
+    {
+        // We only care that we _can_ solve this function, it doesn't matter what it returns.
+        if (!solveFunctionCall(ctx, ctx->constraint ? ctx->constraint->location : Location{}, *mmType, ctx->arena->addTypePack({lhsTy, rhsTy})))
+            return {std::nullopt, Reduction::Erroneous, {}, {}};
+    }
+    else
+    {
+        const FunctionType* mmFtv = get<FunctionType>(*mmType);
+        if (!mmFtv)
+            return {std::nullopt, Reduction::Erroneous, {}, {}};
 
-    std::optional<TypeId> instantiatedMmType = instantiate(ctx->builtins, ctx->arena, ctx->limits, ctx->scope, *mmType);
-    if (!instantiatedMmType)
-        return {std::nullopt, Reduction::Erroneous, {}, {}};
+        std::optional<TypeId> instantiatedMmType = instantiate(ctx->builtins, ctx->arena, ctx->limits, ctx->scope, *mmType);
+        if (!instantiatedMmType)
+            return {std::nullopt, Reduction::Erroneous, {}, {}};
 
-    const FunctionType* instantiatedMmFtv = get<FunctionType>(*instantiatedMmType);
-    if (!instantiatedMmFtv)
-        return {ctx->builtins->errorType, Reduction::MaybeOk, {}, {}};
+        const FunctionType* instantiatedMmFtv = get<FunctionType>(*instantiatedMmType);
+        if (!instantiatedMmFtv)
+            return {ctx->builtins->errorType, Reduction::MaybeOk, {}, {}};
 
-    TypePackId inferredArgPack = ctx->arena->addTypePack({lhsTy, rhsTy});
-    Unifier2 u2{ctx->arena, ctx->builtins, ctx->scope, ctx->ice};
-    if (UnifyResult::Ok != u2.unify(inferredArgPack, instantiatedMmFtv->argTypes))
-        return {std::nullopt, Reduction::Erroneous, {}, {}}; // occurs check failed
+        TypePackId inferredArgPack = ctx->arena->addTypePack({lhsTy, rhsTy});
+        Unifier2 u2{ctx->arena, ctx->builtins, ctx->scope, ctx->ice};
+        if (UnifyResult::Ok != u2.unify(inferredArgPack, instantiatedMmFtv->argTypes))
+            return {std::nullopt, Reduction::Erroneous, {}, {}}; // occurs check failed
 
-    Subtyping subtyping{ctx->builtins, ctx->arena, ctx->normalizer, ctx->typeFunctionRuntime, ctx->ice};
-    if (!subtyping.isSubtype(inferredArgPack, instantiatedMmFtv->argTypes, ctx->scope, {}).isSubtype)
-        return {std::nullopt, Reduction::Erroneous, {}, {}};
+        Subtyping subtyping{ctx->builtins, ctx->arena, ctx->normalizer, ctx->typeFunctionRuntime, ctx->ice};
+        if (!subtyping.isSubtype(inferredArgPack, instantiatedMmFtv->argTypes, ctx->scope, {}).isSubtype)
+            return {std::nullopt, Reduction::Erroneous, {}, {}};
+    }
+
 
     return {ctx->builtins->booleanType, Reduction::MaybeOk, {}, {}};
 }
@@ -1069,26 +1123,35 @@ TypeFunctionReductionResult<TypeId> eqTypeFunction(
     if (isPending(*mmType, ctx->solver))
         return {std::nullopt, Reduction::MaybeOk, {*mmType}, {}};
 
-    const FunctionType* mmFtv = get<FunctionType>(*mmType);
-    if (!mmFtv)
-        return {std::nullopt, Reduction::Erroneous, {}, {}};
+    if (FFlag::LuauTypeFunctionsUseSolveFunctionCall)
+    {
+        if (!solveFunctionCall(ctx, ctx->constraint ? ctx->constraint->location : Location{}, *mmType, ctx->arena->addTypePack({lhsTy, rhsTy})))
+            return {std::nullopt, Reduction::Erroneous, {}, {}};
+    }
+    else
+    {
+        const FunctionType* mmFtv = get<FunctionType>(*mmType);
+        if (!mmFtv)
+            return {std::nullopt, Reduction::Erroneous, {}, {}};
 
-    std::optional<TypeId> instantiatedMmType = instantiate(ctx->builtins, ctx->arena, ctx->limits, ctx->scope, *mmType);
-    if (!instantiatedMmType)
-        return {std::nullopt, Reduction::Erroneous, {}, {}};
+        std::optional<TypeId> instantiatedMmType = instantiate(ctx->builtins, ctx->arena, ctx->limits, ctx->scope, *mmType);
+        if (!instantiatedMmType)
+            return {std::nullopt, Reduction::Erroneous, {}, {}};
 
-    const FunctionType* instantiatedMmFtv = get<FunctionType>(*instantiatedMmType);
-    if (!instantiatedMmFtv)
-        return {ctx->builtins->errorType, Reduction::MaybeOk, {}, {}};
+        const FunctionType* instantiatedMmFtv = get<FunctionType>(*instantiatedMmType);
+        if (!instantiatedMmFtv)
+            return {ctx->builtins->errorType, Reduction::MaybeOk, {}, {}};
 
-    TypePackId inferredArgPack = ctx->arena->addTypePack({lhsTy, rhsTy});
-    Unifier2 u2{ctx->arena, ctx->builtins, ctx->scope, ctx->ice};
-    if (UnifyResult::Ok != u2.unify(inferredArgPack, instantiatedMmFtv->argTypes))
-        return {std::nullopt, Reduction::Erroneous, {}, {}}; // occurs check failed
+        TypePackId inferredArgPack = ctx->arena->addTypePack({lhsTy, rhsTy});
+        Unifier2 u2{ctx->arena, ctx->builtins, ctx->scope, ctx->ice};
+        if (UnifyResult::Ok != u2.unify(inferredArgPack, instantiatedMmFtv->argTypes))
+            return {std::nullopt, Reduction::Erroneous, {}, {}}; // occurs check failed
 
-    Subtyping subtyping{ctx->builtins, ctx->arena, ctx->normalizer, ctx->typeFunctionRuntime, ctx->ice};
-    if (!subtyping.isSubtype(inferredArgPack, instantiatedMmFtv->argTypes, ctx->scope, {}).isSubtype)
-        return {std::nullopt, Reduction::Erroneous, {}, {}};
+        Subtyping subtyping{ctx->builtins, ctx->arena, ctx->normalizer, ctx->typeFunctionRuntime, ctx->ice};
+        if (!subtyping.isSubtype(inferredArgPack, instantiatedMmFtv->argTypes, ctx->scope, {}).isSubtype)
+            return {std::nullopt, Reduction::Erroneous, {}, {}};
+    }
+
 
     return {ctx->builtins->booleanType, Reduction::MaybeOk, {}, {}};
 }
@@ -1341,8 +1404,6 @@ TypeFunctionReductionResult<TypeId> refineTypeFunction(
     }
 
     std::vector<TypeId> discriminantTypes;
-    if (FFlag::LuauRefineNoRefineAlways2)
-    {
         for (size_t i = 1; i < typeParams.size(); i++)
         {
             auto discriminant = follow(typeParams[i]);
@@ -1367,12 +1428,6 @@ TypeFunctionReductionResult<TypeId> refineTypeFunction(
         // if we don't have any real refinements, i.e. they're all `*no-refine*`, then we can reduce immediately.
         if (discriminantTypes.empty())
             return {targetTy, {}};
-    }
-    else
-    {
-        for (size_t i = 1; i < typeParams.size(); i++)
-            discriminantTypes.push_back(follow(typeParams.at(i)));
-    }
 
     const bool targetIsPending = isBlockedOrUnsolvedType(targetTy);
 
@@ -1402,9 +1457,7 @@ TypeFunctionReductionResult<TypeId> refineTypeFunction(
     // Returns result : TypeId, toBlockOn : vector<TypeId>
     auto stepRefine = [&stepRefineCount, &ctx](TypeId target, TypeId discriminant) -> std::pair<TypeId, std::vector<TypeId>>
     {
-        std::optional<RecursionLimiter> rl;
-        if (FFlag::LuauRefineDistributesOverUnions)
-            rl.emplace("BuiltInTypeFunctions::stepRefine", &stepRefineCount, DFInt::LuauStepRefineRecursionLimit);
+        RecursionLimiter rl{"BuiltInTypeFunctions::stepRefine", &stepRefineCount, DFInt::LuauStepRefineRecursionLimit};
 
         std::vector<TypeId> toBlock;
         // we need a more complex check for blocking on the discriminant in particular
@@ -1413,19 +1466,6 @@ TypeFunctionReductionResult<TypeId> refineTypeFunction(
 
         if (!frb.found.empty())
             return {nullptr, {frb.found.begin(), frb.found.end()}};
-
-        // FFlag::LuauRefineNoRefineAlways2 moves this check upwards so that it runs even if the thing being refined is pending.
-        if (!FFlag::LuauRefineNoRefineAlways2)
-        {
-            // If the discriminant type is only:
-            // - The `*no-refine*` type or,
-            // - tables, metatables, unions, intersections, functions, or negations _containing_ `*no-refine*`.
-            // There's no point in refining against it.
-            ContainsRefinableType crt;
-            crt.traverse(discriminant);
-            if (!crt.found)
-                return {target, {}};
-        }
 
         if (auto ty = intersectWithSimpleDiscriminant(ctx->builtins, ctx->arena, target, discriminant))
             return {*ty, {}};
@@ -1494,56 +1534,53 @@ TypeFunctionReductionResult<TypeId> refineTypeFunction(
     {
         TypeId discriminant = discriminantTypes.back();
 
-        if (FFlag::LuauRefineDistributesOverUnions)
+        discriminant = follow(discriminant);
+
+        // first, we'll see if simplifying the discriminant alone will solve our problem...
+        if (auto ut = get<UnionType>(discriminant))
         {
-            discriminant = follow(discriminant);
+            TypeId workingType = ctx->builtins->neverType;
 
-            // first, we'll see if simplifying the discriminant alone will solve our problem...
-            if (auto ut = get<UnionType>(discriminant))
+            for (auto optionAsDiscriminant : ut->options)
             {
-                TypeId workingType = ctx->builtins->neverType;
+                SimplifyResult simplified = simplifyUnion(ctx->builtins, ctx->arena, workingType, optionAsDiscriminant);
 
-                for (auto optionAsDiscriminant : ut->options)
-                {
-                    SimplifyResult simplified = simplifyUnion(ctx->builtins, ctx->arena, workingType, optionAsDiscriminant);
+                if (!simplified.blockedTypes.empty())
+                    return {std::nullopt, Reduction::MaybeOk, {simplified.blockedTypes.begin(), simplified.blockedTypes.end()}, {}};
 
-                    if (!simplified.blockedTypes.empty())
-                        return {std::nullopt, Reduction::MaybeOk, {simplified.blockedTypes.begin(), simplified.blockedTypes.end()}, {}};
-
-                    workingType = simplified.result;
-                }
-
-                discriminant = workingType;
+                workingType = simplified.result;
             }
 
-            // if not, we try distributivity: a & (b | c) <=> (a & b) | (a & c)
-            if (auto ut = get<UnionType>(discriminant))
+            discriminant = workingType;
+        }
+
+        // if not, we try distributivity: a & (b | c) <=> (a & b) | (a & c)
+        if (auto ut = get<UnionType>(discriminant))
+        {
+            TypeId finalRefined = ctx->builtins->neverType;
+
+            for (auto optionAsDiscriminant : ut->options)
             {
-                TypeId finalRefined = ctx->builtins->neverType;
+                auto [refined, blocked] = stepRefine(target, follow(optionAsDiscriminant));
 
-                for (auto optionAsDiscriminant : ut->options)
-                {
-                    auto [refined, blocked] = stepRefine(target, follow(optionAsDiscriminant));
+                if (blocked.empty() && refined == nullptr)
+                    return {std::nullopt, Reduction::MaybeOk, {}, {}};
 
-                    if (blocked.empty() && refined == nullptr)
-                        return {std::nullopt, Reduction::MaybeOk, {}, {}};
+                if (!blocked.empty())
+                    return {std::nullopt, Reduction::MaybeOk, blocked, {}};
 
-                    if (!blocked.empty())
-                        return {std::nullopt, Reduction::MaybeOk, blocked, {}};
+                SimplifyResult simplified = simplifyUnion(ctx->builtins, ctx->arena, finalRefined, refined);
 
-                    SimplifyResult simplified = simplifyUnion(ctx->builtins, ctx->arena, finalRefined, refined);
+                if (!simplified.blockedTypes.empty())
+                    return {std::nullopt, Reduction::MaybeOk, {simplified.blockedTypes.begin(), simplified.blockedTypes.end()}, {}};
 
-                    if (!simplified.blockedTypes.empty())
-                        return {std::nullopt, Reduction::MaybeOk, {simplified.blockedTypes.begin(), simplified.blockedTypes.end()}, {}};
-
-                    finalRefined = simplified.result;
-                }
-
-                target = finalRefined;
-                discriminantTypes.pop_back();
-
-                continue;
+                finalRefined = simplified.result;
             }
+
+            target = finalRefined;
+            discriminantTypes.pop_back();
+
+            continue;
         }
 
         auto [refined, blocked] = stepRefine(target, discriminant);
@@ -2541,7 +2578,7 @@ static TypeFunctionReductionResult<TypeId> getmetatableHelper(TypeId targetTy, c
 
     if (auto primitive = get<PrimitiveType>(targetTy))
     {
-        if (FFlag::LuauGetmetatableError && primitive->type == PrimitiveType::Table)
+        if (primitive->type == PrimitiveType::Table)
         {
             // If we have `table` then we could have something with a
             // metatable, so claim the result is `table?`.
@@ -2571,7 +2608,7 @@ static TypeFunctionReductionResult<TypeId> getmetatableHelper(TypeId targetTy, c
         erroneous = false;
     }
 
-    if (FFlag::LuauGetmetatableError && get<ErrorType>(targetTy))
+    if (get<ErrorType>(targetTy))
     {
         // getmetatable<error> ~ error
         result = targetTy;

--- a/Analysis/src/Clone.cpp
+++ b/Analysis/src/Clone.cpp
@@ -273,7 +273,7 @@ private:
 
     void cloneChildren(GenericType* t)
     {
-        // TOOD: clone upper bounds.
+        // TODO: clone upper bounds.
     }
 
     void cloneChildren(PrimitiveType* t)
@@ -410,7 +410,7 @@ private:
 
     void cloneChildren(GenericTypePack* t)
     {
-        // TOOD: clone upper bounds.
+        // TODO: clone upper bounds.
     }
 
     void cloneChildren(BlockedTypePack* t)

--- a/Analysis/src/ConstraintSolver.cpp
+++ b/Analysis/src/ConstraintSolver.cpp
@@ -25,6 +25,7 @@
 #include "Luau/Type.h"
 #include "Luau/TypeFunction.h"
 #include "Luau/TypeFwd.h"
+#include "Luau/TypePack.h"
 #include "Luau/TypeUtils.h"
 #include "Luau/Unifier2.h"
 #include "Luau/VisitType.h"
@@ -40,19 +41,16 @@ LUAU_FASTFLAGVARIABLE(DebugLuauAssertOnForcedConstraint)
 LUAU_FASTFLAGVARIABLE(DebugLuauLogSolver)
 LUAU_FASTFLAGVARIABLE(DebugLuauLogSolverIncludeDependencies)
 LUAU_FASTFLAGVARIABLE(DebugLuauLogBindings)
-LUAU_FASTFLAGVARIABLE(LuauCollapseShouldNotCrash)
 LUAU_FASTFLAGVARIABLE(LuauDontDynamicallyCreateRedundantSubtypeConstraints)
 LUAU_FASTFLAG(DebugLuauStringSingletonBasedOnQuotes)
-LUAU_FASTFLAG(LuauExplicitTypeExpressionInstantiation)
-LUAU_FASTFLAG(LuauSimplifyIntersectionNoTreeSet)
+LUAU_FASTFLAG(LuauExplicitTypeInstantiationSupport)
 LUAU_FASTFLAG(LuauInstantiationUsesGenericPolarity2)
-LUAU_FASTFLAG(LuauPushTypeConstraintLambdas2)
-LUAU_FASTFLAGVARIABLE(LuauPushTypeConstriantAlwaysCompletes)
-LUAU_FASTFLAG(LuauNewOverloadResolver2)
+LUAU_FASTFLAG(LuauPushTypeConstraintLambdas3)
 LUAU_FASTFLAG(LuauMarkUnscopedGenericsAsSolved)
 LUAU_FASTFLAGVARIABLE(LuauUseFastSubtypeForIndexerWithName)
 LUAU_FASTFLAG(LuauUseIterativeTypeVisitor)
 LUAU_FASTFLAGVARIABLE(LuauDoNotUseApplyTypeFunctionToClone)
+LUAU_FASTFLAGVARIABLE(LuauReworkInfiniteTypeFinder)
 
 namespace Luau
 {
@@ -350,26 +348,76 @@ struct InfiniteTypeFinder : BaseVisitor
     {
     }
 
+    bool visit(TypeId ty) override
+    {
+        if (FFlag::LuauReworkInfiniteTypeFinder)
+            return !foundInfiniteType;
+        else
+            return true;
+    }
 
     bool visit(TypeId ty, const PendingExpansionType& petv) override
     {
-        const std::optional<TypeFun> tf =
-            (petv.prefix) ? scope->lookupImportedType(petv.prefix->value, petv.name.value) : scope->lookupType(petv.name.value);
-
-        if (!tf.has_value())
-            return true;
-
-        auto [typeArguments, packArguments] = saturateArguments(solver->arena, solver->builtinTypes, *tf, petv.typeArguments, petv.packArguments);
-
-        if (follow(tf->type) == follow(signature.fn.type) && (signature.arguments != typeArguments || signature.packArguments != packArguments))
+        if (FFlag::LuauReworkInfiniteTypeFinder)
         {
-            foundInfiniteType = true;
+            if (foundInfiniteType)
+                return false;
+
+            const std::optional<TypeFun> tf =
+                petv.prefix ? scope->lookupImportedType(petv.prefix->value, petv.name.value) : scope->lookupType(petv.name.value);
+
+            if (!tf)
+                return true;
+
+            // If `tf->type` is different from `signature.fn.type` then we
+            // have two different type aliases.
+            if (follow(tf->type) != follow(signature.fn.type))
+                return true;
+
+            // We want to check that the arguments to this pending expansion
+            // type are exactly the generic arguments provided.
+            for (size_t i = 0; i < std::min(petv.typeArguments.size(), tf->typeParams.size()); ++i)
+            {
+                if (petv.typeArguments[i] != tf->typeParams[i].ty)
+                {
+                    foundInfiniteType = true;
+                    return false;
+                }
+            }
+
+            // Ditto with packs.
+            for (size_t i = 0; i < std::min(petv.packArguments.size(), tf->typePackParams.size()); ++i)
+            {
+                if (petv.packArguments[i] != tf->typePackParams[i].tp)
+                {
+                    foundInfiniteType = true;
+                    return false;
+                }
+            }
+
             return false;
         }
+        else
+        {
+            const std::optional<TypeFun> tf =
+                (petv.prefix) ? scope->lookupImportedType(petv.prefix->value, petv.name.value) : scope->lookupType(petv.name.value);
 
-        return true;
+            if (!tf.has_value())
+                return true;
+
+            auto [typeArguments, packArguments] = saturateArguments(solver->arena, solver->builtinTypes, *tf, petv.typeArguments, petv.packArguments);
+
+            if (follow(tf->type) == follow(signature.fn.type) && (signature.arguments != typeArguments || signature.packArguments != packArguments))
+            {
+                foundInfiniteType = true;
+                return false;
+            }
+
+            return true;
+        }
     }
 };
+
 
 ConstraintSolver::ConstraintSolver(
     NotNull<Normalizer> normalizer,
@@ -880,7 +928,7 @@ bool ConstraintSolver::tryDispatch(NotNull<const Constraint> constraint, bool fo
         success = tryDispatch(*pftc, constraint);
     else if (auto esgc = get<TypeInstantiationConstraint>(*constraint))
     {
-        LUAU_ASSERT(FFlag::LuauExplicitTypeExpressionInstantiation);
+        LUAU_ASSERT(FFlag::LuauExplicitTypeInstantiationSupport);
         success = tryDispatch(*esgc, constraint);
     }
     else if (auto ptc = get<PushTypeConstraint>(*constraint))
@@ -1150,7 +1198,10 @@ bool ConstraintSolver::tryDispatch(const NameConstraint& c, NotNull<const Constr
 
             if (itf.foundInfiniteType)
             {
-                constraint->scope->invalidTypeAliasNames.insert(c.name);
+                if (FFlag::LuauReworkInfiniteTypeFinder)
+                    constraint->scope->invalidTypeAliases[c.name] = constraint->location;
+                else
+                    constraint->scope->invalidTypeAliasNames_DEPRECATED.insert(c.name);
                 shiftReferences(target, builtinTypes->errorType);
                 emplaceType<BoundType>(asMutable(target), builtinTypes->errorType);
                 return true;
@@ -1163,7 +1214,10 @@ bool ConstraintSolver::tryDispatch(const NameConstraint& c, NotNull<const Constr
 
             if (itf.foundInfiniteType)
             {
-                constraint->scope->invalidTypeAliasNames.insert(c.name);
+                if (FFlag::LuauReworkInfiniteTypeFinder)
+                    constraint->scope->invalidTypeAliases[c.name] = constraint->location;
+                else
+                    constraint->scope->invalidTypeAliasNames_DEPRECATED.insert(c.name);
                 shiftReferences(target, builtinTypes->errorType);
                 emplaceType<BoundType>(asMutable(target), builtinTypes->errorType);
                 return true;
@@ -1314,7 +1368,10 @@ bool ConstraintSolver::tryDispatch(const TypeAliasExpansionConstraint& c, NotNul
         {
             // TODO (CLI-56761): Report an error.
             bindResult(builtinTypes->errorType);
-            reportError(GenericError{"Recursive type being used with different parameters"}, constraint->location);
+            if (FFlag::LuauReworkInfiniteTypeFinder)
+                constraint->scope->invalidTypeAliases[petv->name.value] = constraint->location;
+            else
+                reportError(GenericError{"Recursive type being used with different parameters"}, constraint->location);
             return true;
         }
     }
@@ -1327,7 +1384,10 @@ bool ConstraintSolver::tryDispatch(const TypeAliasExpansionConstraint& c, NotNul
         {
             // TODO (CLI-56761): Report an error.
             bindResult(builtinTypes->errorType);
-            reportError(GenericError{"Recursive type being used with different parameters"}, constraint->location);
+            if (FFlag::LuauReworkInfiniteTypeFinder)
+                constraint->scope->invalidTypeAliases[petv->name.value] = constraint->location;
+            else
+                reportError(GenericError{"Recursive type being used with different parameters"}, constraint->location);
             return true;
         }
     }
@@ -1528,7 +1588,7 @@ bool ConstraintSolver::tryDispatch(const FunctionCallConstraint& c, NotNull<cons
         auto it = begin(t);
         auto endIt = end(t);
 
-        if (FFlag::LuauCollapseShouldNotCrash && it == endIt)
+        if (it == endIt)
             return std::nullopt;
 
         TypeId fst = follow(*it);
@@ -1550,43 +1610,17 @@ bool ConstraintSolver::tryDispatch(const FunctionCallConstraint& c, NotNull<cons
 
     bool usedMagic = false;
 
-    // We don't support magic __call metamethods.
-    if (std::optional<TypeId> callMm = findMetatableEntry(builtinTypes, errors, fn, "__call", constraint->location);
-        callMm && !FFlag::LuauNewOverloadResolver2)
+    const FunctionType* ftv = get<FunctionType>(fn);
+    if (ftv)
     {
-        if (isBlocked(*callMm))
-            return block(*callMm, constraint);
-
-        argsHead.insert(argsHead.begin(), fn);
-
-        if (argsTail && isBlocked(*argsTail))
-            return block(*argsTail, constraint);
-
-        argsPack = arena->addTypePack(TypePack{std::move(argsHead), argsTail});
-        fn = follow(*callMm);
-        emplace<FreeTypePack>(constraint, c.result, constraint->scope, Polarity::Positive);
-        trackInteriorFreeTypePack(constraint->scope, c.result);
-    }
-    else
-    {
-        const FunctionType* ftv = get<FunctionType>(fn);
-        if (ftv)
+        if (ftv->magic && c.callSite)
         {
-            if (ftv->magic && c.callSite)
-            {
-                usedMagic = ftv->magic->infer(MagicFunctionCallContext{NotNull{this}, constraint, NotNull{c.callSite}, c.argsPack, result});
-                ftv->magic->refine(MagicRefinementContext{constraint->scope, c.callSite, c.discriminantTypes});
-            }
-        }
-
-        if (!FFlag::LuauNewOverloadResolver2 && !usedMagic)
-        {
-            emplace<FreeTypePack>(constraint, c.result, constraint->scope, Polarity::Positive);
-            trackInteriorFreeTypePack(constraint->scope, c.result);
+            usedMagic = ftv->magic->infer(MagicFunctionCallContext{NotNull{this}, constraint, NotNull{c.callSite}, c.argsPack, result});
+            ftv->magic->refine(MagicRefinementContext{constraint->scope, c.callSite, c.discriminantTypes});
         }
     }
 
-    if (FFlag::LuauExplicitTypeExpressionInstantiation)
+    if (FFlag::LuauExplicitTypeInstantiationSupport)
     {
         if (!c.typeArguments.empty() || !c.typePackArguments.empty())
         {
@@ -1617,44 +1651,35 @@ bool ConstraintSolver::tryDispatch(const FunctionCallConstraint& c, NotNull<cons
     // point in trying to do overload selection: we're just wasting CPU.
     if (!is<FunctionType>(fn))
     {
-        if (FFlag::LuauNewOverloadResolver2)
+        auto res = resolver.resolveOverload(
+            fn,
+            argsPack,
+            c.callSite ? c.callSite->func->location : Location{},
+            NotNull{&uniqueTypes},
+            /* useFreeTypeBounds */ true
+        );
+
+        // For now we never retry as it's prohibitively expensive.
+        auto [overload, _constraints, _shouldRetry] = res.getUnambiguousOverload();
+
+        if (overload)
         {
-            auto res = resolver.resolveOverload(
-                fn,
-                argsPack,
-                c.callSite ? c.callSite->func->location : Location{},
-                NotNull{&uniqueTypes},
-                /* useFreeTypeBounds */ true
-            );
-
-            // For now we never retry as it's prohibitively expensive.
-            auto [overload, _constraints, _shouldRetry] = res.getUnambiguousOverload();
-
-            if (overload)
-            {
-                // NOTE: We may need to enqueue constraints here.
-                overloadToUse = *overload;
-            }
-            else
-            {
-                // If we fail to select an unambiguous overload then unify the
-                // result with error and move on.
-                bind(constraint, c.result, builtinTypes->errorTypePack);
-                return true;
-            }
-
-            if (res.metamethods.contains(overloadToUse))
-                argsPack = arena->addTypePack(TypePack{{fn}, argsPack});
+            // NOTE: We may need to enqueue constraints here.
+            overloadToUse = *overload;
         }
         else
         {
-            auto [status, overload] = resolver.selectOverload_DEPRECATED(fn, argsPack, NotNull{&uniqueTypes}, /*useFreeTypeBounds*/ force);
-            if (status == OverloadResolver::Analysis::Ok)
-                overloadToUse = overload;
+            // If we fail to select an unambiguous overload then unify the
+            // result with error and move on.
+            bind(constraint, c.result, builtinTypes->errorTypePack);
+            return true;
         }
+
+        if (res.metamethods.contains(overloadToUse))
+            argsPack = arena->addTypePack(TypePack{{fn}, argsPack});
     }
 
-    if (FFlag::LuauNewOverloadResolver2 && !usedMagic)
+    if (!usedMagic)
     {
         emplace<FreeTypePack>(constraint, c.result, constraint->scope, Polarity::Positive);
         trackInteriorFreeTypePack(constraint->scope, c.result);
@@ -1742,62 +1767,6 @@ bool ConstraintSolver::tryDispatch(const FunctionCallConstraint& c, NotNull<cons
     return true;
 }
 
-namespace
-{
-template<typename BaseVisitor>
-struct ContainsGenerics : public BaseVisitor
-{
-    NotNull<DenseHashSet<const void*>> generics;
-
-    explicit ContainsGenerics(NotNull<DenseHashSet<const void*>> generics)
-        : BaseVisitor("ContainsGenerics", /* skipBoundTypes */ true)
-        , generics{generics}
-    {
-    }
-
-    bool found = false;
-
-    bool visit(TypeId ty) override
-    {
-        return !found;
-    }
-
-    bool visit(TypeId ty, const GenericType&) override
-    {
-        found |= generics->contains(ty);
-        return true;
-    }
-
-    bool visit(TypeId ty, const TypeFunctionInstanceType&) override
-    {
-        return !found;
-    }
-
-    bool visit(TypePackId tp, const GenericTypePack&) override
-    {
-        found |= generics->contains(tp);
-        return !found;
-    }
-};
-
-bool containsGeneric(TypeId ty, NotNull<DenseHashSet<const void*>> generics)
-{
-    if (FFlag::LuauUseIterativeTypeVisitor)
-    {
-        ContainsGenerics<IterativeTypeVisitor> cg{generics};
-        cg.run(ty);
-        return cg.found;
-    }
-    else
-    {
-        ContainsGenerics<TypeOnceVisitor> cg{generics};
-        cg.traverse(ty);
-        return cg.found;
-    }
-}
-
-} // namespace
-
 bool ConstraintSolver::tryDispatch(const FunctionCheckConstraint& c, NotNull<const Constraint> constraint, bool force)
 {
     TypeId fn = follow(c.fn);
@@ -1870,7 +1839,7 @@ bool ConstraintSolver::tryDispatch(const FunctionCheckConstraint& c, NotNull<con
     // We don't attempt to perform bidirectional inference on the self type.
     const size_t typeOffset = c.callSite->self ? 1 : 0;
 
-    if (FFlag::LuauPushTypeConstraintLambdas2)
+    if (FFlag::LuauPushTypeConstraintLambdas3)
     {
         Subtyping subtyping{builtinTypes, arena, normalizer, typeFunctionRuntime, NotNull{&iceReporter}};
 
@@ -1879,8 +1848,17 @@ bool ConstraintSolver::tryDispatch(const FunctionCheckConstraint& c, NotNull<con
             TypeId expectedArgTy = follow(expectedArgs[i + typeOffset]);
             AstExpr* expr = unwrapGroup(c.callSite->args.data[i]);
 
-            PushTypeResult result =
-                pushTypeInto(c.astTypes, c.astExpectedTypes, NotNull{this}, constraint, NotNull{&u2}, NotNull{&subtyping}, expectedArgTy, expr);
+            PushTypeResult result = pushTypeInto(
+                c.astTypes,
+                c.astExpectedTypes,
+                NotNull{this},
+                constraint,
+                NotNull{&genericTypesAndPacks},
+                NotNull{&u2},
+                NotNull{&subtyping},
+                expectedArgTy,
+                expr
+            );
 
             // Consider:
             //
@@ -1961,7 +1939,7 @@ bool ConstraintSolver::tryDispatch(const FunctionCheckConstraint& c, NotNull<con
                 }
                 Subtyping subtyping{builtinTypes, arena, normalizer, typeFunctionRuntime, NotNull{&iceReporter}};
                 PushTypeResult result =
-                    pushTypeInto(c.astTypes, c.astExpectedTypes, NotNull{this}, constraint, NotNull{&u2}, NotNull{&subtyping}, expectedArgTy, expr);
+                    pushTypeInto_DEPRECATED(c.astTypes, c.astExpectedTypes, NotNull{this}, constraint, NotNull{&u2}, NotNull{&subtyping}, expectedArgTy, expr);
                 // Consider:
                 //
                 //  local Direction = { Left = 1, Right = 2 }
@@ -2567,94 +2545,46 @@ bool ConstraintSolver::tryDispatch(const AssignIndexConstraint& c, NotNull<const
     if (auto lhsIntersection = getMutable<IntersectionType>(lhsType))
     {
 
-        if (FFlag::LuauSimplifyIntersectionNoTreeSet)
+        TypeIds parts;
+
+        for (TypeId t : lhsIntersection)
         {
-
-            TypeIds parts;
-
-            for (TypeId t : lhsIntersection)
+            if (auto tbl = getMutable<TableType>(follow(t)))
             {
-                if (auto tbl = getMutable<TableType>(follow(t)))
+                if (tbl->indexer)
                 {
-                    if (tbl->indexer)
-                    {
-                        unify(constraint, indexType, tbl->indexer->indexType);
-                        parts.insert(tbl->indexer->indexResultType);
-                    }
-
-                    if (tbl->state == TableState::Unsealed || tbl->state == TableState::Free)
-                    {
-                        tbl->indexer = TableIndexer{indexType, rhsType};
-                        parts.insert(rhsType);
-                    }
+                    unify(constraint, indexType, tbl->indexer->indexType);
+                    parts.insert(tbl->indexer->indexResultType);
                 }
-                else if (auto cls = get<ExternType>(follow(t)))
-                {
-                    while (true)
-                    {
-                        if (cls->indexer)
-                        {
-                            unify(constraint, indexType, cls->indexer->indexType);
-                            parts.insert(cls->indexer->indexResultType);
-                            break;
-                        }
 
-                        if (cls->parent)
-                            cls = get<ExternType>(cls->parent);
-                        else
-                            break;
-                    }
+                if (tbl->state == TableState::Unsealed || tbl->state == TableState::Free)
+                {
+                    tbl->indexer = TableIndexer{indexType, rhsType};
+                    parts.insert(rhsType);
                 }
             }
-
-            TypeId res = simplifyIntersection(constraint->scope, constraint->location, std::move(parts));
-
-            unify(constraint, rhsType, res);
-        }
-        else
-        {
-
-            std::set<TypeId> parts;
-
-            for (TypeId t : lhsIntersection)
+            else if (auto cls = get<ExternType>(follow(t)))
             {
-                if (auto tbl = getMutable<TableType>(follow(t)))
+                while (true)
                 {
-                    if (tbl->indexer)
+                    if (cls->indexer)
                     {
-                        unify(constraint, indexType, tbl->indexer->indexType);
-                        parts.insert(tbl->indexer->indexResultType);
+                        unify(constraint, indexType, cls->indexer->indexType);
+                        parts.insert(cls->indexer->indexResultType);
+                        break;
                     }
 
-                    if (tbl->state == TableState::Unsealed || tbl->state == TableState::Free)
-                    {
-                        tbl->indexer = TableIndexer{indexType, rhsType};
-                        parts.insert(rhsType);
-                    }
-                }
-                else if (auto cls = get<ExternType>(follow(t)))
-                {
-                    while (true)
-                    {
-                        if (cls->indexer)
-                        {
-                            unify(constraint, indexType, cls->indexer->indexType);
-                            parts.insert(cls->indexer->indexResultType);
-                            break;
-                        }
-
-                        if (cls->parent)
-                            cls = get<ExternType>(cls->parent);
-                        else
-                            break;
-                    }
+                    if (cls->parent)
+                        cls = get<ExternType>(cls->parent);
+                    else
+                        break;
                 }
             }
-
-            TypeId res = simplifyIntersection_DEPRECATED(constraint->scope, constraint->location, std::move(parts));
-
-            unify(constraint, rhsType, res);
         }
+
+        TypeId res = simplifyIntersection(constraint->scope, constraint->location, std::move(parts));
+
+        unify(constraint, rhsType, res);
     }
 
     // Other types do not support index assignment.
@@ -2979,7 +2909,10 @@ bool ConstraintSolver::tryDispatch(const PushFunctionTypeConstraint& c, NotNull<
 
 bool ConstraintSolver::tryDispatch(const TypeInstantiationConstraint& c, NotNull<const Constraint> constraint)
 {
-    LUAU_ASSERT(FFlag::LuauExplicitTypeExpressionInstantiation);
+    LUAU_ASSERT(FFlag::LuauExplicitTypeInstantiationSupport);
+
+    if (isBlocked(c.functionType))
+        return block(c.functionType, constraint);
 
     bind(
         constraint,
@@ -2990,6 +2923,14 @@ bool ConstraintSolver::tryDispatch(const TypeInstantiationConstraint& c, NotNull
     return true;
 }
 
+template<typename T, typename Predicate>
+void dropWhile(std::vector<T>& vec, Predicate pred) {
+    auto it = std::find_if(vec.begin(), vec.end(), [&pred](const T& elem) {
+        return !pred(elem);
+    });
+    vec.erase(vec.begin(), it);
+}
+
 TypeId ConstraintSolver::instantiateFunctionType(
     TypeId functionTypeId,
     const std::vector<TypeId>& typeArguments,
@@ -2998,18 +2939,22 @@ TypeId ConstraintSolver::instantiateFunctionType(
     const Location& location
 )
 {
-    const FunctionType* ftv = get<FunctionType>(follow(functionTypeId));
-    if (!ftv)
+    // no work to be done if we're not instantiating with anything
+    if (typeArguments.empty() && typePackArguments.empty())
+        return functionTypeId;
+
+    const FunctionType* ft = get<FunctionType>(follow(functionTypeId));
+    if (!ft)
     {
         return functionTypeId;
     }
 
     DenseHashMap<TypeId, TypeId> replacements{nullptr};
-    auto typeParametersIter = ftv->generics.begin();
+    auto typeParametersIter = ft->generics.begin();
 
     for (const TypeId typeArgument : typeArguments)
     {
-        if (typeParametersIter == ftv->generics.end())
+        if (typeParametersIter == ft->generics.end())
         {
             break;
         }
@@ -3017,17 +2962,17 @@ TypeId ConstraintSolver::instantiateFunctionType(
         replacements[*typeParametersIter++] = typeArgument;
     }
 
-    while (typeParametersIter != ftv->generics.end())
+    while (typeParametersIter != ft->generics.end())
     {
         replacements[*typeParametersIter++] = freshType(arena, builtinTypes, scope, Polarity::Mixed);
     }
 
     DenseHashMap<TypePackId, TypePackId> replacementPacks{nullptr};
-    auto typePackParametersIter = ftv->genericPacks.begin();
+    auto typePackParametersIter = ft->genericPacks.begin();
 
     for (const TypePackId typePackArgument : typePackArguments)
     {
-        if (typePackParametersIter == ftv->genericPacks.end())
+        if (typePackParametersIter == ft->genericPacks.end())
         {
             break;
         }
@@ -3035,9 +2980,19 @@ TypeId ConstraintSolver::instantiateFunctionType(
         replacementPacks[*typePackParametersIter++] = typePackArgument;
     }
 
-    // FIXME: replacer is _not_ actually instantiation, but we don't have a real instantiation implementation at this moment
-    Replacer replacer{arena, std::move(replacements), std::move(replacementPacks)};
-    return replacer.substitute(functionTypeId).value_or(builtinTypes->errorType);
+    Replacer r{arena, std::move(replacements), std::move(replacementPacks)};
+
+    std::optional<TypeId> result = r.substitute(functionTypeId);
+    if (!result)
+        return builtinTypes->errorType;
+
+    FunctionType* ft2 = getMutable<FunctionType>(*result);
+
+    // we must remove the portions we successfully instantiated
+    dropWhile(ft2->generics, [](const TypeId& ty) { return !is<GenericType>(follow(ty)); });
+    dropWhile(ft2->genericPacks, [](const TypePackId& ty) { return !is<GenericTypePack>(follow(ty)); });
+
+    return *result;
 }
 
 bool ConstraintSolver::tryDispatch(const PushTypeConstraint& c, NotNull<const Constraint> constraint, bool force)
@@ -3055,7 +3010,28 @@ bool ConstraintSolver::tryDispatch(const PushTypeConstraint& c, NotNull<const Co
         return force;
     }
 
-    auto result = pushTypeInto(c.astTypes, c.astExpectedTypes, NotNull{this}, NotNull{constraint}, NotNull{&u2}, NotNull{&subtyping}, c.expectedType, c.expr);
+    DenseHashSet<const void*> empty{nullptr};
+    PushTypeResult result;
+    if (FFlag::LuauPushTypeConstraintLambdas3)
+    {
+        result = pushTypeInto(
+            c.astTypes,
+            c.astExpectedTypes,
+            NotNull{this},
+            NotNull{constraint},
+            NotNull{&empty},
+            NotNull{&u2},
+            NotNull{&subtyping},
+            c.expectedType,
+            c.expr
+        );
+    }
+    else
+    {
+        result = pushTypeInto_DEPRECATED(
+            c.astTypes, c.astExpectedTypes, NotNull{this}, NotNull{constraint}, NotNull{&u2}, NotNull{&subtyping}, c.expectedType, c.expr
+        );
+    }
 
     // If we're forcing this constraint, just early exit: we can continue
     // inferring the rest of the file, we might just error when we shouldn't.
@@ -3078,7 +3054,7 @@ bool ConstraintSolver::tryDispatch(const PushTypeConstraint& c, NotNull<const Co
         inheritBlocks(constraint, addition);
     }
 
-    return FFlag::LuauPushTypeConstriantAlwaysCompletes;
+    return true;
 }
 
 bool ConstraintSolver::tryDispatchIterableTable(TypeId iteratorTy, const IterableConstraint& c, NotNull<const Constraint> constraint, bool force)
@@ -3743,7 +3719,7 @@ void ConstraintSolver::unblock_(BlockedConstraintId progressed)
             printf("Unblocking count=%d\t%s\n", int(count), toString(*unblockedConstraint, opts).c_str());
 
         // This assertion being hit indicates that `blocked` and
-        // `blockedConstraints` desynchronized at some point. This is problematic
+        // `blockedConstraints` de-synchronized at some point. This is problematic
         // because we rely on this count being correct to skip over blocked
         // constraints.
         LUAU_ASSERT(count > 0);
@@ -4021,11 +3997,6 @@ TypeId ConstraintSolver::simplifyIntersection(NotNull<Scope> scope, Location loc
 TypeId ConstraintSolver::simplifyIntersection(NotNull<Scope> scope, Location location, TypeIds parts)
 {
     return ::Luau::simplifyIntersection(builtinTypes, arena, std::move(parts)).result;
-}
-
-TypeId ConstraintSolver::simplifyIntersection_DEPRECATED(NotNull<Scope> scope, Location location, std::set<TypeId> parts)
-{
-    return ::Luau::simplifyIntersection_DEPRECATED(builtinTypes, arena, std::move(parts)).result;
 }
 
 TypeId ConstraintSolver::simplifyUnion(NotNull<Scope> scope, Location location, TypeId left, TypeId right)

--- a/Analysis/src/DataFlowGraph.cpp
+++ b/Analysis/src/DataFlowGraph.cpp
@@ -13,7 +13,8 @@
 
 LUAU_FASTFLAG(DebugLuauFreezeArena)
 LUAU_FASTFLAG(LuauSolverV2)
-LUAU_FASTFLAG(LuauExplicitTypeExpressionInstantiation)
+LUAU_FASTFLAG(LuauExplicitTypeInstantiationSyntax)
+LUAU_FASTFLAG(LuauExplicitTypeInstantiationSupport)
 
 namespace Luau
 {
@@ -499,7 +500,7 @@ ControlFlow DataFlowGraphBuilder::visit(AstStatWhile* w)
     }
 
     auto scope = currentScope();
-    // If the inner loop unconditioanlly returns or throws we shouldn't
+    // If the inner loop unconditionally returns or throws we shouldn't
     // consume any type state from the loop body.
     if (!matches(cf, ControlFlow::Returns | ControlFlow::Throws))
         join(scope, scope, whileScope);
@@ -620,7 +621,7 @@ ControlFlow DataFlowGraphBuilder::visit(AstStatFor* f)
     }
 
     auto scope = currentScope();
-    // If the inner loop unconditioanlly returns or throws we shouldn't
+    // If the inner loop unconditionally returns or throws we shouldn't
     // consume any type state from the loop body.
     if (!matches(cf, ControlFlow::Returns | ControlFlow::Throws))
         join(scope, scope, forScope);
@@ -656,7 +657,7 @@ ControlFlow DataFlowGraphBuilder::visit(AstStatForIn* f)
     }
 
     auto scope = currentScope();
-    // If the inner loop unconditioanlly returns or throws we shouldn't
+    // If the inner loop unconditionally returns or throws we shouldn't
     // consume any type state from the loop body.
     if (!matches(cf, ControlFlow::Returns | ControlFlow::Throws))
         join(scope, scope, forScope);
@@ -857,7 +858,7 @@ DataFlowResult DataFlowGraphBuilder::visitExpr(AstExpr* e)
             return visitExpr(i);
         else if (auto i = e->as<AstExprInstantiate>())
         {
-            LUAU_ASSERT(FFlag::LuauExplicitTypeExpressionInstantiation);
+            LUAU_ASSERT(FFlag::LuauExplicitTypeInstantiationSyntax);
             return visitExpr(i);
         }
         else if (auto error = e->as<AstExprError>())
@@ -1079,21 +1080,22 @@ DataFlowResult DataFlowGraphBuilder::visitExpr(AstExprInterpString* i)
 
 DataFlowResult DataFlowGraphBuilder::visitExpr(AstExprInstantiate* i)
 {
-    LUAU_ASSERT(FFlag::LuauExplicitTypeExpressionInstantiation);
-
-    for (const AstTypeOrPack& typeOrPack : i->typeArguments)
+    if (FFlag::LuauExplicitTypeInstantiationSupport)
     {
-        if (typeOrPack.type)
+        for (const AstTypeOrPack& typeOrPack : i->typeArguments)
         {
-            visitType(typeOrPack.type);
-        }
-        else
-        {
-            LUAU_ASSERT(typeOrPack.typePack);
-            visitTypePack(typeOrPack.typePack);
+            if (typeOrPack.type)
+            {
+                visitType(typeOrPack.type);
+            }
+            else
+            {
+                LUAU_ASSERT(typeOrPack.typePack);
+                visitTypePack(typeOrPack.typePack);
+            }
         }
     }
-
+    
     return visitExpr(i->expr);
 }
 

--- a/Analysis/src/Error.cpp
+++ b/Analysis/src/Error.cpp
@@ -19,8 +19,6 @@
 LUAU_FASTINTVARIABLE(LuauIndentTypeMismatchMaxTypeLength, 10)
 
 LUAU_FASTFLAGVARIABLE(LuauNewNonStrictReportsOneIndexedErrors)
-LUAU_FASTFLAG(LuauUnknownGlobalFixSuggestion)
-LUAU_FASTFLAGVARIABLE(LuauNewNonStrictBetterCheckedFunctionErrorMessage)
 LUAU_FASTFLAGVARIABLE(LuauBetterTypeMismatchErrors)
 
 static std::string wrongNumberOfArgsString(
@@ -196,8 +194,7 @@ struct ErrorConverter
         switch (e.context)
         {
         case UnknownSymbol::Binding:
-            return FFlag::LuauUnknownGlobalFixSuggestion ? "Unknown global '" + e.name + "'; consider assigning to it first"
-                                                         : "Unknown global '" + e.name + "'";
+            return "Unknown global '" + e.name + "'; consider assigning to it first";
         case UnknownSymbol::Type:
             return "Unknown type '" + e.name + "'";
         }
@@ -783,38 +780,14 @@ struct ErrorConverter
 
     std::string operator()(const CheckedFunctionCallError& e) const
     {
-        if (FFlag::LuauNewNonStrictBetterCheckedFunctionErrorMessage)
-        {
-            return "the function '" + e.checkedFunctionName + "' expects to get a " + toString(e.expected) + " as its " +
-                   toHumanReadableIndex(e.argumentIndex) + " argument, but is being given a " + toString(e.passed) + "";
-        }
-        else
-        {
-            // TODO: What happens if checkedFunctionName cannot be found??
-            return "Function '" + e.checkedFunctionName + "' expects '" + toString(e.expected) + "' at argument #" +
-                   std::to_string(e.argumentIndex + 1) + ", but got '" + Luau::toString(e.passed) + "'";
-        }
+        return "the function '" + e.checkedFunctionName + "' expects to get a " + toString(e.expected) + " as its " +
+            toHumanReadableIndex(e.argumentIndex) + " argument, but is being given a " + toString(e.passed) + "";
     }
 
     std::string operator()(const NonStrictFunctionDefinitionError& e) const
     {
-        if (FFlag::LuauNewNonStrictBetterCheckedFunctionErrorMessage)
-        {
-            std::string prefix = e.functionName.empty() ? "" : "in the function '" + e.functionName + "', '";
-            return prefix + "the argument '" + e.argument + "' is used in a way that will error at runtime";
-        }
-        else
-        {
-            if (e.functionName.empty())
-            {
-                return "Argument " + e.argument + " with type '" + toString(e.argumentType) + "' is used in a way that will run time error";
-            }
-            else
-            {
-                return "Argument " + e.argument + " with type '" + toString(e.argumentType) + "' in function '" + e.functionName +
-                       "' is used in a way that will run time error";
-            }
-        }
+        std::string prefix = e.functionName.empty() ? "" : "in the function '" + e.functionName + "', '";
+        return prefix + "the argument '" + e.argument + "' is used in a way that will error at runtime";
     }
 
     std::string operator()(const PropertyAccessViolation& e) const
@@ -835,16 +808,8 @@ struct ErrorConverter
     std::string operator()(const CheckedFunctionIncorrectArgs& e) const
     {
 
-        if (FFlag::LuauNewNonStrictBetterCheckedFunctionErrorMessage)
-        {
-            return "the function '" + e.functionName + "' will error at runtime if it is not called with " + std::to_string(e.expected) +
-                   " arguments, but we are calling it here with " + std::to_string(e.actual) + " arguments";
-        }
-        else
-        {
-            return "Checked Function " + e.functionName + " expects " + std::to_string(e.expected) + " arguments, but received " +
-                   std::to_string(e.actual);
-        }
+        return "the function '" + e.functionName + "' will error at runtime if it is not called with " + std::to_string(e.expected) +
+            " arguments, but we are calling it here with " + std::to_string(e.actual) + " arguments";
     }
 
     std::string operator()(const UnexpectedTypeInSubtyping& e) const

--- a/Analysis/src/FragmentAutocomplete.cpp
+++ b/Analysis/src/FragmentAutocomplete.cpp
@@ -647,7 +647,7 @@ void cloneTypesFromFragment(
     UsageFinder f{dfg};
     program->visit(&f);
     // These are defs that have been mentioned. find the appropriate lvalue type and rvalue types and place them in the scope
-    // First - any locals that have been mentioned in the fragment need to be placed in the bindings and lvalueTypes secionts.
+    // First - any locals that have been mentioned in the fragment need to be placed in the bindings and lvalueTypes sections.
 
     for (const auto& d : f.mentionedDefs)
     {

--- a/Analysis/src/InferPolarity.cpp
+++ b/Analysis/src/InferPolarity.cpp
@@ -154,12 +154,12 @@ static void inferGenericPolarities_(NotNull<TypeArena> arena, NotNull<Scope> sco
     }
 }
 
-void inferGenericPolarities(NotNull<TypeArena> arena, NotNull<Scope> scope, TypeId ty)
+void inferGenericPolarities_DEPRECATED(NotNull<TypeArena> arena, NotNull<Scope> scope, TypeId ty)
 {
     inferGenericPolarities_(arena, scope, ty);
 }
 
-void inferGenericPolarities(NotNull<TypeArena> arena, NotNull<Scope> scope, TypePackId tp)
+void inferGenericPolarities_DEPRECATED(NotNull<TypeArena> arena, NotNull<Scope> scope, TypePackId tp)
 {
     inferGenericPolarities_(arena, scope, tp);
 }

--- a/Analysis/src/IostreamHelpers.cpp
+++ b/Analysis/src/IostreamHelpers.cpp
@@ -209,8 +209,8 @@ static void errorToString(std::ostream& stream, const T& err)
         for (auto [s, t] : err.recommendedArgs)
             recArgs += " " + s + ": " + toString(t);
         recArgs += " ]";
-        stream << "ExplicitFunctionAnnotationRecommended { recommmendedReturn = '" + toString(err.recommendedReturn) +
-                      "', recommmendedArgs = " + recArgs + "}";
+        stream << "ExplicitFunctionAnnotationRecommended { recommendedReturn = '" + toString(err.recommendedReturn) +
+                      "', recommendedArgs = " + recArgs + "}";
     }
     else if constexpr (std::is_same_v<T, UninhabitedTypePackFunction>)
         stream << "UninhabitedTypePackFunction { " << toString(err.tp) << " }";

--- a/Analysis/src/Linter.cpp
+++ b/Analysis/src/Linter.cpp
@@ -9,16 +9,14 @@
 #include "Luau/Common.h"
 
 #include <algorithm>
-#include <math.h>
-#include <limits.h>
+#include <cmath>
+#include <climits>
 
 LUAU_FASTINTVARIABLE(LuauSuggestionDistance, 4)
 
 LUAU_FASTFLAG(LuauSolverV2)
 
-LUAU_FASTFLAGVARIABLE(LuauUnknownGlobalFixSuggestion)
-
-LUAU_FASTFLAG(LuauExplicitTypeExpressionInstantiation)
+LUAU_FASTFLAG(LuauExplicitTypeInstantiationSyntax)
 
 namespace Luau
 {
@@ -194,7 +192,7 @@ static bool similar(AstExpr* lhs, AstExpr* rhs)
     }
     CASE(AstExprInstantiate)
     {
-        LUAU_ASSERT(FFlag::LuauExplicitTypeExpressionInstantiation);
+        LUAU_ASSERT(FFlag::LuauExplicitTypeInstantiationSyntax);
         return similar(le->expr, re->expr);
     }
     else
@@ -277,11 +275,7 @@ private:
 
             if (!g || (!g->assigned && !g->builtin))
                 emitWarning(
-                    *context,
-                    LintWarning::Code_UnknownGlobal,
-                    gv->location,
-                    FFlag::LuauUnknownGlobalFixSuggestion ? "Unknown global '%s'; consider assigning to it first" : "Unknown global '%s'",
-                    gv->name.value
+                    *context, LintWarning::Code_UnknownGlobal, gv->location, "Unknown global '%s'; consider assigning to it first", gv->name.value
                 );
             else if (g->deprecated)
             {

--- a/Analysis/src/StructuralTypeEquality.cpp
+++ b/Analysis/src/StructuralTypeEquality.cpp
@@ -1,0 +1,243 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+
+#include "Luau/StructuralTypeEquality.h"
+
+#include "Luau/Type.h"
+#include "Luau/TypePack.h"
+
+LUAU_FASTFLAG(LuauSolverV2)
+
+// Test Types for equivalence
+// More complex than we'd like because Types can self-reference.
+
+namespace Luau
+{
+
+bool areSeen(SeenSet& seen, const void* lhs, const void* rhs)
+{
+    if (lhs == rhs)
+        return true;
+
+    auto p = std::make_pair(const_cast<void*>(lhs), const_cast<void*>(rhs));
+    if (seen.find(p) != seen.end())
+        return true;
+
+    seen.insert(p);
+    return false;
+}
+
+bool areEqual(SeenSet& seen, const TypePackVar& lhs, const TypePackVar& rhs)
+{
+    TypePackId lhsId = const_cast<TypePackId>(&lhs);
+    TypePackId rhsId = const_cast<TypePackId>(&rhs);
+    TypePackIterator lhsIter = begin(lhsId);
+    TypePackIterator rhsIter = begin(rhsId);
+    TypePackIterator lhsEnd = end(lhsId);
+    TypePackIterator rhsEnd = end(rhsId);
+    while (lhsIter != lhsEnd && rhsIter != rhsEnd)
+    {
+        if (!areEqual(seen, **lhsIter, **rhsIter))
+            return false;
+        ++lhsIter;
+        ++rhsIter;
+    }
+
+    if (lhsIter != lhsEnd || rhsIter != rhsEnd)
+        return false;
+
+    if (!lhsIter.tail() && !rhsIter.tail())
+        return true;
+    if (!lhsIter.tail() || !rhsIter.tail())
+        return false;
+
+    TypePackId lhsTail = *lhsIter.tail();
+    TypePackId rhsTail = *rhsIter.tail();
+
+    {
+        const FreeTypePack* lf = get_if<FreeTypePack>(&lhsTail->ty);
+        const FreeTypePack* rf = get_if<FreeTypePack>(&rhsTail->ty);
+        if (lf && rf)
+            return lf->index == rf->index;
+    }
+
+    {
+        const Unifiable::Bound<TypePackId>* lb = get_if<Unifiable::Bound<TypePackId>>(&lhsTail->ty);
+        const Unifiable::Bound<TypePackId>* rb = get_if<Unifiable::Bound<TypePackId>>(&rhsTail->ty);
+        if (lb && rb)
+            return areEqual(seen, *lb->boundTo, *rb->boundTo);
+    }
+
+    {
+        const GenericTypePack* lg = get_if<GenericTypePack>(&lhsTail->ty);
+        const GenericTypePack* rg = get_if<GenericTypePack>(&rhsTail->ty);
+        if (lg && rg)
+            return lg->index == rg->index;
+    }
+
+    {
+        const VariadicTypePack* lv = get_if<VariadicTypePack>(&lhsTail->ty);
+        const VariadicTypePack* rv = get_if<VariadicTypePack>(&rhsTail->ty);
+        if (lv && rv)
+            return areEqual(seen, *lv->ty, *rv->ty);
+    }
+
+    return false;
+}
+
+bool areEqual(SeenSet& seen, const FunctionType& lhs, const FunctionType& rhs)
+{
+    if (areSeen(seen, &lhs, &rhs))
+        return true;
+
+    // TODO: check generics CLI-39915
+
+    if (!areEqual(seen, *lhs.argTypes, *rhs.argTypes))
+        return false;
+
+    if (!areEqual(seen, *lhs.retTypes, *rhs.retTypes))
+        return false;
+
+    return true;
+}
+
+bool areEqual(SeenSet& seen, const TableType& lhs, const TableType& rhs)
+{
+    if (areSeen(seen, &lhs, &rhs))
+        return true;
+
+    if (lhs.state != rhs.state)
+        return false;
+
+    if (lhs.props.size() != rhs.props.size())
+        return false;
+
+    if (bool(lhs.indexer) != bool(rhs.indexer))
+        return false;
+
+    if (lhs.indexer && rhs.indexer)
+    {
+        if (!areEqual(seen, *lhs.indexer->indexType, *rhs.indexer->indexType))
+            return false;
+
+        if (!areEqual(seen, *lhs.indexer->indexResultType, *rhs.indexer->indexResultType))
+            return false;
+    }
+
+    auto l = lhs.props.begin();
+    auto r = rhs.props.begin();
+
+    while (l != lhs.props.end())
+    {
+        if (l->first != r->first)
+            return false;
+
+        if (FFlag::LuauSolverV2)
+        {
+            if (l->second.readTy && r->second.readTy)
+            {
+                if (!areEqual(seen, **l->second.readTy, **r->second.readTy))
+                    return false;
+            }
+            else if (l->second.readTy || r->second.readTy)
+                return false;
+
+            if (l->second.writeTy && r->second.writeTy)
+            {
+                if (!areEqual(seen, **l->second.writeTy, **r->second.writeTy))
+                    return false;
+            }
+            else if (l->second.writeTy || r->second.writeTy)
+                return false;
+        }
+        else if (!areEqual(seen, *l->second.type_DEPRECATED(), *r->second.type_DEPRECATED()))
+            return false;
+        ++l;
+        ++r;
+    }
+
+    return true;
+}
+
+static bool areEqual(SeenSet& seen, const MetatableType& lhs, const MetatableType& rhs)
+{
+    if (areSeen(seen, &lhs, &rhs))
+        return true;
+
+    return areEqual(seen, *lhs.table, *rhs.table) && areEqual(seen, *lhs.metatable, *rhs.metatable);
+}
+
+bool areEqual(SeenSet& seen, const Type& lhs, const Type& rhs)
+{
+    if (auto bound = get_if<BoundType>(&lhs.ty))
+        return areEqual(seen, *bound->boundTo, rhs);
+
+    if (auto bound = get_if<BoundType>(&rhs.ty))
+        return areEqual(seen, lhs, *bound->boundTo);
+
+    if (lhs.ty.index() != rhs.ty.index())
+        return false;
+
+    {
+        const FreeType* lf = get_if<FreeType>(&lhs.ty);
+        const FreeType* rf = get_if<FreeType>(&rhs.ty);
+        if (lf && rf)
+            return lf->index == rf->index;
+    }
+
+    {
+        const GenericType* lg = get_if<GenericType>(&lhs.ty);
+        const GenericType* rg = get_if<GenericType>(&rhs.ty);
+        if (lg && rg)
+            return lg->index == rg->index;
+    }
+
+    {
+        const PrimitiveType* lp = get_if<PrimitiveType>(&lhs.ty);
+        const PrimitiveType* rp = get_if<PrimitiveType>(&rhs.ty);
+        if (lp && rp)
+            return lp->type == rp->type;
+    }
+
+    {
+        const GenericType* lg = get_if<GenericType>(&lhs.ty);
+        const GenericType* rg = get_if<GenericType>(&rhs.ty);
+        if (lg && rg)
+            return lg->index == rg->index;
+    }
+
+    {
+        const ErrorType* le = get_if<ErrorType>(&lhs.ty);
+        const ErrorType* re = get_if<ErrorType>(&rhs.ty);
+        if (le && re)
+            return le->index == re->index;
+    }
+
+    {
+        const FunctionType* lf = get_if<FunctionType>(&lhs.ty);
+        const FunctionType* rf = get_if<FunctionType>(&rhs.ty);
+        if (lf && rf)
+            return areEqual(seen, *lf, *rf);
+    }
+
+    {
+        const TableType* lt = get_if<TableType>(&lhs.ty);
+        const TableType* rt = get_if<TableType>(&rhs.ty);
+        if (lt && rt)
+            return areEqual(seen, *lt, *rt);
+    }
+
+    {
+        const MetatableType* lmt = get_if<MetatableType>(&lhs.ty);
+        const MetatableType* rmt = get_if<MetatableType>(&rhs.ty);
+
+        if (lmt && rmt)
+            return areEqual(seen, *lmt, *rmt);
+    }
+
+    if (get_if<AnyType>(&lhs.ty) && get_if<AnyType>(&rhs.ty))
+        return true;
+
+    return false;
+}
+
+}

--- a/Analysis/src/Subtyping.cpp
+++ b/Analysis/src/Subtyping.cpp
@@ -18,7 +18,6 @@
 #include "Luau/TypePath.h"
 #include "Luau/TypeUtils.h"
 
-LUAU_FASTFLAGVARIABLE(LuauIndividualRecursionLimits)
 LUAU_DYNAMIC_FASTINTVARIABLE(LuauSubtypingRecursionLimit, 100)
 
 LUAU_FASTFLAGVARIABLE(DebugLuauSubtypingCheckPathValidity)
@@ -26,8 +25,7 @@ LUAU_FASTINTVARIABLE(LuauSubtypingReasoningLimit, 100)
 LUAU_FASTFLAGVARIABLE(LuauIndexInMetatableSubtyping)
 LUAU_FASTFLAGVARIABLE(LuauSubtypingPackRecursionLimits)
 LUAU_FASTFLAGVARIABLE(LuauTryFindSubstitutionReturnOptional)
-LUAU_FASTFLAG(LuauNewOverloadResolver2)
-LUAU_FASTFLAGVARIABLE(LuauFixSubtypingOfNegations)
+LUAU_FASTFLAGVARIABLE(LuauSubtypingHandlesExternTypesWithIndexers)
 
 namespace Luau
 {
@@ -178,14 +176,15 @@ static void assertReasoningValid(TID subTy, TID superTy, const SubtypingResult& 
 
 template<>
 void assertReasoningValid<TableIndexer>(
-    TableIndexer subIdx,
-    TableIndexer superIdx,
-    const SubtypingResult& result,
-    NotNull<BuiltinTypes> builtinTypes,
-    NotNull<TypeArena> arena
+    TableIndexer,
+    TableIndexer,
+    const SubtypingResult&,
+    NotNull<BuiltinTypes>,
+    NotNull<TypeArena>
 )
 {
-    // Empty method to satisfy the compiler.
+    // This specialization exists so that we can invoke methods like
+    // isInvariantWith() on a pair of TableIndexers.
 }
 
 static SubtypingReasonings mergeReasonings(const SubtypingReasonings& a, const SubtypingReasonings& b)
@@ -239,16 +238,14 @@ SubtypingResult& SubtypingResult::andAlso(const SubtypingResult& other)
     // reasonings to this one. If this result already has reasonings of its own,
     // those need to be attributed here whenever this _also_ failed.
     if (!other.isSubtype)
-        reasoning = isSubtype ? std::move(other.reasoning) : mergeReasonings(reasoning, other.reasoning);
+        reasoning = isSubtype ? other.reasoning : mergeReasonings(reasoning, other.reasoning);
 
     isSubtype &= other.isSubtype;
     normalizationTooComplex |= other.normalizationTooComplex;
     isCacheable &= other.isCacheable;
     errors.insert(errors.end(), other.errors.begin(), other.errors.end());
     genericBoundsMismatches.insert(genericBoundsMismatches.end(), other.genericBoundsMismatches.begin(), other.genericBoundsMismatches.end());
-
-    if (FFlag::LuauNewOverloadResolver2)
-        assumedConstraints.insert(assumedConstraints.end(), other.assumedConstraints.begin(), other.assumedConstraints.end());
+    assumedConstraints.insert(assumedConstraints.end(), other.assumedConstraints.begin(), other.assumedConstraints.end());
 
     return *this;
 }
@@ -261,25 +258,15 @@ SubtypingResult& SubtypingResult::orElse(const SubtypingResult& other)
     // reasoning lists.
     if (!isSubtype)
     {
-        if (FFlag::LuauNewOverloadResolver2)
+        if (other.isSubtype)
         {
-            if (other.isSubtype)
-            {
-                reasoning.clear();
-                // It would be nice to be able to `std::move` this.
-                assumedConstraints = other.assumedConstraints;
-            }
-            else
-            {
-                reasoning = mergeReasonings(reasoning, other.reasoning);
-            }
+            reasoning.clear();
+            // It would be nice to be able to `std::move` this.
+            assumedConstraints = other.assumedConstraints;
         }
         else
         {
-            if (other.isSubtype)
-                reasoning.clear();
-            else
-                reasoning = mergeReasonings(reasoning, other.reasoning);
+            reasoning = mergeReasonings(reasoning, other.reasoning);
         }
     }
 
@@ -403,7 +390,7 @@ struct ApplyMappedGenerics : Substitution
     NotNull<TypeArena> arena;
     NotNull<InternalErrorReporter> iceReporter;
 
-    SubtypingEnvironment& env;
+    NotNull<SubtypingEnvironment> env;
 
     ApplyMappedGenerics(
         NotNull<BuiltinTypes> builtinTypes,
@@ -415,23 +402,23 @@ struct ApplyMappedGenerics : Substitution
         , builtinTypes(builtinTypes)
         , arena(arena)
         , iceReporter(iceReporter.get())
-        , env(env)
+        , env(NotNull{&env})
     {
     }
 
     bool isDirty(TypeId ty) override
     {
-        return env.containsMappedType(ty);
+        return env->containsMappedType(ty);
     }
 
     bool isDirty(TypePackId tp) override
     {
-        return env.containsMappedPack(tp);
+        return env->containsMappedPack(tp);
     }
 
     TypeId clean(TypeId ty) override
     {
-        const auto& [lowerBound, upperBound] = env.getMappedTypeBounds(ty, NotNull{iceReporter});
+        const auto& [lowerBound, upperBound] = env->getMappedTypeBounds(ty, NotNull{iceReporter});
 
         if (upperBound.empty() && lowerBound.empty())
         {
@@ -498,7 +485,7 @@ struct ApplyMappedGenerics : Substitution
 
     TypePackId clean(TypePackId tp) override
     {
-        const MappedGenericEnvironment::LookupResult result = env.lookupGenericPack(tp);
+        const MappedGenericEnvironment::LookupResult result = env->lookupGenericPack(tp);
         if (const TypePackId* mappedGen = get_if<TypePackId>(&result))
             return *mappedGen;
         // Clean is only called when isDirty found a pack bound
@@ -515,7 +502,7 @@ struct ApplyMappedGenerics : Substitution
         {
             for (TypeId g : f->generics)
             {
-                if (const std::vector<SubtypingEnvironment::GenericBounds>* bounds = env.mappedGenerics.find(g); bounds && !bounds->empty())
+                if (const std::vector<SubtypingEnvironment::GenericBounds>* bounds = env->mappedGenerics.find(g); bounds && !bounds->empty())
                     // We don't want to mutate the generics of a function that's being subtyped
                     return true;
             }
@@ -698,8 +685,7 @@ SubtypingResult Subtyping::isSubtype(
     for (TypeId g : bindableGenerics)
         env.mappedGenerics[follow(g)] = {SubtypingEnvironment::GenericBounds{}};
 
-    if (FFlag::LuauNewOverloadResolver2)
-        env.mappedGenericPacks.pushFrame(bindableGenericPacks);
+    env.mappedGenericPacks.pushFrame(bindableGenericPacks);
 
     SubtypingResult result = isCovariantWith(env, subTp, superTp, scope);
 
@@ -737,16 +723,8 @@ SubtypingResult Subtyping::isCovariantWith(SubtypingEnvironment& env, TypeId sub
 {
     UnifierCounters& counters = normalizer->sharedState->counters;
     RecursionCounter rc(&counters.recursionCount);
-    if (FFlag::LuauIndividualRecursionLimits)
-    {
-        if (DFInt::LuauSubtypingRecursionLimit > 0 && DFInt::LuauSubtypingRecursionLimit < counters.recursionCount)
-            return SubtypingResult{false, true};
-    }
-    else
-    {
-        if (counters.recursionLimit > 0 && counters.recursionLimit < counters.recursionCount)
-            return SubtypingResult{false, true};
-    }
+    if (DFInt::LuauSubtypingRecursionLimit > 0 && DFInt::LuauSubtypingRecursionLimit < counters.recursionCount)
+        return SubtypingResult{false, true};
 
     subTy = follow(subTy);
     superTy = follow(superTy);
@@ -847,7 +825,7 @@ SubtypingResult Subtyping::isCovariantWith(SubtypingEnvironment& env, TypeId sub
         LUAU_ASSERT(!get<UnionType>(subTy));        // TODO: replace with ice.
         LUAU_ASSERT(!get<IntersectionType>(subTy)); // TODO: replace with ice.
 
-        bool errorSuppressing = get<ErrorType>(subTy);
+        bool errorSuppressing = nullptr != get<ErrorType>(subTy);
         result = {!errorSuppressing};
     }
     else if (get<NeverType>(subTy))
@@ -952,9 +930,7 @@ SubtypingResult Subtyping::isCovariantWith(SubtypingEnvironment& env, TypeId sub
     else if (auto p = get2<NegationType, NegationType>(subTy, superTy))
         // We use `isContravariantWith` here in order to make sure that the
         // type paths still look coherent.
-        result = FFlag::LuauFixSubtypingOfNegations
-                     ? isContravariantWith(env, p.first->ty, p.second->ty, scope).withBothComponent(TypePath::TypeField::Negated)
-                     : isCovariantWith(env, p.first->ty, p.second->ty, scope).withBothComponent(TypePath::TypeField::Negated);
+        result = isContravariantWith(env, p.first->ty, p.second->ty, scope).withBothComponent(TypePath::TypeField::Negated);
     else if (auto subNegation = get<NegationType>(subTy))
     {
         result = isCovariantWith(env, subNegation, superTy, scope);
@@ -1025,16 +1001,8 @@ SubtypingResult Subtyping::isCovariantWith(SubtypingEnvironment& env, TypePackId
     {
         rc.emplace(&counters.recursionCount);
 
-        if (FFlag::LuauIndividualRecursionLimits)
-        {
-            if (DFInt::LuauSubtypingRecursionLimit > 0 && counters.recursionCount > DFInt::LuauSubtypingRecursionLimit)
-                return SubtypingResult{false, true};
-        }
-        else
-        {
-            if (counters.recursionLimit > 0 && counters.recursionLimit < counters.recursionCount)
-                return SubtypingResult{false, true};
-        }
+        if (DFInt::LuauSubtypingRecursionLimit > 0 && counters.recursionCount > DFInt::LuauSubtypingRecursionLimit)
+            return SubtypingResult{false, true};
     }
 
     subTp = follow(subTp);
@@ -1114,7 +1082,7 @@ SubtypingResult Subtyping::isCovariantWith(SubtypingEnvironment& env, TypePackId
         else if (get<ErrorTypePack>(*subTail) || get<ErrorTypePack>(*superTail))
             // error type is fine on either side
             results.push_back(SubtypingResult{true}.withBothComponent(TypePath::PackField::Tail));
-        else if (FFlag::LuauNewOverloadResolver2 && (get<FreeTypePack>(*subTail) || get<FreeTypePack>(*superTail)))
+        else if (get<FreeTypePack>(*subTail) || get<FreeTypePack>(*superTail))
         {
             return SubtypingResult{true}
                 .withBothComponent(TypePath::PackField::Tail)
@@ -1481,7 +1449,7 @@ SubtypingResult Subtyping::isTailCovariantWithTail(SubtypingEnvironment& env, No
 
 
 template<typename SubTy, typename SuperTy>
-SubtypingResult Subtyping::isContravariantWith(SubtypingEnvironment& env, SubTy&& subTy, SuperTy&& superTy, NotNull<Scope> scope)
+SubtypingResult Subtyping::isContravariantWith(SubtypingEnvironment& env, SubTy subTy, SuperTy superTy, NotNull<Scope> scope)
 {
     SubtypingResult result = isCovariantWith(env, superTy, subTy, scope);
     if (result.reasoning.empty())
@@ -1511,7 +1479,7 @@ SubtypingResult Subtyping::isContravariantWith(SubtypingEnvironment& env, SubTy&
 }
 
 template<typename SubTy, typename SuperTy>
-SubtypingResult Subtyping::isInvariantWith(SubtypingEnvironment& env, SubTy&& subTy, SuperTy&& superTy, NotNull<Scope> scope)
+SubtypingResult Subtyping::isInvariantWith(SubtypingEnvironment& env, SubTy subTy, SuperTy superTy, NotNull<Scope> scope)
 {
     SubtypingResult result = isCovariantWith(env, subTy, superTy, scope);
     result.andAlso(isContravariantWith(env, subTy, superTy, scope));
@@ -1881,7 +1849,7 @@ SubtypingResult Subtyping::isCovariantWith(
     if (subTable->props.empty() && !subTable->indexer && subTable->state == TableState::Sealed && superTable->indexer)
     {
         // While it is certainly the case that {} </: {T}, the story is a little bit different for {| |} <: {T}
-        // The shape of an unsealed tabel is still in flux, so it is probably the case that the unsealed table
+        // The shape of an unsealed table is still in flux, so it is probably the case that the unsealed table
         // will later gain the necessary indexer as type inference proceeds.
         //
         // Unsealed tables are always sealed by the time inference completes, so this should never affect the
@@ -1965,7 +1933,7 @@ SubtypingResult Subtyping::isCovariantWith(SubtypingEnvironment& env, const Meta
             // effectively a repeat of the logic for the `index<_, _>`
             // type function. These should use similar logic. Otherwise
             // this all constantly falls over for the same reasons
-            // structural subtypying falls over.
+            // structural subtyping falls over.
             //
             // Notably, this does not support `__index` as a function.
 
@@ -1973,17 +1941,17 @@ SubtypingResult Subtyping::isCovariantWith(SubtypingEnvironment& env, const Meta
             if (!subMTTable)
                 return doDefault();
 
-            auto __index = subMTTable->props.find("__index");
-            if (__index == subMTTable->props.end())
+            auto indexProp = subMTTable->props.find("__index");
+            if (indexProp == subMTTable->props.end())
                 return doDefault();
 
             // `read`-only __index sounds reasonable, but write-only
             // or non-shared sounds weird.
-            if (!__index->second.readTy)
+            if (!indexProp->second.readTy)
                 return doDefault();
 
-            auto __indexAsTable = get<TableType>(follow(*__index->second.readTy));
-            if (!__indexAsTable)
+            auto indexTableProp = get<TableType>(follow(*indexProp->second.readTy));
+            if (!indexTableProp)
                 return doDefault();
 
             // Consider the snippet:
@@ -2026,7 +1994,7 @@ SubtypingResult Subtyping::isCovariantWith(SubtypingEnvironment& env, const Meta
             // This should error, as we cannot write to `const`.
 
             TableType fauxSubTable{*subTable};
-            for (auto& [name, prop] : __indexAsTable->props)
+            for (auto& [name, prop] : indexTableProp->props)
             {
                 if (prop.readTy && fauxSubTable.props.find(name) == fauxSubTable.props.end())
                     fauxSubTable.props[name] = Property::readonly(*prop.readTy);
@@ -2090,6 +2058,42 @@ SubtypingResult Subtyping::isCovariantWith(
             result = {false};
             break;
         }
+    }
+
+    if (FFlag::LuauSubtypingHandlesExternTypesWithIndexers)
+    {
+        if (superTable->indexer && subExternType->indexer)
+        {
+            // NOTE: despite the name, this will internally check that the two 
+            // indexers are invariant with one another.
+            result.andAlso(isCovariantWith(env, *subExternType->indexer, *superTable->indexer, scope));
+        }
+        else if (superTable->indexer && !subExternType->indexer)
+        {
+            // If the super table has an indexer and the sub extern type does
+            // not, claim this isn't a subtype. For example:
+            //
+            //  declare extern type Vector3 with
+            //      X: number
+            //      Y: number
+            //      Z: number
+            //  end
+            //
+            //  local function cast(v: Vector3): { [string]: number }
+            //      return v
+            //  end
+            //
+            //  local function ohno(v: Vector3)
+            //      local v_prime = cast(v)
+            //      v_prime["well thats not good"] = 42
+            //  end
+            result = { /* isSubtype */ false};
+        }
+        // The remaining cases are:
+        //  - The extern type has an indexer and the table does not: this is
+        //    fine under width subtyping (for now).
+        //  - Neither the extern type nor the table has an indexer, which is
+        //    also fine.
     }
 
     env.substitutions[superTy] = nullptr;
@@ -2496,7 +2500,7 @@ SubtypingResult Subtyping::isCovariantWith(
     return isCovariantWith(env, subVariadic->ty, superVariadic->ty, scope).withBothComponent(TypePath::TypeField::Variadic);
 }
 
-bool Subtyping::bindGeneric(SubtypingEnvironment& env, TypeId subTy, TypeId superTy)
+bool Subtyping::bindGeneric(SubtypingEnvironment& env, TypeId subTy, TypeId superTy) const
 {
     subTy = follow(subTy);
     superTy = follow(superTy);

--- a/Analysis/src/TableLiteralInference.cpp
+++ b/Analysis/src/TableLiteralInference.cpp
@@ -13,10 +13,9 @@
 #include "Luau/TypeUtils.h"
 #include "Luau/Unifier2.h"
 
-LUAU_FASTFLAGVARIABLE(LuauPushTypeConstraintIntersection)
-LUAU_FASTFLAGVARIABLE(LuauPushTypeConstraintIndexer)
-LUAU_FASTFLAGVARIABLE(LuauPushTypeConstraintLambdas2)
+LUAU_FASTFLAGVARIABLE(LuauPushTypeConstraintLambdas3)
 LUAU_FASTFLAGVARIABLE(LuauPushTypeConstraintStripNilFromFunction)
+LUAU_FASTFLAGVARIABLE(LuauPushTypeUnifyConstantHandling)
 
 namespace Luau
 {
@@ -32,12 +31,32 @@ struct BidirectionalTypePusher
 
     NotNull<ConstraintSolver> solver;
     NotNull<const Constraint> constraint;
+    DenseHashSet<const void*>* genericTypesAndPacks;
     NotNull<Unifier2> unifier;
     NotNull<Subtyping> subtyping;
 
     std::vector<IncompleteInference> incompleteInferences;
 
     DenseHashSet<std::pair<TypeId, const AstExpr*>, PairHash<TypeId, const AstExpr*>> seen{{nullptr, nullptr}};
+
+    BidirectionalTypePusher(
+        NotNull<DenseHashMap<const AstExpr*, TypeId>> astTypes,
+        NotNull<DenseHashMap<const AstExpr*, TypeId>> astExpectedTypes,
+        NotNull<ConstraintSolver> solver,
+        NotNull<const Constraint> constraint,
+        NotNull<DenseHashSet<const void*>> genericTypesAndPacks,
+        NotNull<Unifier2> unifier,
+        NotNull<Subtyping> subtyping
+    )
+        : astTypes{astTypes}
+        , astExpectedTypes{astExpectedTypes}
+        , solver{solver}
+        , constraint{constraint}
+        , genericTypesAndPacks{genericTypesAndPacks.get()}
+        , unifier{unifier}
+        , subtyping{subtyping}
+    {
+    }
 
     BidirectionalTypePusher(
         NotNull<DenseHashMap<const AstExpr*, TypeId>> astTypes,
@@ -51,6 +70,7 @@ struct BidirectionalTypePusher
         , astExpectedTypes{astExpectedTypes}
         , solver{solver}
         , constraint{constraint}
+        , genericTypesAndPacks{nullptr}
         , unifier{unifier}
         , subtyping{subtyping}
     {
@@ -58,7 +78,7 @@ struct BidirectionalTypePusher
 
     TypeId pushType(TypeId expectedType, const AstExpr* expr)
     {
-        if (FFlag::LuauPushTypeConstraintLambdas2)
+        if (FFlag::LuauPushTypeConstraintLambdas3)
         {
             (*astExpectedTypes)[expr] = expectedType;
             // We may not have a type here if this is the last argument
@@ -75,12 +95,9 @@ struct BidirectionalTypePusher
 
         TypeId exprType = *astTypes->find(expr);
 
-        if (FFlag::LuauPushTypeConstraintIntersection)
-        {
-            if (seen.contains({expectedType, expr}))
-                return exprType;
-            seen.insert({expectedType, expr});
-        }
+        if (seen.contains({expectedType, expr}))
+            return exprType;
+        seen.insert({expectedType, expr});
 
         expectedType = follow(expectedType);
         exprType = follow(exprType);
@@ -110,7 +127,7 @@ struct BidirectionalTypePusher
         if (is<AnyType, UnknownType>(expectedType))
             return exprType;
 
-        if (!FFlag::LuauPushTypeConstraintLambdas2)
+        if (!FFlag::LuauPushTypeConstraintLambdas3)
             (*astExpectedTypes)[expr] = expectedType;
 
         if (auto group = expr->as<AstExprGroup>())
@@ -131,132 +148,180 @@ struct BidirectionalTypePusher
             // just return the original expression type.
             return exprType;
 
-        if (expr->is<AstExprConstantString>())
+        if (FFlag::LuauPushTypeUnifyConstantHandling)
         {
-            auto ft = get<FreeType>(exprType);
-            if (ft && get<SingletonType>(ft->lowerBound) && fastIsSubtype(solver->builtinTypes->stringType, ft->upperBound) &&
-                fastIsSubtype(ft->lowerBound, solver->builtinTypes->stringType))
+            if (expr->is<AstExprConstantString>() || expr->is<AstExprConstantNumber>() || expr->is<AstExprConstantBool>() ||
+                expr->is<AstExprConstantNil>())
             {
-                if (maybeSingleton(expectedType) && maybeSingleton(ft->lowerBound))
+                if (auto ft = get<FreeType>(exprType))
                 {
-                    // If we see a pattern like:
-                    //
-                    //  local function foo<T>(my_enum: "foo" | "bar" | T) -> T
-                    //      return my_enum
-                    //  end
-                    //  local var = foo("meow")
-                    //
-                    // ... where we are attempting to push a singleton onto any string
-                    // literal, and the lower bound is still a singleton, then snap
-                    // to said lower bound.
-                    if (FFlag::LuauPushTypeConstraintLambdas2)
+                    if (maybeSingleton(expectedType) && maybeSingleton(ft->lowerBound))
                     {
+                        // If we see a pattern like:
+                        //
+                        //  local function foo<T>(my_enum: "foo" | "bar" | T) -> T
+                        //      return my_enum
+                        //  end
+                        //  local var = foo("meow")
+                        //
+                        // ... where we are attempting to push a singleton onto any string
+                        // literal, and the lower bound is still a singleton, then snap
+                        // to said lower bound.
                         solver->bind(constraint, exprType, ft->lowerBound);
+                        return exprType;
                     }
-                    else
-                    {
-                        emplaceType<BoundType>(asMutable(exprType), ft->lowerBound);
-                        solver->unblock(exprType, expr->location);
-                    }
-                    return exprType;
-                }
 
-                // if the upper bound is a subtype of the expected type, we can push the expected type in
-                Relation upperBoundRelation = relate(ft->upperBound, expectedType);
-                if (upperBoundRelation == Relation::Subset || upperBoundRelation == Relation::Coincident)
-                {
-                    if (FFlag::LuauPushTypeConstraintLambdas2)
+                    // if the upper bound is a subtype of the expected type, we can push the expected type in
+                    Relation upperBoundRelation = relate(ft->upperBound, expectedType);
+                    if (upperBoundRelation == Relation::Subset || upperBoundRelation == Relation::Coincident)
                     {
                         solver->bind(constraint, exprType, expectedType);
+                        return exprType;
                     }
-                    else
-                    {
-                        emplaceType<BoundType>(asMutable(exprType), expectedType);
-                        solver->unblock(exprType, expr->location);
-                    }
-                    return exprType;
-                }
 
-                // likewise, if the lower bound is a subtype, we can force the expected type in
-                // if this is the case and the previous relation failed, it means that the primitive type
-                // constraint was going to have to select the lower bound for this type anyway.
-                Relation lowerBoundRelation = relate(ft->lowerBound, expectedType);
-                if (lowerBoundRelation == Relation::Subset || lowerBoundRelation == Relation::Coincident)
-                {
-                    if (FFlag::LuauPushTypeConstraintLambdas2)
+                    // likewise, if the lower bound is a subtype, we can force the expected type in
+                    // if this is the case and the previous relation failed, it means that the primitive type
+                    // constraint was going to have to select the lower bound for this type anyway.
+                    Relation lowerBoundRelation = relate(ft->lowerBound, expectedType);
+                    if (lowerBoundRelation == Relation::Subset || lowerBoundRelation == Relation::Coincident)
                     {
                         solver->bind(constraint, exprType, expectedType);
+                        return exprType;
                     }
-                    else
-                    {
-                        emplaceType<BoundType>(asMutable(exprType), expectedType);
-                        solver->unblock(exprType, expr->location);
-                    }
-                    return exprType;
                 }
             }
         }
-        else if (expr->is<AstExprConstantBool>())
+        else
         {
-            auto ft = get<FreeType>(exprType);
-            if (ft && get<SingletonType>(ft->lowerBound) && fastIsSubtype(solver->builtinTypes->booleanType, ft->upperBound) &&
-                fastIsSubtype(ft->lowerBound, solver->builtinTypes->booleanType))
+            if (expr->is<AstExprConstantString>())
             {
-                // if the upper bound is a subtype of the expected type, we can push the expected type in
-                Relation upperBoundRelation = relate(ft->upperBound, expectedType);
-                if (upperBoundRelation == Relation::Subset || upperBoundRelation == Relation::Coincident)
+                auto ft = get<FreeType>(exprType);
+                if (ft && get<SingletonType>(ft->lowerBound) && fastIsSubtype(solver->builtinTypes->stringType, ft->upperBound) &&
+                    fastIsSubtype(ft->lowerBound, solver->builtinTypes->stringType))
                 {
-                    if (FFlag::LuauPushTypeConstraintLambdas2)
+                    if (maybeSingleton(expectedType) && maybeSingleton(ft->lowerBound))
                     {
-                        solver->bind(constraint, exprType, expectedType);
+                        // If we see a pattern like:
+                        //
+                        //  local function foo<T>(my_enum: "foo" | "bar" | T) -> T
+                        //      return my_enum
+                        //  end
+                        //  local var = foo("meow")
+                        //
+                        // ... where we are attempting to push a singleton onto any string
+                        // literal, and the lower bound is still a singleton, then snap
+                        // to said lower bound.
+                        if (FFlag::LuauPushTypeConstraintLambdas3)
+                        {
+                            solver->bind(constraint, exprType, ft->lowerBound);
+                        }
+                        else
+                        {
+                            emplaceType<BoundType>(asMutable(exprType), ft->lowerBound);
+                            solver->unblock(exprType, expr->location);
+                        }
+                        return exprType;
                     }
-                    else
-                    {
-                        emplaceType<BoundType>(asMutable(exprType), expectedType);
-                        solver->unblock(exprType, expr->location);
-                    }
-                    return exprType;
-                }
 
-                // likewise, if the lower bound is a subtype, we can force the expected type in
-                // if this is the case and the previous relation failed, it means that the primitive type
-                // constraint was going to have to select the lower bound for this type anyway.
-                Relation lowerBoundRelation = relate(ft->lowerBound, expectedType);
-                if (lowerBoundRelation == Relation::Subset || lowerBoundRelation == Relation::Coincident)
-                {
-                    if (FFlag::LuauPushTypeConstraintLambdas2)
+                    // if the upper bound is a subtype of the expected type, we can push the expected type in
+                    Relation upperBoundRelation = relate(ft->upperBound, expectedType);
+                    if (upperBoundRelation == Relation::Subset || upperBoundRelation == Relation::Coincident)
                     {
-                        solver->bind(constraint, exprType, expectedType);
+                        if (FFlag::LuauPushTypeConstraintLambdas3)
+                        {
+                            solver->bind(constraint, exprType, expectedType);
+                        }
+                        else
+                        {
+                            emplaceType<BoundType>(asMutable(exprType), expectedType);
+                            solver->unblock(exprType, expr->location);
+                        }
+                        return exprType;
                     }
-                    else
+
+                    // likewise, if the lower bound is a subtype, we can force the expected type in
+                    // if this is the case and the previous relation failed, it means that the primitive type
+                    // constraint was going to have to select the lower bound for this type anyway.
+                    Relation lowerBoundRelation = relate(ft->lowerBound, expectedType);
+                    if (lowerBoundRelation == Relation::Subset || lowerBoundRelation == Relation::Coincident)
                     {
-                        emplaceType<BoundType>(asMutable(exprType), expectedType);
-                        solver->unblock(exprType, expr->location);
+                        if (FFlag::LuauPushTypeConstraintLambdas3)
+                        {
+                            solver->bind(constraint, exprType, expectedType);
+                        }
+                        else
+                        {
+                            emplaceType<BoundType>(asMutable(exprType), expectedType);
+                            solver->unblock(exprType, expr->location);
+                        }
+                        return exprType;
                     }
-                    return exprType;
                 }
             }
-        }
-
-        if (expr->is<AstExprConstantString>() || expr->is<AstExprConstantNumber>() || expr->is<AstExprConstantBool>() ||
-            expr->is<AstExprConstantNil>())
-        {
-            if (auto ft = get<FreeType>(exprType); ft && fastIsSubtype(ft->upperBound, expectedType))
+            else if (expr->is<AstExprConstantBool>())
             {
-                emplaceType<BoundType>(asMutable(exprType), expectedType);
-                solver->unblock(exprType, expr->location);
+                auto ft = get<FreeType>(exprType);
+                if (ft && get<SingletonType>(ft->lowerBound) && fastIsSubtype(solver->builtinTypes->booleanType, ft->upperBound) &&
+                    fastIsSubtype(ft->lowerBound, solver->builtinTypes->booleanType))
+                {
+                    // if the upper bound is a subtype of the expected type, we can push the expected type in
+                    Relation upperBoundRelation = relate(ft->upperBound, expectedType);
+                    if (upperBoundRelation == Relation::Subset || upperBoundRelation == Relation::Coincident)
+                    {
+                        if (FFlag::LuauPushTypeConstraintLambdas3)
+                        {
+                            solver->bind(constraint, exprType, expectedType);
+                        }
+                        else
+                        {
+                            emplaceType<BoundType>(asMutable(exprType), expectedType);
+                            solver->unblock(exprType, expr->location);
+                        }
+                        return exprType;
+                    }
+
+                    // likewise, if the lower bound is a subtype, we can force the expected type in
+                    // if this is the case and the previous relation failed, it means that the primitive type
+                    // constraint was going to have to select the lower bound for this type anyway.
+                    Relation lowerBoundRelation = relate(ft->lowerBound, expectedType);
+                    if (lowerBoundRelation == Relation::Subset || lowerBoundRelation == Relation::Coincident)
+                    {
+                        if (FFlag::LuauPushTypeConstraintLambdas3)
+                        {
+                            solver->bind(constraint, exprType, expectedType);
+                        }
+                        else
+                        {
+                            emplaceType<BoundType>(asMutable(exprType), expectedType);
+                            solver->unblock(exprType, expr->location);
+                        }
+                        return exprType;
+                    }
+                }
+            }
+
+            if (expr->is<AstExprConstantString>() || expr->is<AstExprConstantNumber>() || expr->is<AstExprConstantBool>() ||
+                expr->is<AstExprConstantNil>())
+            {
+                if (auto ft = get<FreeType>(exprType); ft && fastIsSubtype(ft->upperBound, expectedType))
+                {
+                    emplaceType<BoundType>(asMutable(exprType), expectedType);
+                    solver->unblock(exprType, expr->location);
+                    return exprType;
+                }
+
+                Relation r = relate(exprType, expectedType);
+                if (r == Relation::Coincident || r == Relation::Subset)
+                    return expectedType;
+
                 return exprType;
             }
-
-            Relation r = relate(exprType, expectedType);
-            if (r == Relation::Coincident || r == Relation::Subset)
-                return expectedType;
-
-            return exprType;
         }
 
-        if (FFlag::LuauPushTypeConstraintLambdas2)
+
+        if (FFlag::LuauPushTypeConstraintLambdas3)
         {
+            LUAU_ASSERT(genericTypesAndPacks);
             if (auto exprLambda = expr->as<AstExprFunction>())
             {
                 const auto lambdaTy = get<FunctionType>(exprType);
@@ -274,7 +339,7 @@ struct BidirectionalTypePusher
                         if (
                             !exprLambda->args.data[argIndex]->annotation &&
                             get<FreeType>(follow(lambdaArgTys[argIndex])) &&
-                            !ContainsAnyGeneric::hasAnyGeneric(expectedLambdaArgTys[argIndex])
+                            !containsGeneric(expectedLambdaArgTys[argIndex], NotNull{genericTypesAndPacks})
                         )
                             solver->bind(NotNull{constraint}, lambdaArgTys[argIndex], expectedLambdaArgTys[argIndex]);
                     }
@@ -282,7 +347,7 @@ struct BidirectionalTypePusher
                     if (
                         !exprLambda->returnAnnotation &&
                         get<FreeTypePack>(follow(lambdaTy->retTypes)) &&
-                        !ContainsAnyGeneric::hasAnyGeneric(expectedLambdaTy->retTypes)
+                        !containsGeneric(expectedLambdaTy->retTypes, NotNull{genericTypesAndPacks})
                     )
                         solver->bind(NotNull{constraint}, lambdaTy->retTypes, expectedLambdaTy->retTypes);
                 }
@@ -315,7 +380,7 @@ struct BidirectionalTypePusher
                     if (tt)
                         (void)pushType(*tt, expr);
                 }
-                else if (auto itv = get<IntersectionType>(expectedType); FFlag::LuauPushTypeConstraintIntersection && itv)
+                else if (auto itv = get<IntersectionType>(expectedType))
                 {
                     for (const auto part : itv)
                         (void)pushType(part, expr);
@@ -348,16 +413,8 @@ struct BidirectionalTypePusher
                         //  { foo = bar }
                         //
                         // Then the intent is probably to push `U` into `bar`.
-                        if (FFlag::LuauPushTypeConstraintIndexer)
-                        {
-                            if (expectedTableTy->indexer)
-                                (void)pushType(expectedTableTy->indexer->indexResultType, item.value);
-                        }
-                        else
-                        {
-                            if (expectedTableTy->indexer && fastIsSubtype(solver->builtinTypes->stringType, expectedTableTy->indexer->indexType))
-                                (void)pushType(expectedTableTy->indexer->indexResultType, item.value);
-                        }
+                        if (expectedTableTy->indexer)
+                            (void)pushType(expectedTableTy->indexer->indexResultType, item.value);
 
                         // If it's just an extra property and the expected type
                         // has no indexer, there's no work to do here.
@@ -410,7 +467,7 @@ struct BidirectionalTypePusher
 };
 } // namespace
 
-PushTypeResult pushTypeInto(
+PushTypeResult pushTypeInto_DEPRECATED(
     NotNull<DenseHashMap<const AstExpr*, TypeId>> astTypes,
     NotNull<DenseHashMap<const AstExpr*, TypeId>> astExpectedTypes,
     NotNull<ConstraintSolver> solver,
@@ -422,6 +479,23 @@ PushTypeResult pushTypeInto(
 )
 {
     BidirectionalTypePusher btp{astTypes, astExpectedTypes, solver, constraint, unifier, subtyping};
+    (void)btp.pushType(expectedType, expr);
+    return {std::move(btp.incompleteInferences)};
+}
+
+PushTypeResult pushTypeInto(
+    NotNull<DenseHashMap<const AstExpr*, TypeId>> astTypes,
+    NotNull<DenseHashMap<const AstExpr*, TypeId>> astExpectedTypes,
+    NotNull<ConstraintSolver> solver,
+    NotNull<const Constraint> constraint,
+    NotNull<DenseHashSet<const void*>> genericTypesAndPacks,
+    NotNull<Unifier2> unifier,
+    NotNull<Subtyping> subtyping,
+    TypeId expectedType,
+    const AstExpr* expr
+)
+{
+    BidirectionalTypePusher btp{astTypes, astExpectedTypes, solver, constraint, genericTypesAndPacks, unifier, subtyping};
     (void)btp.pushType(expectedType, expr);
     return {std::move(btp.incompleteInferences)};
 }

--- a/Analysis/src/TxnLog.cpp
+++ b/Analysis/src/TxnLog.cpp
@@ -167,7 +167,7 @@ void TxnLog::concatAsUnion(TxnLog rhs, NotNull<TypeArena> arena)
 
 // Like follow(), but only takes a single step.
 //
-// This is potentailly performance sensitive, so we use nullptr rather than an
+// This is potentially performance sensitive, so we use nullptr rather than an
 // optional<TypeId> for the return type here.
 static TypeId followOnce(TxnLog& log, TypeId ty)
 {

--- a/Analysis/src/TypeChecker2.cpp
+++ b/Analysis/src/TypeChecker2.cpp
@@ -34,18 +34,16 @@
 
 LUAU_FASTFLAG(DebugLuauMagicTypes)
 
-LUAU_FASTFLAG(LuauExplicitTypeExpressionInstantiation)
+LUAU_FASTFLAG(LuauExplicitTypeInstantiationSyntax)
+LUAU_FASTFLAG(LuauExplicitTypeInstantiationSupport)
 
 LUAU_FASTFLAGVARIABLE(LuauIceLess)
 LUAU_FASTFLAGVARIABLE(LuauCheckForInWithSubtyping3)
-LUAU_FASTFLAGVARIABLE(LuauNewOverloadResolver2)
 LUAU_FASTFLAGVARIABLE(LuauHandleFunctionOversaturation)
-LUAU_FASTFLAG(LuauSimplifyIntersectionNoTreeSet)
-LUAU_FASTFLAG(LuauAddRefinementToAssertions)
-LUAU_FASTFLAGVARIABLE(LuauSuppressIndexingIntoError)
 LUAU_FASTFLAG(LuauBetterTypeMismatchErrors)
 LUAU_FASTFLAGVARIABLE(LuauFixIndexingUnionWithNonTable)
 LUAU_FASTFLAGVARIABLE(LuauCheckFunctionStatementTypes)
+LUAU_FASTFLAG(LuauReworkInfiniteTypeFinder)
 
 namespace Luau
 {
@@ -1337,8 +1335,16 @@ void TypeChecker2::visit(AstStatTypeAlias* stat)
 
     if (const Scope* scope = findInnermostScope(stat->location))
     {
-        if (scope->isInvalidTypeAliasName(stat->name.value))
-            reportError(RecursiveRestraintViolation{}, stat->location);
+        if (FFlag::LuauReworkInfiniteTypeFinder)
+        {
+            if (auto loc = scope->isInvalidTypeAlias(stat->name.value))
+                reportError(RecursiveRestraintViolation{}, *loc);
+        }
+        else
+        {
+            if (scope->isInvalidTypeAliasName_DEPRECATED(stat->name.value))
+                reportError(RecursiveRestraintViolation{}, stat->location);
+        }
     }
 
     visitGenerics(stat->generics, stat->genericPacks);
@@ -1428,7 +1434,7 @@ void TypeChecker2::visit(AstExpr* expr, ValueContext context)
         return visit(e);
     else if (auto e = expr->as<AstExprInstantiate>())
     {
-        LUAU_ASSERT(FFlag::LuauExplicitTypeExpressionInstantiation);
+        LUAU_ASSERT(FFlag::LuauExplicitTypeInstantiationSyntax);
         return visit(e);
     }
     else if (auto e = expr->as<AstExprInterpString>())
@@ -1587,7 +1593,7 @@ void TypeChecker2::visitCall(AstExprCall* call)
         return;
     }
 
-    if (FFlag::LuauExplicitTypeExpressionInstantiation)
+    if (FFlag::LuauExplicitTypeInstantiationSupport)
     {
         if (call->typeArguments.size)
         {
@@ -1761,220 +1767,126 @@ void TypeChecker2::visitCall(AstExprCall* call)
     DenseHashSet<TypeId> uniqueTypes{nullptr};
     findUniqueTypes(NotNull{&uniqueTypes}, argExprs, NotNull{&module->astTypes});
 
-    if (FFlag::LuauNewOverloadResolver2)
+    TypePackId argsPack = module->internalTypes.addTypePack(args);
+    const OverloadResolution result2 = resolver.resolveOverload(fnTy, argsPack, call->func->location, NotNull{&uniqueTypes}, false);
+
+    if (!result2.potentialOverloads.empty())
+        reportError(InternalError{"Internal error: outstanding free or blocked type in function call"}, call->location);
+
+    /*
+     * If one overload matches, stop.  Nothing to report.
+     *
+     * If 2 or more overloads match, report that it is ambiguous.  List the overloads that match.
+     *
+     * If 0 overloads match:
+     *      If multiple overloads are arity matches, but are nonviable, report MultipleNonviableOverloads and report the overloads that have matching
+     * arities. Note: Error suppressing overloads are ignored in this calculation! If only one overload is an arity match but it is nonviable, report
+     * subtyping errors for just that.
+     *
+     *      If no overloads are arity matches, list all overloads.
+     */
+
+    if (!result2.ok.empty())
     {
-        TypePackId argsPack = module->internalTypes.addTypePack(args);
-        const OverloadResolution result2 = resolver.resolveOverload(fnTy, argsPack, call->func->location, NotNull{&uniqueTypes}, false);
+        if (result2.ok.size() > 1)
+            reportError(AmbiguousFunctionCall{fnTy, argsPack}, call->location);
+        return;
+    }
 
-        if (!result2.potentialOverloads.empty())
-            reportError(InternalError{"Internal error: outstanding free or blocked type in function call"}, call->location);
+    std::vector<TypeId> overloadsToReport;
 
-        /*
-         * If one overload matches, stop.  Nothing to report.
-         *
-         * If 2 or more overloads match, report that it is ambiguous.  List the overloads that match.
-         *
-         * If 0 overloads match:
-         *      If multiple overloads are arity matches, but are nonviable, report MultipleNonviableOverloads and report the overloads that have matching arities.
-         *          Note: Error suppressing overloads are ignored in this calculation!
-         *      If only one overload is an arity match but it is nonviable, report subtyping errors for just that.
-         *
-         *      If no overloads are arity matches, list all overloads.
-         */
-
-        if (!result2.ok.empty())
+    if (1 == result2.incompatibleOverloads.size())
+    {
+        for (const auto& [ty, reasons] : result2.incompatibleOverloads)
         {
-            if (result2.ok.size() > 1)
-                reportError(AmbiguousFunctionCall{fnTy, argsPack}, call->location);
-            return;
-        }
-
-        std::vector<TypeId> overloadsToReport;
-
-        if (1 == result2.incompatibleOverloads.size())
-        {
-            for (const auto& [ty, reasons] : result2.incompatibleOverloads)
+            if (const SubtypingReasonings* sr = get_if<SubtypingReasonings>(&reasons))
             {
-                if (const SubtypingReasonings* sr = get_if<SubtypingReasonings>(&reasons))
-                {
-                    for (const SubtypingReasoning& reason : *sr)
-                        resolver.reportErrors(module->errors, ty, call->func->location, module->name, argsPack, argExprs, reason);
-                }
-                else if (const auto errorVec = get_if<ErrorVec>(&reasons))
-                {
-                    reportErrors(*errorVec);
-                }
-                else
-                    LUAU_ASSERT(!"Unreachable");
+                for (const SubtypingReasoning& reason : *sr)
+                    resolver.reportErrors(module->errors, ty, call->func->location, module->name, argsPack, argExprs, reason);
             }
-
-            return;
-        }
-
-        // TODO: arity mismatches need expected/actual counts.
-        const auto [argHead, _argTail] = flatten(argsPack);
-        if (result2.incompatibleOverloads.size() > 1)
-        {
-            overloadsToReport.reserve(result2.nonFunctions.size());
-            for (const auto& [overloadTy, _reasons] : result2.incompatibleOverloads)
+            else if (const auto errorVec = get_if<ErrorVec>(&reasons))
             {
-                if (!isErrorSuppressing(call->location, overloadTy))
-                    overloadsToReport.emplace_back(overloadTy);
+                reportErrors(*errorVec);
             }
-
-            // If all nonviable overloads are error suppressing, don't report anything.
-            if (!overloadsToReport.empty())
-            {
-                reportError(MultipleNonviableOverloads{argHead.size()}, call->location);
-                reportAvailableOverloads(module->errors, call->location, overloadsToReport);
-            }
-
-            return;
-        }
-
-        LUAU_ASSERT(0 == result2.ok.size() && 0 == result2.incompatibleOverloads.size());
-
-        if (1 == result2.arityMismatches.size())
-        {
-            const TypeId fnTy = follow(result2.arityMismatches.front());
-            const FunctionType* fn = get<FunctionType>(fnTy);
-            LUAU_ASSERT(fn);
-
-            if (fn)
-            {
-                const bool isVariadic = Luau::isVariadic(fn->argTypes);
-
-                auto [minParams, optMaxParams] = getParameterExtents(TxnLog::empty(), fn->argTypes);
-                reportError(
-                    CountMismatch{
-                        minParams,
-                        optMaxParams,
-                        argHead.size(),
-                        CountMismatch::Arg,
-                        isVariadic
-                    },
-                    call->func->location
-                );
-                return;
-            }
-        }
-
-        if (!result2.arityMismatches.empty())
-        {
-            std::stringstream ss;
-            ss << "No overload for function accepts " << argHead.size() << " arguments.";
-            reportError(GenericError{ss.str()}, call->func->location);
-            reportAvailableOverloads(module->errors, call->func->location, result2.arityMismatches);
-            return;
-        }
-
-        if (!result2.nonFunctions.empty())
-        {
-            auto norm = normalizer.normalize(fnTy);
-            if (!norm || normalizer.isInhabited(norm.get()) == NormalizationResult::HitLimits)
-                reportError(NormalizationTooComplex{}, call->func->location);
-            // At this point norm is non-null and inhabited.
-            if (!norm->shouldSuppressErrors())
-                reportError(CannotCallNonFunction{fnTy}, call->func->location);
-            return;
+            else
+                LUAU_ASSERT(!"Unreachable");
         }
 
         return;
     }
 
-    resolver.resolve_DEPRECATED(fnTy, &args, call->func, &argExprs, NotNull{&uniqueTypes});
-
-    auto norm = normalizer.normalize(fnTy);
-    if (!norm)
-        reportError(NormalizationTooComplex{}, call->func->location);
-    auto isInhabited = normalizer.isInhabited(norm.get());
-    if (isInhabited == NormalizationResult::HitLimits)
-        reportError(NormalizationTooComplex{}, call->func->location);
-
-    if (norm && norm->shouldSuppressErrors())
-        return; // error suppressing function type!
-    else if (!resolver.ok.empty())
-        return; // We found a call that works, so this is ok.
-    else if (!norm || isInhabited == NormalizationResult::False)
-        return; // Ok. Calling an uninhabited type is no-op.
-    else if (!resolver.nonviableOverloads.empty())
+    // TODO: arity mismatches need expected/actual counts.
+    const auto [argHead, _argTail] = flatten(argsPack);
+    if (result2.incompatibleOverloads.size() > 1)
     {
-        const bool reportedErrors =
-            reportNonviableOverloadErrors(resolver.nonviableOverloads, call->func->location, args.head.size(), call->location);
-        if (!reportedErrors)
-            return; // We did not report any errors, so we can just return.
-    }
-    else if (!resolver.arityMismatches.empty())
-    {
-        if (resolver.arityMismatches.size() == 1)
-            reportErrors(resolver.arityMismatches.front().second);
-        else
+        overloadsToReport.reserve(result2.nonFunctions.size());
+        for (const auto& [overloadTy, _reasons] : result2.incompatibleOverloads)
         {
-            std::string s = "No overload for function accepts ";
-            s += std::to_string(args.head.size());
-            s += " arguments.";
-            reportError(GenericError{std::move(s)}, call->location);
+            if (!isErrorSuppressing(call->location, overloadTy))
+                overloadsToReport.emplace_back(overloadTy);
+        }
+
+        // If all nonviable overloads are error suppressing, don't report anything.
+        if (!overloadsToReport.empty())
+        {
+            reportError(MultipleNonviableOverloads{argHead.size()}, call->location);
+            reportAvailableOverloads(module->errors, call->location, overloadsToReport);
+        }
+
+        return;
+    }
+
+    LUAU_ASSERT(0 == result2.ok.size() && 0 == result2.incompatibleOverloads.size());
+
+    if (1 == result2.arityMismatches.size())
+    {
+        const TypeId fnTy = follow(result2.arityMismatches.front());
+        const FunctionType* fn = get<FunctionType>(fnTy);
+        LUAU_ASSERT(fn);
+
+        if (fn)
+        {
+            const bool isVariadic = Luau::isVariadic(fn->argTypes);
+
+            auto [minParams, optMaxParams] = getParameterExtents(TxnLog::empty(), fn->argTypes);
+            reportError(CountMismatch{minParams, optMaxParams, argHead.size(), CountMismatch::Arg, isVariadic}, call->func->location);
+            return;
         }
     }
-    else if (!resolver.nonFunctions.empty())
-        reportError(CannotCallNonFunction{fnTy}, call->func->location);
-    else
-        LUAU_ASSERT(!"Generating the best possible error from this function call resolution was inexhaustive?");
 
-    if (resolver.nonviableOverloads.size() <= 1 && resolver.arityMismatches.size() <= 1)
+    if (!result2.arityMismatches.empty())
+    {
+        std::stringstream ss;
+        ss << "No overload for function accepts " << argHead.size() << " arguments.";
+        reportError(GenericError{ss.str()}, call->func->location);
+        reportAvailableOverloads(module->errors, call->func->location, result2.arityMismatches);
         return;
-
-    std::string s = "Available overloads: ";
-
-    std::vector<TypeId> overloads;
-    if (resolver.nonviableOverloads.empty())
-    {
-        for (const auto& [ty, p] : resolver.resolution)
-        {
-            if (p.first == OverloadResolver::TypeIsNotAFunction)
-                continue;
-
-            overloads.push_back(ty);
-        }
-    }
-    else
-    {
-        for (const auto& [ty, _] : resolver.nonviableOverloads)
-            overloads.push_back(ty);
     }
 
-    if (overloads.size() <= 1)
+    if (!result2.nonFunctions.empty())
+    {
+        auto norm = normalizer.normalize(fnTy);
+        if (!norm || normalizer.isInhabited(norm.get()) == NormalizationResult::HitLimits)
+            reportError(NormalizationTooComplex{}, call->func->location);
+        // At this point norm is non-null and inhabited.
+        if (!norm->shouldSuppressErrors())
+            reportError(CannotCallNonFunction{fnTy}, call->func->location);
         return;
-
-    for (size_t i = 0; i < overloads.size(); ++i)
-    {
-        if (i > 0)
-            s += (i == overloads.size() - 1) ? "; and " : "; ";
-
-        s += toString(overloads[i]);
     }
 
-    reportError(ExtraInformation{std::move(s)}, call->func->location);
 }
 
 void TypeChecker2::visit(AstExprCall* call)
 {
     std::optional<InConditionalContext> flipper;
-    if (FFlag::LuauAddRefinementToAssertions)
-    {
-        // We want to preserve the existing conditional context if we are in a `typeof` call.
-        if (!matchTypeOf(*call))
-            flipper.emplace(&typeContext, TypeContext::Default);
 
-        visit(call->func, ValueContext::RValue);
-    }
-    else
-    {
-        InConditionalContext flipper(&typeContext, TypeContext::Default);
-        visit(call->func, ValueContext::RValue);
-    }
+    // We want to preserve the existing conditional context if we are in a `typeof` call.
+    if (!matchTypeOf(*call))
+        flipper.emplace(&typeContext, TypeContext::Default);
 
-    if (FFlag::LuauAddRefinementToAssertions && matchAssert(*call) && call->args.size > 0)
+    visit(call->func, ValueContext::RValue);
+
+    if (matchAssert(*call) && call->args.size > 0)
     {
         {
             InConditionalContext flipper(&typeContext);
@@ -2130,24 +2042,19 @@ void TypeChecker2::visit(AstExprIndexExpr* indexExpr, ValueContext context)
         // if all of the typeArguments are a table type, the union must be a table, and so we shouldn't error.
         if (!std::all_of(begin(ut), end(ut), getTableType))
         {
-            if (FFlag::LuauSuppressIndexingIntoError)
+            switch (shouldSuppressErrors(NotNull{&normalizer}, exprType))
             {
-                switch (shouldSuppressErrors(NotNull{&normalizer}, exprType))
-                {
-                case ErrorSuppression::Suppress:
-                    break;
-                case ErrorSuppression::NormalizationFailed:
-                    reportError(NormalizationTooComplex{}, indexExpr->location);
-                    [[fallthrough]];
-                case ErrorSuppression::DoNotSuppress:
-                    if (FFlag::LuauFixIndexingUnionWithNonTable)
-                        reportError(NotATable{exprType}, indexExpr->location);
-                    else
-                        reportError(OptionalValueAccess{exprType}, indexExpr->location);
-                }
+            case ErrorSuppression::Suppress:
+                break;
+            case ErrorSuppression::NormalizationFailed:
+                reportError(NormalizationTooComplex{}, indexExpr->location);
+                [[fallthrough]];
+            case ErrorSuppression::DoNotSuppress:
+                if (FFlag::LuauFixIndexingUnionWithNonTable)
+                    reportError(NotATable{exprType}, indexExpr->location);
+                else
+                    reportError(OptionalValueAccess{exprType}, indexExpr->location);
             }
-            else
-                reportError(NotATable{exprType}, indexExpr->location);
         }
     }
     else if (auto it = get<IntersectionType>(exprType))
@@ -2828,14 +2735,15 @@ void TypeChecker2::visit(AstExprIfElse* expr)
 
 void TypeChecker2::visit(AstExprInstantiate* explicitTypeInstantiation)
 {
-    LUAU_ASSERT(FFlag::LuauExplicitTypeExpressionInstantiation);
+    LUAU_ASSERT(FFlag::LuauExplicitTypeInstantiationSyntax);
     visit(explicitTypeInstantiation->expr, ValueContext::RValue);
-    checkTypeInstantiation(
-        explicitTypeInstantiation->expr,
-        lookupType(explicitTypeInstantiation->expr),
-        explicitTypeInstantiation->location,
-        explicitTypeInstantiation->typeArguments
-    );
+    if (FFlag::LuauExplicitTypeInstantiationSupport)
+        checkTypeInstantiation(
+            explicitTypeInstantiation->expr,
+            lookupType(explicitTypeInstantiation->expr),
+            explicitTypeInstantiation->location,
+            explicitTypeInstantiation->typeArguments
+        );
 }
 
 void TypeChecker2::visit(AstExprInterpString* interpString)
@@ -3180,7 +3088,7 @@ Reasonings TypeChecker2::explainReasonings_(TID subTy, TID superTy, Location loc
             if (FFlag::LuauIceLess)
             {
                 reportError(InternalError{"Subtyping test returned a reasoning with an invalid path"}, location);
-                return {}; // TOOD test this
+                return {}; // TODO test this
             }
             else
                 ice->ice("Subtyping test returned a reasoning with an invalid path", location);
@@ -3371,22 +3279,11 @@ bool TypeChecker2::testPotentialLiteralIsSubtype(AstExpr* expr, TypeId expectedT
         {
             // If we _happen_ to have an intersection of tables, let's try to
             // construct it and use it as the input to this algorithm.
-            if (FFlag::LuauSimplifyIntersectionNoTreeSet)
-            {
-                TypeIds parts;
-                parts.insert(begin(itv), end(itv));
-                TypeId simplified = simplifyIntersection(builtinTypes, NotNull{&module->internalTypes}, std::move(parts)).result;
-                if (is<TableType>(simplified))
-                    return testPotentialLiteralIsSubtype(expr, simplified);
-            }
-            else
-            {
-
-                std::set<TypeId> parts{begin(itv), end(itv)};
-                TypeId simplified = simplifyIntersection_DEPRECATED(builtinTypes, NotNull{&module->internalTypes}, std::move(parts)).result;
-                if (is<TableType>(simplified))
-                    return testPotentialLiteralIsSubtype(expr, simplified);
-            }
+            TypeIds parts;
+            parts.insert(begin(itv), end(itv));
+            TypeId simplified = simplifyIntersection(builtinTypes, NotNull{&module->internalTypes}, std::move(parts)).result;
+            if (is<TableType>(simplified))
+                return testPotentialLiteralIsSubtype(expr, simplified);
         }
 
         return testIsSubtype(exprType, expectedType, expr->location);
@@ -3819,8 +3716,8 @@ PropertyType TypeChecker2::hasIndexTypeFromType(
             return {NormalizationResult::True, context == ValueContext::LValue ? property->writeTy : property->readTy};
         if (cls->indexer)
         {
-            TypeId inhabitatedTestType = module->internalTypes.addType(IntersectionType{{cls->indexer->indexType, astIndexExprType}});
-            return {normalizer.isInhabited(inhabitatedTestType), {cls->indexer->indexResultType}};
+            TypeId inhabitedTestType = module->internalTypes.addType(IntersectionType{{cls->indexer->indexType, astIndexExprType}});
+            return {normalizer.isInhabited(inhabitedTestType), {cls->indexer->indexResultType}};
         }
         return {NormalizationResult::False, {}};
     }
@@ -3919,7 +3816,7 @@ void TypeChecker2::checkTypeInstantiation(
     const AstArray<AstTypeOrPack>& typeArguments
 )
 {
-    LUAU_ASSERT(FFlag::LuauExplicitTypeExpressionInstantiation);
+    LUAU_ASSERT(FFlag::LuauExplicitTypeInstantiationSupport);
 
     const FunctionType* ftv = get<FunctionType>(follow(fnType));
     if (!ftv)

--- a/Analysis/src/TypeFunction.cpp
+++ b/Analysis/src/TypeFunction.cpp
@@ -684,7 +684,7 @@ static FunctionGraphReductionResult reduceFunctionsInternal(
     if (ctx->normalizer->sharedState->reentrantTypeReduction)
         return {};
 
-    TypeReductionRentrancyGuard _{ctx->normalizer->sharedState};
+    TypeReductionReentrancyGuard _{ctx->normalizer->sharedState};
     while (!reducer.done())
     {
         reducer.step();

--- a/Analysis/src/TypeFunctionRuntime.cpp
+++ b/Analysis/src/TypeFunctionRuntime.cpp
@@ -412,7 +412,7 @@ static int createSingleton(lua_State* L)
 }
 
 // Luau: `types.generic(name: string, ispack: boolean?) -> type
-// Create a generic type with the specified type. If an optinal boolean is set to true, result is a generic pack
+// Create a generic type with the specified type. If an optional boolean is set to true, result is a generic pack
 static int createGeneric(lua_State* L)
 {
     const char* name = luaL_checkstring(L, 1);
@@ -1106,7 +1106,7 @@ static TypeFunctionTypePackId getTypePack(lua_State* L, int headIdx, int tailIdx
     return result;
 }
 
-static void pushTypePack(lua_State* L, TypeFunctionTypePackId tp)
+void pushTypePack(lua_State* L, TypeFunctionTypePackId tp)
 {
     if (auto tftp = get<TypeFunctionTypePack>(tp))
     {

--- a/Analysis/src/TypePath.cpp
+++ b/Analysis/src/TypePath.cpp
@@ -17,8 +17,6 @@
 #include <sstream>
 
 LUAU_FASTFLAG(LuauSolverV2);
-LUAU_FASTFLAG(LuauNewOverloadResolver2)
-LUAU_FASTFLAG(LuauNewNonStrictBetterCheckedFunctionErrorMessage)
 
 // Maximum number of steps to follow when traversing a path. May not always
 // equate to the number of components in a path, depending on the traversal
@@ -793,44 +791,14 @@ std::string toStringHuman(const TypePath::Path& path)
         }
         else if constexpr (std::is_same_v<T, TypePath::Index>)
         {
-            if (FFlag::LuauNewNonStrictBetterCheckedFunctionErrorMessage)
-            {
-                if (state == State::Initial && !last)
-                    result << "in" << ' ';
-                else if (state == State::PendingIs)
-                    result << ' ' << "has" << ' ';
-                else if (state == State::Property)
-                    result << '`' << ' ' << "has" << ' ';
+            if (state == State::Initial && !last)
+                result << "in" << ' ';
+            else if (state == State::PendingIs)
+                result << ' ' << "has" << ' ';
+            else if (state == State::Property)
+                result << '`' << ' ' << "has" << ' ';
 
-                result << "the " << toHumanReadableIndex(c.index);
-            }
-            else
-            {
-                size_t humanIndex = c.index + 1;
-
-                if (state == State::Initial && !last)
-                    result << "in" << ' ';
-                else if (state == State::PendingIs)
-                    result << ' ' << "has" << ' ';
-                else if (state == State::Property)
-                    result << '`' << ' ' << "has" << ' ';
-
-                result << "the " << humanIndex;
-                switch (humanIndex)
-                {
-                case 1:
-                    result << "st";
-                    break;
-                case 2:
-                    result << "nd";
-                    break;
-                case 3:
-                    result << "rd";
-                    break;
-                default:
-                    result << "th";
-                }
-            }
+            result << "the " << toHumanReadableIndex(c.index);
 
             switch (c.variant)
             {
@@ -1025,7 +993,7 @@ std::optional<TypeOrPack> traverse(const TypePackId root, const Path& path, cons
     TraversalState state(follow(root), builtinTypes, arena);
     if (traverse(state, path))
     {
-        if (FFlag::LuauNewOverloadResolver2 && state.encounteredErrorSuppression)
+        if (state.encounteredErrorSuppression)
             return builtinTypes->errorType;
         return state.current;
     }

--- a/Analysis/src/Unifier.cpp
+++ b/Analysis/src/Unifier.cpp
@@ -2218,7 +2218,7 @@ void Unifier::tryUnifyScalarShape(TypeId subTy, TypeId superTy, bool reversed)
             child->tryUnify_(ty, superTy);
 
             // To perform subtype <: free table unification, we have tried to unify (subtype's metatable) <: free table
-            // There is a chance that it was unified with the origial subtype, but then, (subtype's metatable) <: subtype could've failed
+            // There is a chance that it was unified with the original subtype, but then, (subtype's metatable) <: subtype could've failed
             // Here we check if we have a new supertype instead of the original free table and try original subtype <: new supertype check
             TypeId newSuperTy = child->log.follow(superTy);
 

--- a/Ast/include/Luau/Ast.h
+++ b/Ast/include/Luau/Ast.h
@@ -1458,6 +1458,10 @@ public:
     {
         return visit(static_cast<AstExpr*>(node));
     }
+    virtual bool visit(class AstExprInstantiate* node)
+    {
+        return visit(static_cast<AstExpr*>(node));
+    }
     virtual bool visit(class AstExprError* node)
     {
         return visit(static_cast<AstExpr*>(node));

--- a/Ast/src/Ast.cpp
+++ b/Ast/src/Ast.cpp
@@ -5,7 +5,7 @@
 
 LUAU_FASTFLAGVARIABLE(LuauStandaloneParseType)
 
-LUAU_FASTFLAG(LuauExplicitTypeExpressionInstantiation)
+LUAU_FASTFLAG(LuauExplicitTypeInstantiationSyntax)
 
 namespace Luau
 {
@@ -37,7 +37,7 @@ static void visitTypeList(AstVisitor* visitor, const AstTypeList& list)
 
 static void visitTypeOrPackArray(AstVisitor* visitor, const AstArray<AstTypeOrPack>& arrayOfTypeOrPack)
 {
-    LUAU_ASSERT(FFlag::LuauExplicitTypeExpressionInstantiation);
+    LUAU_ASSERT(FFlag::LuauExplicitTypeInstantiationSyntax);
 
     for (const AstTypeOrPack& param : arrayOfTypeOrPack)
     {
@@ -241,7 +241,7 @@ AstExprCall::AstExprCall(
     , self(self)
     , argLocation(argLocation)
 {
-    LUAU_ASSERT(FFlag::LuauExplicitTypeExpressionInstantiation || explicitTypes.size == 0);
+    LUAU_ASSERT(FFlag::LuauExplicitTypeInstantiationSyntax || explicitTypes.size == 0);
 }
 
 void AstExprCall::visit(AstVisitor* visitor)
@@ -552,11 +552,13 @@ AstExprInstantiate::AstExprInstantiate(const Location& location, AstExpr* expr, 
     , expr(expr)
     , typeArguments(types)
 {
-    LUAU_ASSERT(FFlag::LuauExplicitTypeExpressionInstantiation);
+    LUAU_ASSERT(FFlag::LuauExplicitTypeInstantiationSyntax);
 }
 
 void AstExprInstantiate::visit(AstVisitor* visitor)
 {
+    expr->visit(visitor);
+
     if (visitor->visit(this))
     {
         visitTypeOrPackArray(visitor, typeArguments);
@@ -1098,7 +1100,7 @@ void AstTypeReference::visit(AstVisitor* visitor)
 {
     if (visitor->visit(this))
     {
-        if (FFlag::LuauExplicitTypeExpressionInstantiation)
+        if (FFlag::LuauExplicitTypeInstantiationSyntax)
         {
             visitTypeOrPackArray(visitor, parameters);
         }

--- a/Ast/src/Parser.cpp
+++ b/Ast/src/Parser.cpp
@@ -20,7 +20,7 @@ LUAU_FASTINTVARIABLE(LuauParseErrorLimit, 100)
 LUAU_FASTFLAGVARIABLE(LuauSolverV2)
 LUAU_DYNAMIC_FASTFLAGVARIABLE(DebugLuauReportReturnTypeVariadicWithTypeSuffix, false)
 LUAU_FASTFLAGVARIABLE(DebugLuauStringSingletonBasedOnQuotes)
-LUAU_FASTFLAGVARIABLE(LuauExplicitTypeExpressionInstantiation)
+LUAU_FASTFLAGVARIABLE(LuauExplicitTypeInstantiationSyntax)
 LUAU_FASTFLAG(LuauStandaloneParseType)
 LUAU_FASTFLAGVARIABLE(LuauCstStatDoWithStatsStart)
 
@@ -3087,7 +3087,7 @@ AstExpr* Parser::parsePrimaryExpr(bool asStatement)
         {
             expr = parseFunctionArgs(expr, false);
         }
-        else if (FFlag::LuauExplicitTypeExpressionInstantiation && lexer.current().type == '<' && lexer.lookahead().type == '<')
+        else if (FFlag::LuauExplicitTypeInstantiationSyntax && lexer.current().type == '<' && lexer.lookahead().type == '<')
         {
             expr = parseExplicitTypeInstantiationExpr(start, *expr);
         }
@@ -3113,7 +3113,7 @@ AstExpr* Parser::parseMethodCall(Position start, AstExpr* expr)
     Name index = parseIndexName("method name", opPosition);
     AstExpr* func = allocator.alloc<AstExprIndexName>(Location(start, index.location.end), expr, index.name, index.location, opPosition, ':');
 
-    if (FFlag::LuauExplicitTypeExpressionInstantiation)
+    if (FFlag::LuauExplicitTypeInstantiationSyntax)
     {
         AstArray<AstTypeOrPack> typeArguments;
         CstTypeInstantiation* cstTypeArguments = options.storeCstData ? allocator.alloc<CstTypeInstantiation>() : nullptr;
@@ -4114,7 +4114,7 @@ LUAU_NOINLINE AstExpr* Parser::parseExplicitTypeInstantiationExpr(Position start
 
 AstArray<AstTypeOrPack> Parser::parseTypeInstantiationExpr(CstTypeInstantiation* cstNodeOut, Location* endLocationOut)
 {
-    LUAU_ASSERT(FFlag::LuauExplicitTypeExpressionInstantiation);
+    LUAU_ASSERT(FFlag::LuauExplicitTypeInstantiationSyntax);
 
     LUAU_ASSERT(lexer.current().type == '<' && lexer.lookahead().type == '<');
 

--- a/Ast/src/PrettyPrinter.cpp
+++ b/Ast/src/PrettyPrinter.cpp
@@ -9,7 +9,7 @@
 #include <limits>
 #include <math.h>
 
-LUAU_FASTFLAG(LuauExplicitTypeExpressionInstantiation)
+LUAU_FASTFLAG(LuauExplicitTypeInstantiationSyntax)
 LUAU_FASTFLAG(LuauCstStatDoWithStatsStart)
 
 namespace
@@ -541,7 +541,7 @@ struct Printer
 
             const auto cstNode = lookupCstNode<CstExprCall>(a);
 
-            if (FFlag::LuauExplicitTypeExpressionInstantiation)
+            if (FFlag::LuauExplicitTypeInstantiationSyntax)
             {
                 if (writeTypes && (a->typeArguments.size > 0 || (cstNode && cstNode->explicitTypes)))
                 {
@@ -831,7 +831,7 @@ struct Printer
         }
         else if (const auto& a = expr.as<AstExprInstantiate>())
         {
-            LUAU_ASSERT(FFlag::LuauExplicitTypeExpressionInstantiation);
+            LUAU_ASSERT(FFlag::LuauExplicitTypeInstantiationSyntax);
 
             visualize(*a->expr);
 
@@ -1892,7 +1892,7 @@ struct Printer
 
     void visualizeExplicitTypeInstantiation(const AstArray<AstTypeOrPack>& typeArguments, const CstTypeInstantiation* cstNode)
     {
-        LUAU_ASSERT(FFlag::LuauExplicitTypeExpressionInstantiation);
+        LUAU_ASSERT(FFlag::LuauExplicitTypeInstantiationSyntax);
 
         if (cstNode)
         {

--- a/CodeGen/include/Luau/AssemblyBuilderA64.h
+++ b/CodeGen/include/Luau/AssemblyBuilderA64.h
@@ -44,10 +44,20 @@ public:
     void sub(RegisterA64 dst, RegisterA64 src1, uint16_t src2);
     void neg(RegisterA64 dst, RegisterA64 src);
 
+    // Prevent implicit conversions from happening
+    template<typename T>
+    void add(RegisterA64 dst, RegisterA64 src1, T src2) = delete;
+    template<typename T>
+    void sub(RegisterA64 dst, RegisterA64 src1, T src2) = delete;
+
     // Comparisons
     // Note: some arithmetic instructions also have versions that update flags (ADDS etc) but we aren't using them atm
     void cmp(RegisterA64 src1, RegisterA64 src2);
     void cmp(RegisterA64 src1, uint16_t src2);
+
+    template<typename T>
+    void cmp(RegisterA64 src1, T src2) = delete; // Prevent implicit conversions from happening
+
     void csel(RegisterA64 dst, RegisterA64 src1, RegisterA64 src2, ConditionA64 cond);
     void cset(RegisterA64 dst, ConditionA64 cond);
 

--- a/CodeGen/include/Luau/AssemblyBuilderX64.h
+++ b/CodeGen/include/Luau/AssemblyBuilderX64.h
@@ -125,21 +125,26 @@ public:
     void vaddss(OperandX64 dst, OperandX64 src1, OperandX64 src2);
 
     void vsubsd(OperandX64 dst, OperandX64 src1, OperandX64 src2);
+    void vsubss(OperandX64 dst, OperandX64 src1, OperandX64 src2);
     void vsubps(OperandX64 dst, OperandX64 src1, OperandX64 src2);
     void vmulsd(OperandX64 dst, OperandX64 src1, OperandX64 src2);
+    void vmulss(OperandX64 dst, OperandX64 src1, OperandX64 src2);
     void vmulps(OperandX64 dst, OperandX64 src1, OperandX64 src2);
     void vdivsd(OperandX64 dst, OperandX64 src1, OperandX64 src2);
+    void vdivss(OperandX64 dst, OperandX64 src1, OperandX64 src2);
     void vdivps(OperandX64 dst, OperandX64 src1, OperandX64 src2);
 
     void vandps(OperandX64 dst, OperandX64 src1, OperandX64 src2);
     void vandpd(OperandX64 dst, OperandX64 src1, OperandX64 src2);
     void vandnpd(OperandX64 dst, OperandX64 src1, OperandX64 src2);
 
+    void vxorps(OperandX64 dst, OperandX64 src1, OperandX64 src2);
     void vxorpd(OperandX64 dst, OperandX64 src1, OperandX64 src2);
     void vorps(OperandX64 dst, OperandX64 src1, OperandX64 src2);
     void vorpd(OperandX64 dst, OperandX64 src1, OperandX64 src2);
 
     void vucomisd(OperandX64 src1, OperandX64 src2);
+    void vucomiss(OperandX64 src1, OperandX64 src2);
 
     void vcvttsd2si(OperandX64 dst, OperandX64 src);
     void vcvtsi2sd(OperandX64 dst, OperandX64 src1, OperandX64 src2);
@@ -147,6 +152,8 @@ public:
     void vcvtss2sd(OperandX64 dst, OperandX64 src1, OperandX64 src2);
 
     void vroundsd(OperandX64 dst, OperandX64 src1, OperandX64 src2, RoundingModeX64 roundingMode); // inexact
+    void vroundss(OperandX64 dst, OperandX64 src1, OperandX64 src2, RoundingModeX64 roundingMode); // inexact
+    void vroundps(OperandX64 dst, OperandX64 src, RoundingModeX64 roundingMode);                   // inexact
 
     void vsqrtpd(OperandX64 dst, OperandX64 src);
     void vsqrtps(OperandX64 dst, OperandX64 src);
@@ -164,10 +171,13 @@ public:
     void vmovq(OperandX64 lhs, OperandX64 rhs);
 
     void vmaxsd(OperandX64 dst, OperandX64 src1, OperandX64 src2);
+    void vmaxss(OperandX64 dst, OperandX64 src1, OperandX64 src2);
     void vminsd(OperandX64 dst, OperandX64 src1, OperandX64 src2);
+    void vminss(OperandX64 dst, OperandX64 src1, OperandX64 src2);
 
     void vcmpeqsd(OperandX64 dst, OperandX64 src1, OperandX64 src2);
     void vcmpltsd(OperandX64 dst, OperandX64 src1, OperandX64 src2);
+    void vcmpltss(OperandX64 dst, OperandX64 src1, OperandX64 src2);
     void vcmpeqps(OperandX64 dst, OperandX64 src1, OperandX64 src2);
 
     void vblendvps(RegisterX64 dst, RegisterX64 src1, OperandX64 src2, RegisterX64 mask);

--- a/CodeGen/include/Luau/IrData.h
+++ b/CodeGen/include/Luau/IrData.h
@@ -200,6 +200,44 @@ enum class IrCmd : uint8_t
     // A: double
     SIGN_NUM,
 
+    // Add/Sub/Mul/Div/Idiv/Mod two float numbers
+    // A, B: float
+    // In final x64 lowering, B can also be Rn or Kn
+    ADD_FLOAT,
+    SUB_FLOAT,
+    MUL_FLOAT,
+    DIV_FLOAT,
+
+    // Get the minimum/maximum of two numbers
+    // If one of the values is NaN, 'B' is returned as the result
+    // A, B: float
+    MIN_FLOAT,
+    MAX_FLOAT,
+
+    // Negate a float number
+    // A: float
+    UNM_FLOAT,
+
+    // Round number to negative infinity
+    // A: float
+    FLOOR_FLOAT,
+
+    // Round number to positive infinity
+    // A: float
+    CEIL_FLOAT,
+
+    // Get square root of the argument
+    // A: float
+    SQRT_FLOAT,
+
+    // Get absolute value of the argument
+    // A: float
+    ABS_FLOAT,
+
+    // Get the sign of the argument
+    // A: float
+    SIGN_FLOAT,
+
     // Select B if C == D, otherwise select A
     // A, B: double (endpoints)
     // C, D: double (condition arguments)
@@ -222,6 +260,7 @@ enum class IrCmd : uint8_t
     SUB_VEC,
     MUL_VEC,
     DIV_VEC,
+    IDIV_VEC,
     // Lanewise A * B + C
     // A, B, C: TValue
     MULADD_VEC,
@@ -308,6 +347,13 @@ enum class IrCmd : uint8_t
     // E: block (if false)
     JUMP_CMP_NUM,
 
+    // Perform a conditional jump based on the result of float comparison
+    // A, B: float
+    // C: condition
+    // D: block (if true)
+    // E: block (if false)
+    JUMP_CMP_FLOAT,
+
     // Perform jump based on a numerical loop condition (step > 0 ? idx <= limit : limit <= idx)
     // A: double (index)
     // B: double (limit)
@@ -384,7 +430,11 @@ enum class IrCmd : uint8_t
 
     // Converts a double number to a vector with the value in X/Y/Z
     // A: double
-    NUM_TO_VEC,
+    NUM_TO_VEC_DEPRECATED,
+
+    // Converts a float number to a vector with the value in X/Y/Z (use NUM_TO_FLOAT to convert from double)
+    // A: float
+    FLOAT_TO_VEC,
 
     // Adds VECTOR type tag to a vector, preserving X/Y/Z components
     // A: TValue
@@ -536,11 +586,14 @@ enum class IrCmd : uint8_t
     // When undef is specified instead of a block, execution is aborted on check failure
     CHECK_NODE_VALUE,
 
-    // Guard against access at specified offset/size overflowing the buffer length
+    // Guard against access at specified offset with [min, max) range of bytes overflowing the buffer length
+    // When base offset source number is provided, instruction will additionally validate that the integer and double versions of base are exact
     // A: pointer (buffer)
-    // B: int (offset)
-    // C: int (size)
-    // D: block/vmexit/undef
+    // B: int (base offset)
+    // C: int (access range min inclusive)
+    // D: int (access range max exclusive)
+    // E: double/undef (base offset source double)
+    // F: block/vmexit/undef
     // When undef is specified instead of a block, execution is aborted on check failure
     CHECK_BUFFER_LEN,
 

--- a/CodeGen/include/Luau/IrUtils.h
+++ b/CodeGen/include/Luau/IrUtils.h
@@ -33,6 +33,7 @@ inline bool isBlockTerminator(IrCmd cmd)
     case IrCmd::JUMP_CMP_INT:
     case IrCmd::JUMP_EQ_POINTER:
     case IrCmd::JUMP_CMP_NUM:
+    case IrCmd::JUMP_CMP_FLOAT:
     case IrCmd::JUMP_FORN_LOOP_COND:
     case IrCmd::JUMP_SLOT_MATCH:
     case IrCmd::RETURN:
@@ -108,12 +109,25 @@ inline bool hasResult(IrCmd cmd)
     case IrCmd::SQRT_NUM:
     case IrCmd::ABS_NUM:
     case IrCmd::SIGN_NUM:
+    case IrCmd::ADD_FLOAT:
+    case IrCmd::SUB_FLOAT:
+    case IrCmd::MUL_FLOAT:
+    case IrCmd::DIV_FLOAT:
+    case IrCmd::MIN_FLOAT:
+    case IrCmd::MAX_FLOAT:
+    case IrCmd::UNM_FLOAT:
+    case IrCmd::FLOOR_FLOAT:
+    case IrCmd::CEIL_FLOAT:
+    case IrCmd::SQRT_FLOAT:
+    case IrCmd::ABS_FLOAT:
+    case IrCmd::SIGN_FLOAT:
     case IrCmd::SELECT_NUM:
     case IrCmd::SELECT_IF_TRUTHY:
     case IrCmd::ADD_VEC:
     case IrCmd::SUB_VEC:
     case IrCmd::MUL_VEC:
     case IrCmd::DIV_VEC:
+    case IrCmd::IDIV_VEC:
     case IrCmd::UNM_VEC:
     case IrCmd::DOT_VEC:
     case IrCmd::EXTRACT_VEC:
@@ -136,7 +150,8 @@ inline bool hasResult(IrCmd cmd)
     case IrCmd::NUM_TO_UINT:
     case IrCmd::FLOAT_TO_NUM:
     case IrCmd::NUM_TO_FLOAT:
-    case IrCmd::NUM_TO_VEC:
+    case IrCmd::NUM_TO_VEC_DEPRECATED:
+    case IrCmd::FLOAT_TO_VEC:
     case IrCmd::TAG_VECTOR:
     case IrCmd::TRUNCATE_UINT:
     case IrCmd::SUBSTITUTE:

--- a/CodeGen/src/AssemblyBuilderA64.cpp
+++ b/CodeGen/src/AssemblyBuilderA64.cpp
@@ -658,9 +658,13 @@ void AssemblyBuilderA64::fmov(RegisterA64 dst, float src)
 
 void AssemblyBuilderA64::fabs(RegisterA64 dst, RegisterA64 src)
 {
-    CODEGEN_ASSERT(dst.kind == KindA64::d && src.kind == KindA64::d);
+    CODEGEN_ASSERT(dst.kind == src.kind);
+    CODEGEN_ASSERT(dst.kind == KindA64::d || dst.kind == KindA64::s);
 
-    placeR1("fabs", dst, src, 0b000'11110'01'1'0000'01'10000);
+    if (dst.kind == KindA64::d)
+        placeR1("fabs", dst, src, 0b000'11110'01'1'0000'01'10000);
+    else
+        placeR1("fabs", dst, src, 0b000'11110'00'1'0000'01'10000);
 }
 
 void AssemblyBuilderA64::faddp(RegisterA64 dst, RegisterA64 src)
@@ -802,9 +806,13 @@ void AssemblyBuilderA64::fneg(RegisterA64 dst, RegisterA64 src)
 
 void AssemblyBuilderA64::fsqrt(RegisterA64 dst, RegisterA64 src)
 {
-    CODEGEN_ASSERT(dst.kind == KindA64::d && src.kind == KindA64::d);
+    CODEGEN_ASSERT(dst.kind == src.kind);
+    CODEGEN_ASSERT(dst.kind == KindA64::d || dst.kind == KindA64::s);
 
-    placeR1("fsqrt", dst, src, 0b000'11110'01'1'0000'11'10000);
+    if (dst.kind == KindA64::d)
+        placeR1("fsqrt", dst, src, 0b000'11110'01'1'0000'11'10000);
+    else
+        placeR1("fsqrt", dst, src, 0b000'11110'00'1'0000'11'10000);
 }
 
 void AssemblyBuilderA64::fsub(RegisterA64 dst, RegisterA64 src1, RegisterA64 src2)
@@ -939,16 +947,26 @@ void AssemblyBuilderA64::frinta(RegisterA64 dst, RegisterA64 src)
 
 void AssemblyBuilderA64::frintm(RegisterA64 dst, RegisterA64 src)
 {
-    CODEGEN_ASSERT(dst.kind == KindA64::d && src.kind == KindA64::d);
+    CODEGEN_ASSERT(dst.kind == src.kind);
+    CODEGEN_ASSERT(dst.kind == KindA64::d || dst.kind == KindA64::s || dst.kind == KindA64::q);
 
-    placeR1("frintm", dst, src, 0b000'11110'01'1'001'010'10000);
+    if (dst.kind == KindA64::q)
+        placeR1("frintm", dst, src, 0b010'01110'00'1'0000'11001'10);
+    else if (dst.kind == KindA64::d)
+        placeR1("frintm", dst, src, 0b000'11110'01'1'001'010'10000);
+    else
+        placeR1("frintm", dst, src, 0b000'11110'00'1'001'010'10000);
 }
 
 void AssemblyBuilderA64::frintp(RegisterA64 dst, RegisterA64 src)
 {
-    CODEGEN_ASSERT(dst.kind == KindA64::d && src.kind == KindA64::d);
+    CODEGEN_ASSERT(dst.kind == src.kind);
+    CODEGEN_ASSERT(dst.kind == KindA64::d || dst.kind == KindA64::s);
 
-    placeR1("frintp", dst, src, 0b000'11110'01'1'001'001'10000);
+    if (dst.kind == KindA64::d)
+        placeR1("frintp", dst, src, 0b000'11110'01'1'001'001'10000);
+    else
+        placeR1("frintp", dst, src, 0b000'11110'00'1'001'001'10000);
 }
 
 void AssemblyBuilderA64::fcvt(RegisterA64 dst, RegisterA64 src)
@@ -1004,23 +1022,34 @@ void AssemblyBuilderA64::fjcvtzs(RegisterA64 dst, RegisterA64 src)
 
 void AssemblyBuilderA64::fcmp(RegisterA64 src1, RegisterA64 src2)
 {
-    CODEGEN_ASSERT(src1.kind == KindA64::d && src2.kind == KindA64::d);
+    CODEGEN_ASSERT(src1.kind == src2.kind);
+    CODEGEN_ASSERT(src1.kind == KindA64::d || src1.kind == KindA64::s);
 
-    placeFCMP("fcmp", src1, src2, 0b11110'01'1, 0b00);
+    if (src1.kind == KindA64::d)
+        placeFCMP("fcmp", src1, src2, 0b11110'01'1, 0b00);
+    else
+        placeFCMP("fcmp", src1, src2, 0b11110'00'1, 0b00);
 }
 
 void AssemblyBuilderA64::fcmpz(RegisterA64 src)
 {
-    CODEGEN_ASSERT(src.kind == KindA64::d);
+    CODEGEN_ASSERT(src.kind == KindA64::d || src.kind == KindA64::s);
 
-    placeFCMP("fcmp", src, RegisterA64{src.kind, 0}, 0b11110'01'1, 0b01);
+    if (src.kind == KindA64::d)
+        placeFCMP("fcmp", src, RegisterA64{src.kind, 0}, 0b11110'01'1, 0b01);
+    else
+        placeFCMP("fcmp", src, RegisterA64{src.kind, 0}, 0b11110'00'1, 0b01);
 }
 
 void AssemblyBuilderA64::fcsel(RegisterA64 dst, RegisterA64 src1, RegisterA64 src2, ConditionA64 cond)
 {
-    CODEGEN_ASSERT(dst.kind == KindA64::d);
+    CODEGEN_ASSERT(dst.kind == src1.kind && src1.kind == src2.kind);
+    CODEGEN_ASSERT(dst.kind == KindA64::d || dst.kind == KindA64::s);
 
-    placeCS("fcsel", dst, src1, src2, cond, 0b11110'01'1, 0b11);
+    if (src1.kind == KindA64::d)
+        placeCS("fcsel", dst, src1, src2, cond, 0b11110'01'1, 0b11);
+    else
+        placeCS("fcsel", dst, src1, src2, cond, 0b11110'00'1, 0b11);
 }
 
 void AssemblyBuilderA64::udf()

--- a/CodeGen/src/AssemblyBuilderX64.cpp
+++ b/CodeGen/src/AssemblyBuilderX64.cpp
@@ -772,6 +772,11 @@ void AssemblyBuilderX64::vsubsd(OperandX64 dst, OperandX64 src1, OperandX64 src2
     placeAvx("vsubsd", dst, src1, src2, 0x5c, false, AVX_0F, AVX_F2);
 }
 
+void AssemblyBuilderX64::vsubss(OperandX64 dst, OperandX64 src1, OperandX64 src2)
+{
+    placeAvx("vsubss", dst, src1, src2, 0x5c, false, AVX_0F, AVX_F3);
+}
+
 void AssemblyBuilderX64::vsubps(OperandX64 dst, OperandX64 src1, OperandX64 src2)
 {
     placeAvx("vsubps", dst, src1, src2, 0x5c, false, AVX_0F, AVX_NP);
@@ -782,6 +787,11 @@ void AssemblyBuilderX64::vmulsd(OperandX64 dst, OperandX64 src1, OperandX64 src2
     placeAvx("vmulsd", dst, src1, src2, 0x59, false, AVX_0F, AVX_F2);
 }
 
+void AssemblyBuilderX64::vmulss(OperandX64 dst, OperandX64 src1, OperandX64 src2)
+{
+    placeAvx("vmulss", dst, src1, src2, 0x59, false, AVX_0F, AVX_F3);
+}
+
 void AssemblyBuilderX64::vmulps(OperandX64 dst, OperandX64 src1, OperandX64 src2)
 {
     placeAvx("vmulps", dst, src1, src2, 0x59, false, AVX_0F, AVX_NP);
@@ -790,6 +800,11 @@ void AssemblyBuilderX64::vmulps(OperandX64 dst, OperandX64 src1, OperandX64 src2
 void AssemblyBuilderX64::vdivsd(OperandX64 dst, OperandX64 src1, OperandX64 src2)
 {
     placeAvx("vdivsd", dst, src1, src2, 0x5e, false, AVX_0F, AVX_F2);
+}
+
+void AssemblyBuilderX64::vdivss(OperandX64 dst, OperandX64 src1, OperandX64 src2)
+{
+    placeAvx("vdivss", dst, src1, src2, 0x5e, false, AVX_0F, AVX_F3);
 }
 
 void AssemblyBuilderX64::vdivps(OperandX64 dst, OperandX64 src1, OperandX64 src2)
@@ -812,6 +827,11 @@ void AssemblyBuilderX64::vandnpd(OperandX64 dst, OperandX64 src1, OperandX64 src
     placeAvx("vandnpd", dst, src1, src2, 0x55, false, AVX_0F, AVX_66);
 }
 
+void AssemblyBuilderX64::vxorps(OperandX64 dst, OperandX64 src1, OperandX64 src2)
+{
+    placeAvx("vxorps", dst, src1, src2, 0x57, false, AVX_0F, AVX_NP);
+}
+
 void AssemblyBuilderX64::vxorpd(OperandX64 dst, OperandX64 src1, OperandX64 src2)
 {
     placeAvx("vxorpd", dst, src1, src2, 0x57, false, AVX_0F, AVX_66);
@@ -830,6 +850,11 @@ void AssemblyBuilderX64::vorpd(OperandX64 dst, OperandX64 src1, OperandX64 src2)
 void AssemblyBuilderX64::vucomisd(OperandX64 src1, OperandX64 src2)
 {
     placeAvx("vucomisd", src1, src2, 0x2e, false, AVX_0F, AVX_66);
+}
+
+void AssemblyBuilderX64::vucomiss(OperandX64 src1, OperandX64 src2)
+{
+    placeAvx("vucomiss", src1, src2, 0x2e, false, AVX_0F, AVX_NP);
 }
 
 void AssemblyBuilderX64::vcvttsd2si(OperandX64 dst, OperandX64 src)
@@ -865,6 +890,25 @@ void AssemblyBuilderX64::vcvtss2sd(OperandX64 dst, OperandX64 src1, OperandX64 s
 void AssemblyBuilderX64::vroundsd(OperandX64 dst, OperandX64 src1, OperandX64 src2, RoundingModeX64 roundingMode)
 {
     placeAvx("vroundsd", dst, src1, src2, uint8_t(roundingMode) | kRoundingPrecisionInexact, 0x0b, false, AVX_0F3A, AVX_66);
+}
+
+void AssemblyBuilderX64::vroundss(OperandX64 dst, OperandX64 src1, OperandX64 src2, RoundingModeX64 roundingMode)
+{
+    placeAvx("vroundss", dst, src1, src2, uint8_t(roundingMode) | kRoundingPrecisionInexact, 0x0a, false, AVX_0F3A, AVX_66);
+}
+
+void AssemblyBuilderX64::vroundps(OperandX64 dst, OperandX64 src, RoundingModeX64 roundingMode)
+{
+    // 'placeAvx' wrapper doesn't have an overload for this archetype (opcode r/m, reg, imm8)
+    if (logText)
+        log("vroundps", dst, src, uint8_t(roundingMode) | kRoundingPrecisionInexact);
+
+    placeVex(dst, noreg, src, false, AVX_0F3A, AVX_66);
+    place(0x08);
+    placeRegAndModRegMem(dst, src, /*extraCodeBytes=*/1);
+    placeImm8(uint8_t(roundingMode) | kRoundingPrecisionInexact);
+
+    commit();
 }
 
 void AssemblyBuilderX64::vsqrtpd(OperandX64 dst, OperandX64 src)
@@ -952,9 +996,19 @@ void AssemblyBuilderX64::vmaxsd(OperandX64 dst, OperandX64 src1, OperandX64 src2
     placeAvx("vmaxsd", dst, src1, src2, 0x5f, false, AVX_0F, AVX_F2);
 }
 
+void AssemblyBuilderX64::vmaxss(OperandX64 dst, OperandX64 src1, OperandX64 src2)
+{
+    placeAvx("vmaxss", dst, src1, src2, 0x5f, false, AVX_0F, AVX_F3);
+}
+
 void AssemblyBuilderX64::vminsd(OperandX64 dst, OperandX64 src1, OperandX64 src2)
 {
     placeAvx("vminsd", dst, src1, src2, 0x5d, false, AVX_0F, AVX_F2);
+}
+
+void AssemblyBuilderX64::vminss(OperandX64 dst, OperandX64 src1, OperandX64 src2)
+{
+    placeAvx("vminss", dst, src1, src2, 0x5d, false, AVX_0F, AVX_F3);
 }
 
 void AssemblyBuilderX64::vcmpeqsd(OperandX64 dst, OperandX64 src1, OperandX64 src2)
@@ -965,6 +1019,11 @@ void AssemblyBuilderX64::vcmpeqsd(OperandX64 dst, OperandX64 src1, OperandX64 sr
 void AssemblyBuilderX64::vcmpltsd(OperandX64 dst, OperandX64 src1, OperandX64 src2)
 {
     placeAvx("vcmpltsd", dst, src1, src2, 0x01, 0xc2, false, AVX_0F, AVX_F2);
+}
+
+void AssemblyBuilderX64::vcmpltss(OperandX64 dst, OperandX64 src1, OperandX64 src2)
+{
+    placeAvx("vcmpltss", dst, src1, src2, 0x01, 0xc2, false, AVX_0F, AVX_F3);
 }
 
 void AssemblyBuilderX64::vcmpeqps(OperandX64 dst, OperandX64 src1, OperandX64 src2)

--- a/CodeGen/src/CodeGenA64.cpp
+++ b/CodeGen/src/CodeGenA64.cpp
@@ -85,7 +85,7 @@ static void emitInterrupt(AssemblyBuilderA64& build)
     // note: recomputing this avoids having to stash x0
     build.ldr(x1, mem(rState, offsetof(lua_State, ci)));
     build.ldr(x0, mem(x1, offsetof(CallInfo, savedpc)));
-    build.sub(x0, x0, sizeof(Instruction));
+    build.sub(x0, x0, uint16_t(sizeof(Instruction)));
     build.str(x0, mem(x1, offsetof(CallInfo, savedpc)));
 
     emitExit(build, /* continueInVm */ false);
@@ -145,14 +145,14 @@ void emitReturn(AssemblyBuilderA64& build, ModuleHelpers& helpers)
 
     Label repeatNilLoop = build.setLabel();
     build.str(w4, mem(x1, offsetof(TValue, tt)));
-    build.add(x1, x1, sizeof(TValue));
-    build.sub(w2, w2, 1);
+    build.add(x1, x1, uint16_t(sizeof(TValue)));
+    build.sub(w2, w2, uint16_t(1));
     build.cbnz(w2, repeatNilLoop);
 
     build.setLabel(skipResultCopy);
 
     // x2 = cip = ci - 1
-    build.sub(x2, x0, sizeof(CallInfo));
+    build.sub(x2, x0, uint16_t(sizeof(CallInfo)));
 
     // res = cip->top when nresults >= 0
     Label skipFixedRetTop;
@@ -218,7 +218,7 @@ static EntryLocations buildEntryFunction(AssemblyBuilderA64& build, UnwindBuilde
     locations.start = build.setLabel();
 
     // prologue
-    build.sub(sp, sp, kStackSize);
+    build.sub(sp, sp, uint16_t(kStackSize));
     build.stp(x29, x30, mem(sp)); // fp, lr
 
     // stash non-volatile registers used for execution environment
@@ -259,7 +259,7 @@ static EntryLocations buildEntryFunction(AssemblyBuilderA64& build, UnwindBuilde
     build.ldp(x21, x22, mem(sp, 32));
     build.ldp(x19, x20, mem(sp, 16));
     build.ldp(x29, x30, mem(sp)); // fp, lr
-    build.add(sp, sp, kStackSize);
+    build.add(sp, sp, uint16_t(kStackSize));
 
     build.ret();
 

--- a/CodeGen/src/EmitCommonX64.h
+++ b/CodeGen/src/EmitCommonX64.h
@@ -197,7 +197,7 @@ inline void jumpIfTruthy(AssemblyBuilderX64& build, int ri, Label& target, Label
     build.jcc(ConditionX64::NotEqual, target); // true if boolean value is 'true'
 }
 
-void jumpOnNumberCmp(AssemblyBuilderX64& build, RegisterX64 tmp, OperandX64 lhs, OperandX64 rhs, IrCondition cond, Label& label);
+void jumpOnNumberCmp(AssemblyBuilderX64& build, RegisterX64 tmp, OperandX64 lhs, OperandX64 rhs, IrCondition cond, Label& label, bool floatPrecision);
 
 ConditionX64 getConditionInt(IrCondition cond);
 

--- a/CodeGen/src/IrAnalysis.cpp
+++ b/CodeGen/src/IrAnalysis.cpp
@@ -64,7 +64,7 @@ void updateLastUseLocations(IrFunction& function, const std::vector<uint32_t>& s
     std::vector<IrInst>& instructions = function.instructions;
 
 #if defined(LUAU_ASSERTENABLED)
-    // Last use assignements should be called only once
+    // Last use assignments should be called only once
     for (IrInst& inst : instructions)
         CODEGEN_ASSERT(inst.lastUse == 0);
 #endif

--- a/CodeGen/src/IrDump.cpp
+++ b/CodeGen/src/IrDump.cpp
@@ -171,6 +171,30 @@ const char* getCmdName(IrCmd cmd)
         return "ABS_NUM";
     case IrCmd::SIGN_NUM:
         return "SIGN_NUM";
+    case IrCmd::ADD_FLOAT:
+        return "ADD_FLOAT";
+    case IrCmd::SUB_FLOAT:
+        return "SUB_FLOAT";
+    case IrCmd::MUL_FLOAT:
+        return "MUL_FLOAT";
+    case IrCmd::DIV_FLOAT:
+        return "DIV_FLOAT";
+    case IrCmd::MIN_FLOAT:
+        return "MIN_FLOAT";
+    case IrCmd::MAX_FLOAT:
+        return "MAX_FLOAT";
+    case IrCmd::UNM_FLOAT:
+        return "UNM_FLOAT";
+    case IrCmd::FLOOR_FLOAT:
+        return "FLOOR_FLOAT";
+    case IrCmd::CEIL_FLOAT:
+        return "CEIL_FLOAT";
+    case IrCmd::SQRT_FLOAT:
+        return "SQRT_FLOAT";
+    case IrCmd::ABS_FLOAT:
+        return "ABS_FLOAT";
+    case IrCmd::SIGN_FLOAT:
+        return "SIGN_FLOAT";
     case IrCmd::SELECT_NUM:
         return "SELECT_NUM";
     case IrCmd::MULADD_NUM:
@@ -187,6 +211,8 @@ const char* getCmdName(IrCmd cmd)
         return "MUL_VEC";
     case IrCmd::DIV_VEC:
         return "DIV_VEC";
+    case IrCmd::IDIV_VEC:
+        return "IDIV_VEC";
     case IrCmd::MULADD_VEC:
         return "MULADD_VEC";
     case IrCmd::UNM_VEC:
@@ -219,6 +245,8 @@ const char* getCmdName(IrCmd cmd)
         return "JUMP_EQ_POINTER";
     case IrCmd::JUMP_CMP_NUM:
         return "JUMP_CMP_NUM";
+    case IrCmd::JUMP_CMP_FLOAT:
+        return "JUMP_CMP_FLOAT";
     case IrCmd::JUMP_FORN_LOOP_COND:
         return "JUMP_FORN_LOOP_COND";
     case IrCmd::JUMP_SLOT_MATCH:
@@ -251,8 +279,10 @@ const char* getCmdName(IrCmd cmd)
         return "FLOAT_TO_NUM";
     case IrCmd::NUM_TO_FLOAT:
         return "NUM_TO_FLOAT";
-    case IrCmd::NUM_TO_VEC:
+    case IrCmd::NUM_TO_VEC_DEPRECATED:
         return "NUM_TO_VEC";
+    case IrCmd::FLOAT_TO_VEC:
+        return "FLOAT_TO_VEC";
     case IrCmd::TAG_VECTOR:
         return "TAG_VECTOR";
     case IrCmd::TRUNCATE_UINT:

--- a/CodeGen/src/IrLoweringX64.h
+++ b/CodeGen/src/IrLoweringX64.h
@@ -49,6 +49,7 @@ struct IrLoweringX64
 
     // Operand data lookup helpers
     OperandX64 memRegDoubleOp(IrOp op);
+    OperandX64 memRegFloatOp(IrOp op);
     OperandX64 memRegUintOp(IrOp op);
     OperandX64 memRegTagOp(IrOp op);
     RegisterX64 regOp(IrOp op);

--- a/CodeGen/src/IrTranslateBuiltins.cpp
+++ b/CodeGen/src/IrTranslateBuiltins.cpp
@@ -9,6 +9,11 @@
 #include <math.h>
 
 LUAU_FASTFLAGVARIABLE(LuauCodegenSplitFloat)
+LUAU_FASTFLAGVARIABLE(LuauCodegenFloatOps)
+LUAU_FASTFLAGVARIABLE(LuauCodegenSplitFloatExtra)
+LUAU_FASTFLAGVARIABLE(LuauCodegenVectorCreateXy)
+LUAU_FASTFLAG(LuauCodegenNumIntFolds2)
+LUAU_FASTFLAG(LuauCodegenBufferRangeMerge)
 
 // TODO: when nresults is less than our actual result count, we can skip computing/writing unused results
 
@@ -297,13 +302,26 @@ static BuiltinImplResult translateBuiltinVectorLerp(IrBuilder& build, int nparam
     IrOp b = build.inst(IrCmd::LOAD_TVALUE, args);
     IrOp t = builtinLoadDouble(build, arg3);
 
-    IrOp tvec = build.inst(IrCmd::NUM_TO_VEC, t);
-    IrOp one = build.inst(IrCmd::NUM_TO_VEC, build.constDouble(1.0));
-    IrOp diff = build.inst(IrCmd::SUB_VEC, b, a);
+    if (FFlag::LuauCodegenSplitFloat && FFlag::LuauCodegenSplitFloatExtra)
+    {
+        IrOp tvec = build.inst(IrCmd::FLOAT_TO_VEC, build.inst(IrCmd::NUM_TO_FLOAT, t));
+        IrOp one = build.inst(IrCmd::FLOAT_TO_VEC, build.constDouble(1.0));
+        IrOp diff = build.inst(IrCmd::SUB_VEC, b, a);
 
-    IrOp res = build.inst(IrCmd::MULADD_VEC, diff, tvec, a);
-    IrOp ret = build.inst(IrCmd::SELECT_VEC, res, b, tvec, one);
-    build.inst(IrCmd::STORE_TVALUE, build.vmReg(ra), build.inst(IrCmd::TAG_VECTOR, ret));
+        IrOp res = build.inst(IrCmd::MULADD_VEC, diff, tvec, a);
+        IrOp ret = build.inst(IrCmd::SELECT_VEC, res, b, tvec, one);
+        build.inst(IrCmd::STORE_TVALUE, build.vmReg(ra), build.inst(IrCmd::TAG_VECTOR, ret));
+    }
+    else
+    {
+        IrOp tvec = build.inst(IrCmd::NUM_TO_VEC_DEPRECATED, t);
+        IrOp one = build.inst(IrCmd::NUM_TO_VEC_DEPRECATED, build.constDouble(1.0));
+        IrOp diff = build.inst(IrCmd::SUB_VEC, b, a);
+
+        IrOp res = build.inst(IrCmd::MULADD_VEC, diff, tvec, a);
+        IrOp ret = build.inst(IrCmd::SELECT_VEC, res, b, tvec, one);
+        build.inst(IrCmd::STORE_TVALUE, build.vmReg(ra), build.inst(IrCmd::TAG_VECTOR, ret));
+    }
 
     return {BuiltinImplType::Full, 1};
 }
@@ -782,30 +800,63 @@ static BuiltinImplResult translateBuiltinBit32Replace(
 
 static BuiltinImplResult translateBuiltinVector(IrBuilder& build, int nparams, int ra, int arg, IrOp args, IrOp arg3, int nresults, int pcpos)
 {
-    if (nparams < 3 || nresults > 1)
-        return {BuiltinImplType::None, -1};
-
-    CODEGEN_ASSERT(LUA_VECTOR_SIZE == 3);
-
-    builtinCheckDouble(build, build.vmReg(arg), pcpos);
-    builtinCheckDouble(build, args, pcpos);
-    builtinCheckDouble(build, arg3, pcpos);
-
-    IrOp x = builtinLoadDouble(build, build.vmReg(arg));
-    IrOp y = builtinLoadDouble(build, args);
-    IrOp z = builtinLoadDouble(build, arg3);
-
-    if (FFlag::LuauCodegenSplitFloat)
+    if (FFlag::LuauCodegenVectorCreateXy)
     {
-        IrOp xf = build.inst(IrCmd::NUM_TO_FLOAT, x);
-        IrOp yf = build.inst(IrCmd::NUM_TO_FLOAT, y);
-        IrOp zf = build.inst(IrCmd::NUM_TO_FLOAT, z);
-
-        build.inst(IrCmd::STORE_VECTOR, build.vmReg(ra), xf, yf, zf);
+        if (nparams < 2 || nresults > 1)
+            return {BuiltinImplType::None, -1};
     }
     else
     {
-        build.inst(IrCmd::STORE_VECTOR, build.vmReg(ra), x, y, z);
+        if (nparams < 3 || nresults > 1)
+            return {BuiltinImplType::None, -1};
+    }
+
+    CODEGEN_ASSERT(LUA_VECTOR_SIZE == 3);
+
+    if (nparams == 2)
+    {
+        CODEGEN_ASSERT(FFlag::LuauCodegenVectorCreateXy);
+
+        builtinCheckDouble(build, build.vmReg(arg), pcpos);
+        builtinCheckDouble(build, args, pcpos);
+
+        IrOp x = builtinLoadDouble(build, build.vmReg(arg));
+        IrOp y = builtinLoadDouble(build, args);
+
+        if (FFlag::LuauCodegenSplitFloat)
+        {
+            IrOp xf = build.inst(IrCmd::NUM_TO_FLOAT, x);
+            IrOp yf = build.inst(IrCmd::NUM_TO_FLOAT, y);
+
+            build.inst(IrCmd::STORE_VECTOR, build.vmReg(ra), xf, yf, build.constDouble(0.0));
+        }
+        else
+        {
+            build.inst(IrCmd::STORE_VECTOR, build.vmReg(ra), x, y, build.constDouble(0.0));
+        }
+    }
+    else
+    {
+        builtinCheckDouble(build, build.vmReg(arg), pcpos);
+        builtinCheckDouble(build, args, pcpos);
+        builtinCheckDouble(build, arg3, pcpos);
+
+        IrOp x = builtinLoadDouble(build, build.vmReg(arg));
+        IrOp y = builtinLoadDouble(build, args);
+        IrOp z = builtinLoadDouble(build, arg3);
+
+        if (FFlag::LuauCodegenSplitFloat)
+        {
+            IrOp xf = build.inst(IrCmd::NUM_TO_FLOAT, x);
+            IrOp yf = build.inst(IrCmd::NUM_TO_FLOAT, y);
+            IrOp zf = build.inst(IrCmd::NUM_TO_FLOAT, z);
+
+            build.inst(IrCmd::STORE_VECTOR, build.vmReg(ra), xf, yf, zf);
+        }
+        else
+        {
+            build.inst(IrCmd::STORE_VECTOR, build.vmReg(ra), x, y, z);
+        }
     }
 
     build.inst(IrCmd::STORE_TAG, build.vmReg(ra), build.constTag(LUA_TVECTOR));
@@ -890,7 +941,10 @@ static void translateBufferArgsAndCheckBounds(
     IrOp numIndex = builtinLoadDouble(build, args);
     intIndex = build.inst(IrCmd::NUM_TO_INT, numIndex);
 
-    build.inst(IrCmd::CHECK_BUFFER_LEN, buf, intIndex, build.constInt(size), build.vmExit(pcpos));
+    if (FFlag::LuauCodegenBufferRangeMerge && FFlag::LuauCodegenNumIntFolds2)
+        build.inst(IrCmd::CHECK_BUFFER_LEN, buf, intIndex, build.constInt(0), build.constInt(size), build.undef(), build.vmExit(pcpos));
+    else
+        build.inst(IrCmd::CHECK_BUFFER_LEN, buf, intIndex, build.constInt(size), build.vmExit(pcpos));
 }
 
 static BuiltinImplResult translateBuiltinBufferRead(
@@ -968,13 +1022,25 @@ static BuiltinImplResult translateBuiltinVectorMagnitude(
 
     IrOp sum = build.inst(IrCmd::DOT_VEC, a, a);
 
-    if (FFlag::LuauCodegenSplitFloat)
-        sum = build.inst(IrCmd::FLOAT_TO_NUM, sum);
+    if (FFlag::LuauCodegenFloatOps && FFlag::LuauCodegenSplitFloat)
+    {
+        IrOp mag = build.inst(IrCmd::SQRT_FLOAT, sum);
 
-    IrOp mag = build.inst(IrCmd::SQRT_NUM, sum);
+        mag = build.inst(IrCmd::FLOAT_TO_NUM, mag);
 
-    build.inst(IrCmd::STORE_DOUBLE, build.vmReg(ra), mag);
-    build.inst(IrCmd::STORE_TAG, build.vmReg(ra), build.constTag(LUA_TNUMBER));
+        build.inst(IrCmd::STORE_DOUBLE, build.vmReg(ra), mag);
+        build.inst(IrCmd::STORE_TAG, build.vmReg(ra), build.constTag(LUA_TNUMBER));
+    }
+    else
+    {
+        if (FFlag::LuauCodegenSplitFloat)
+            sum = build.inst(IrCmd::FLOAT_TO_NUM, sum);
+
+        IrOp mag = build.inst(IrCmd::SQRT_NUM, sum);
+
+        build.inst(IrCmd::STORE_DOUBLE, build.vmReg(ra), mag);
+        build.inst(IrCmd::STORE_TAG, build.vmReg(ra), build.constTag(LUA_TNUMBER));
+    }
 
     return {BuiltinImplType::Full, 1};
 }
@@ -1000,18 +1066,33 @@ static BuiltinImplResult translateBuiltinVectorNormalize(
     IrOp a = build.inst(IrCmd::LOAD_TVALUE, arg1, build.constInt(0));
     IrOp sum = build.inst(IrCmd::DOT_VEC, a, a);
 
-    if (FFlag::LuauCodegenSplitFloat)
-        sum = build.inst(IrCmd::FLOAT_TO_NUM, sum);
+    if (FFlag::LuauCodegenFloatOps && FFlag::LuauCodegenSplitFloat)
+    {
+        IrOp mag = build.inst(IrCmd::SQRT_FLOAT, sum);
+        IrOp inv = build.inst(IrCmd::DIV_FLOAT, build.constDouble(1.0f), mag);
+        IrOp invvec = build.inst(IrCmd::FLOAT_TO_VEC, inv);
 
-    IrOp mag = build.inst(IrCmd::SQRT_NUM, sum);
-    IrOp inv = build.inst(IrCmd::DIV_NUM, build.constDouble(1.0), mag);
-    IrOp invvec = build.inst(IrCmd::NUM_TO_VEC, inv);
+        IrOp result = build.inst(IrCmd::MUL_VEC, a, invvec);
 
-    IrOp result = build.inst(IrCmd::MUL_VEC, a, invvec);
+        result = build.inst(IrCmd::TAG_VECTOR, result);
 
-    result = build.inst(IrCmd::TAG_VECTOR, result);
+        build.inst(IrCmd::STORE_TVALUE, build.vmReg(ra), result);
+    }
+    else
+    {
+        if (FFlag::LuauCodegenSplitFloat)
+            sum = build.inst(IrCmd::FLOAT_TO_NUM, sum);
 
-    build.inst(IrCmd::STORE_TVALUE, build.vmReg(ra), result);
+        IrOp mag = build.inst(IrCmd::SQRT_NUM, sum);
+        IrOp inv = build.inst(IrCmd::DIV_NUM, build.constDouble(1.0), mag);
+        IrOp invvec = build.inst(IrCmd::NUM_TO_VEC_DEPRECATED, inv);
+
+        IrOp result = build.inst(IrCmd::MUL_VEC, a, invvec);
+
+        result = build.inst(IrCmd::TAG_VECTOR, result);
+
+        build.inst(IrCmd::STORE_TVALUE, build.vmReg(ra), result);
+    }
 
     return {BuiltinImplType::Full, 1};
 }
@@ -1035,39 +1116,59 @@ static BuiltinImplResult translateBuiltinVectorCross(IrBuilder& build, int npara
     IrOp z1 = build.inst(IrCmd::LOAD_FLOAT, arg1, build.constInt(8));
     IrOp z2 = build.inst(IrCmd::LOAD_FLOAT, args, build.constInt(8));
 
-    if (FFlag::LuauCodegenSplitFloat)
+    if (FFlag::LuauCodegenFloatOps && FFlag::LuauCodegenSplitFloat)
     {
-        x1 = build.inst(IrCmd::FLOAT_TO_NUM, x1);
-        x2 = build.inst(IrCmd::FLOAT_TO_NUM, x2);
+        IrOp y1z2 = build.inst(IrCmd::MUL_FLOAT, y1, z2);
+        IrOp z1y2 = build.inst(IrCmd::MUL_FLOAT, z1, y2);
+        IrOp xr = build.inst(IrCmd::SUB_FLOAT, y1z2, z1y2);
 
-        y1 = build.inst(IrCmd::FLOAT_TO_NUM, y1);
-        y2 = build.inst(IrCmd::FLOAT_TO_NUM, y2);
+        IrOp z1x2 = build.inst(IrCmd::MUL_FLOAT, z1, x2);
+        IrOp x1z2 = build.inst(IrCmd::MUL_FLOAT, x1, z2);
+        IrOp yr = build.inst(IrCmd::SUB_FLOAT, z1x2, x1z2);
 
-        z1 = build.inst(IrCmd::FLOAT_TO_NUM, z1);
-        z2 = build.inst(IrCmd::FLOAT_TO_NUM, z2);
+        IrOp x1y2 = build.inst(IrCmd::MUL_FLOAT, x1, y2);
+        IrOp y1x2 = build.inst(IrCmd::MUL_FLOAT, y1, x2);
+        IrOp zr = build.inst(IrCmd::SUB_FLOAT, x1y2, y1x2);
+
+        build.inst(IrCmd::STORE_VECTOR, build.vmReg(ra), xr, yr, zr);
+        build.inst(IrCmd::STORE_TAG, build.vmReg(ra), build.constTag(LUA_TVECTOR));
     }
-
-    IrOp y1z2 = build.inst(IrCmd::MUL_NUM, y1, z2);
-    IrOp z1y2 = build.inst(IrCmd::MUL_NUM, z1, y2);
-    IrOp xr = build.inst(IrCmd::SUB_NUM, y1z2, z1y2);
-
-    IrOp z1x2 = build.inst(IrCmd::MUL_NUM, z1, x2);
-    IrOp x1z2 = build.inst(IrCmd::MUL_NUM, x1, z2);
-    IrOp yr = build.inst(IrCmd::SUB_NUM, z1x2, x1z2);
-
-    IrOp x1y2 = build.inst(IrCmd::MUL_NUM, x1, y2);
-    IrOp y1x2 = build.inst(IrCmd::MUL_NUM, y1, x2);
-    IrOp zr = build.inst(IrCmd::SUB_NUM, x1y2, y1x2);
-
-    if (FFlag::LuauCodegenSplitFloat)
+    else
     {
-        xr = build.inst(IrCmd::NUM_TO_FLOAT, xr);
-        yr = build.inst(IrCmd::NUM_TO_FLOAT, yr);
-        zr = build.inst(IrCmd::NUM_TO_FLOAT, zr);
-    }
+        if (FFlag::LuauCodegenSplitFloat)
+        {
+            x1 = build.inst(IrCmd::FLOAT_TO_NUM, x1);
+            x2 = build.inst(IrCmd::FLOAT_TO_NUM, x2);
 
-    build.inst(IrCmd::STORE_VECTOR, build.vmReg(ra), xr, yr, zr);
-    build.inst(IrCmd::STORE_TAG, build.vmReg(ra), build.constTag(LUA_TVECTOR));
+            y1 = build.inst(IrCmd::FLOAT_TO_NUM, y1);
+            y2 = build.inst(IrCmd::FLOAT_TO_NUM, y2);
+
+            z1 = build.inst(IrCmd::FLOAT_TO_NUM, z1);
+            z2 = build.inst(IrCmd::FLOAT_TO_NUM, z2);
+        }
+
+        IrOp y1z2 = build.inst(IrCmd::MUL_NUM, y1, z2);
+        IrOp z1y2 = build.inst(IrCmd::MUL_NUM, z1, y2);
+        IrOp xr = build.inst(IrCmd::SUB_NUM, y1z2, z1y2);
+
+        IrOp z1x2 = build.inst(IrCmd::MUL_NUM, z1, x2);
+        IrOp x1z2 = build.inst(IrCmd::MUL_NUM, x1, z2);
+        IrOp yr = build.inst(IrCmd::SUB_NUM, z1x2, x1z2);
+
+        IrOp x1y2 = build.inst(IrCmd::MUL_NUM, x1, y2);
+        IrOp y1x2 = build.inst(IrCmd::MUL_NUM, y1, x2);
+        IrOp zr = build.inst(IrCmd::SUB_NUM, x1y2, y1x2);
+
+        if (FFlag::LuauCodegenSplitFloat)
+        {
+            xr = build.inst(IrCmd::NUM_TO_FLOAT, xr);
+            yr = build.inst(IrCmd::NUM_TO_FLOAT, yr);
+            zr = build.inst(IrCmd::NUM_TO_FLOAT, zr);
+        }
+
+        build.inst(IrCmd::STORE_VECTOR, build.vmReg(ra), xr, yr, zr);
+        build.inst(IrCmd::STORE_TAG, build.vmReg(ra), build.constTag(LUA_TVECTOR));
+    }
 
     return {BuiltinImplType::Full, 1};
 }
@@ -1119,7 +1220,7 @@ static BuiltinImplResult translateBuiltinVectorMap1(
     IrOp y1 = build.inst(IrCmd::LOAD_FLOAT, arg1, build.constInt(4));
     IrOp z1 = build.inst(IrCmd::LOAD_FLOAT, arg1, build.constInt(8));
 
-    if (FFlag::LuauCodegenSplitFloat)
+    if (FFlag::LuauCodegenSplitFloat && !FFlag::LuauCodegenFloatOps)
     {
         x1 = build.inst(IrCmd::FLOAT_TO_NUM, x1);
         y1 = build.inst(IrCmd::FLOAT_TO_NUM, y1);
@@ -1130,7 +1231,7 @@ static BuiltinImplResult translateBuiltinVectorMap1(
     IrOp yr = build.inst(cmd, y1);
     IrOp zr = build.inst(cmd, z1);
 
-    if (FFlag::LuauCodegenSplitFloat)
+    if (FFlag::LuauCodegenSplitFloat && !FFlag::LuauCodegenFloatOps)
     {
         xr = build.inst(IrCmd::NUM_TO_FLOAT, xr);
         yr = build.inst(IrCmd::NUM_TO_FLOAT, yr);
@@ -1172,65 +1273,102 @@ static BuiltinImplResult translateBuiltinVectorClamp(
     IrOp xmin = build.inst(IrCmd::LOAD_FLOAT, args, build.constInt(0));
     IrOp xmax = build.inst(IrCmd::LOAD_FLOAT, arg3, build.constInt(0));
 
-    if (FFlag::LuauCodegenSplitFloat)
+    if (FFlag::LuauCodegenFloatOps && FFlag::LuauCodegenSplitFloat)
     {
-        x = build.inst(IrCmd::FLOAT_TO_NUM, x);
-        xmin = build.inst(IrCmd::FLOAT_TO_NUM, xmin);
-        xmax = build.inst(IrCmd::FLOAT_TO_NUM, xmax);
+        build.inst(IrCmd::JUMP_CMP_FLOAT, xmin, xmax, build.cond(IrCondition::NotLessEqual), fallback, block1);
+
+        build.beginBlock(block1);
+
+        IrOp y = build.inst(IrCmd::LOAD_FLOAT, arg1, build.constInt(4));
+        IrOp ymin = build.inst(IrCmd::LOAD_FLOAT, args, build.constInt(4));
+        IrOp ymax = build.inst(IrCmd::LOAD_FLOAT, arg3, build.constInt(4));
+
+        build.inst(IrCmd::JUMP_CMP_FLOAT, ymin, ymax, build.cond(IrCondition::NotLessEqual), fallback, block2);
+
+        build.beginBlock(block2);
+
+        IrOp z = build.inst(IrCmd::LOAD_FLOAT, arg1, build.constInt(8));
+        IrOp zmin = build.inst(IrCmd::LOAD_FLOAT, args, build.constInt(8));
+        IrOp zmax = build.inst(IrCmd::LOAD_FLOAT, arg3, build.constInt(8));
+
+        build.inst(IrCmd::JUMP_CMP_FLOAT, zmin, zmax, build.cond(IrCondition::NotLessEqual), fallback, block3);
+
+        build.beginBlock(block3);
+
+        IrOp xtemp = build.inst(IrCmd::MAX_FLOAT, xmin, x);
+        IrOp xclamped = build.inst(IrCmd::MIN_FLOAT, xmax, xtemp);
+
+        IrOp ytemp = build.inst(IrCmd::MAX_FLOAT, ymin, y);
+        IrOp yclamped = build.inst(IrCmd::MIN_FLOAT, ymax, ytemp);
+
+        IrOp ztemp = build.inst(IrCmd::MAX_FLOAT, zmin, z);
+        IrOp zclamped = build.inst(IrCmd::MIN_FLOAT, zmax, ztemp);
+
+        build.inst(IrCmd::STORE_VECTOR, build.vmReg(ra), xclamped, yclamped, zclamped);
+        build.inst(IrCmd::STORE_TAG, build.vmReg(ra), build.constTag(LUA_TVECTOR));
     }
-
-    build.inst(IrCmd::JUMP_CMP_NUM, xmin, xmax, build.cond(IrCondition::NotLessEqual), fallback, block1);
-
-    build.beginBlock(block1);
-
-    IrOp y = build.inst(IrCmd::LOAD_FLOAT, arg1, build.constInt(4));
-    IrOp ymin = build.inst(IrCmd::LOAD_FLOAT, args, build.constInt(4));
-    IrOp ymax = build.inst(IrCmd::LOAD_FLOAT, arg3, build.constInt(4));
-
-    if (FFlag::LuauCodegenSplitFloat)
+    else
     {
-        y = build.inst(IrCmd::FLOAT_TO_NUM, y);
-        ymin = build.inst(IrCmd::FLOAT_TO_NUM, ymin);
-        ymax = build.inst(IrCmd::FLOAT_TO_NUM, ymax);
+        if (FFlag::LuauCodegenSplitFloat)
+        {
+            x = build.inst(IrCmd::FLOAT_TO_NUM, x);
+            xmin = build.inst(IrCmd::FLOAT_TO_NUM, xmin);
+            xmax = build.inst(IrCmd::FLOAT_TO_NUM, xmax);
+        }
+
+        build.inst(IrCmd::JUMP_CMP_NUM, xmin, xmax, build.cond(IrCondition::NotLessEqual), fallback, block1);
+
+        build.beginBlock(block1);
+
+        IrOp y = build.inst(IrCmd::LOAD_FLOAT, arg1, build.constInt(4));
+        IrOp ymin = build.inst(IrCmd::LOAD_FLOAT, args, build.constInt(4));
+        IrOp ymax = build.inst(IrCmd::LOAD_FLOAT, arg3, build.constInt(4));
+
+        if (FFlag::LuauCodegenSplitFloat)
+        {
+            y = build.inst(IrCmd::FLOAT_TO_NUM, y);
+            ymin = build.inst(IrCmd::FLOAT_TO_NUM, ymin);
+            ymax = build.inst(IrCmd::FLOAT_TO_NUM, ymax);
+        }
+
+        build.inst(IrCmd::JUMP_CMP_NUM, ymin, ymax, build.cond(IrCondition::NotLessEqual), fallback, block2);
+
+        build.beginBlock(block2);
+
+        IrOp z = build.inst(IrCmd::LOAD_FLOAT, arg1, build.constInt(8));
+        IrOp zmin = build.inst(IrCmd::LOAD_FLOAT, args, build.constInt(8));
+        IrOp zmax = build.inst(IrCmd::LOAD_FLOAT, arg3, build.constInt(8));
+
+        if (FFlag::LuauCodegenSplitFloat)
+        {
+            z = build.inst(IrCmd::FLOAT_TO_NUM, z);
+            zmin = build.inst(IrCmd::FLOAT_TO_NUM, zmin);
+            zmax = build.inst(IrCmd::FLOAT_TO_NUM, zmax);
+        }
+
+        build.inst(IrCmd::JUMP_CMP_NUM, zmin, zmax, build.cond(IrCondition::NotLessEqual), fallback, block3);
+
+        build.beginBlock(block3);
+
+        IrOp xtemp = build.inst(IrCmd::MAX_NUM, xmin, x);
+        IrOp xclamped = build.inst(IrCmd::MIN_NUM, xmax, xtemp);
+
+        IrOp ytemp = build.inst(IrCmd::MAX_NUM, ymin, y);
+        IrOp yclamped = build.inst(IrCmd::MIN_NUM, ymax, ytemp);
+
+        IrOp ztemp = build.inst(IrCmd::MAX_NUM, zmin, z);
+        IrOp zclamped = build.inst(IrCmd::MIN_NUM, zmax, ztemp);
+
+        if (FFlag::LuauCodegenSplitFloat)
+        {
+            xclamped = build.inst(IrCmd::NUM_TO_FLOAT, xclamped);
+            yclamped = build.inst(IrCmd::NUM_TO_FLOAT, yclamped);
+            zclamped = build.inst(IrCmd::NUM_TO_FLOAT, zclamped);
+        }
+
+        build.inst(IrCmd::STORE_VECTOR, build.vmReg(ra), xclamped, yclamped, zclamped);
+        build.inst(IrCmd::STORE_TAG, build.vmReg(ra), build.constTag(LUA_TVECTOR));
     }
-
-    build.inst(IrCmd::JUMP_CMP_NUM, ymin, ymax, build.cond(IrCondition::NotLessEqual), fallback, block2);
-
-    build.beginBlock(block2);
-
-    IrOp z = build.inst(IrCmd::LOAD_FLOAT, arg1, build.constInt(8));
-    IrOp zmin = build.inst(IrCmd::LOAD_FLOAT, args, build.constInt(8));
-    IrOp zmax = build.inst(IrCmd::LOAD_FLOAT, arg3, build.constInt(8));
-
-    if (FFlag::LuauCodegenSplitFloat)
-    {
-        z = build.inst(IrCmd::FLOAT_TO_NUM, z);
-        zmin = build.inst(IrCmd::FLOAT_TO_NUM, zmin);
-        zmax = build.inst(IrCmd::FLOAT_TO_NUM, zmax);
-    }
-
-    build.inst(IrCmd::JUMP_CMP_NUM, zmin, zmax, build.cond(IrCondition::NotLessEqual), fallback, block3);
-
-    build.beginBlock(block3);
-
-    IrOp xtemp = build.inst(IrCmd::MAX_NUM, xmin, x);
-    IrOp xclamped = build.inst(IrCmd::MIN_NUM, xmax, xtemp);
-
-    IrOp ytemp = build.inst(IrCmd::MAX_NUM, ymin, y);
-    IrOp yclamped = build.inst(IrCmd::MIN_NUM, ymax, ytemp);
-
-    IrOp ztemp = build.inst(IrCmd::MAX_NUM, zmin, z);
-    IrOp zclamped = build.inst(IrCmd::MIN_NUM, zmax, ztemp);
-
-    if (FFlag::LuauCodegenSplitFloat)
-    {
-        xclamped = build.inst(IrCmd::NUM_TO_FLOAT, xclamped);
-        yclamped = build.inst(IrCmd::NUM_TO_FLOAT, yclamped);
-        zclamped = build.inst(IrCmd::NUM_TO_FLOAT, zclamped);
-    }
-
-    build.inst(IrCmd::STORE_VECTOR, build.vmReg(ra), xclamped, yclamped, zclamped);
-    build.inst(IrCmd::STORE_TAG, build.vmReg(ra), build.constTag(LUA_TVECTOR));
 
     return {BuiltinImplType::UsesFallback, 1};
 }
@@ -1263,7 +1401,7 @@ static BuiltinImplResult translateBuiltinVectorMap2(
     IrOp y2 = build.inst(IrCmd::LOAD_FLOAT, args, build.constInt(4));
     IrOp z2 = build.inst(IrCmd::LOAD_FLOAT, args, build.constInt(8));
 
-    if (FFlag::LuauCodegenSplitFloat)
+    if (FFlag::LuauCodegenSplitFloat && !FFlag::LuauCodegenFloatOps)
     {
         x1 = build.inst(IrCmd::FLOAT_TO_NUM, x1);
         y1 = build.inst(IrCmd::FLOAT_TO_NUM, y1);
@@ -1278,7 +1416,7 @@ static BuiltinImplResult translateBuiltinVectorMap2(
     IrOp yr = build.inst(cmd, y1, y2);
     IrOp zr = build.inst(cmd, z1, z2);
 
-    if (FFlag::LuauCodegenSplitFloat)
+    if (FFlag::LuauCodegenSplitFloat && !FFlag::LuauCodegenFloatOps)
     {
         xr = build.inst(IrCmd::NUM_TO_FLOAT, xr);
         yr = build.inst(IrCmd::NUM_TO_FLOAT, yr);
@@ -1440,19 +1578,37 @@ BuiltinImplResult translateBuiltin(
     case LBF_VECTOR_DOT:
         return translateBuiltinVectorDot(build, nparams, ra, arg, args, arg3, nresults, pcpos);
     case LBF_VECTOR_FLOOR:
-        return translateBuiltinVectorMap1(build, IrCmd::FLOOR_NUM, nparams, ra, arg, args, arg3, nresults, pcpos);
+        if (FFlag::LuauCodegenSplitFloat && FFlag::LuauCodegenFloatOps)
+            return translateBuiltinVectorMap1(build, IrCmd::FLOOR_FLOAT, nparams, ra, arg, args, arg3, nresults, pcpos);
+        else
+            return translateBuiltinVectorMap1(build, IrCmd::FLOOR_NUM, nparams, ra, arg, args, arg3, nresults, pcpos);
     case LBF_VECTOR_CEIL:
-        return translateBuiltinVectorMap1(build, IrCmd::CEIL_NUM, nparams, ra, arg, args, arg3, nresults, pcpos);
+        if (FFlag::LuauCodegenSplitFloat && FFlag::LuauCodegenFloatOps)
+            return translateBuiltinVectorMap1(build, IrCmd::CEIL_FLOAT, nparams, ra, arg, args, arg3, nresults, pcpos);
+        else
+            return translateBuiltinVectorMap1(build, IrCmd::CEIL_NUM, nparams, ra, arg, args, arg3, nresults, pcpos);
     case LBF_VECTOR_ABS:
-        return translateBuiltinVectorMap1(build, IrCmd::ABS_NUM, nparams, ra, arg, args, arg3, nresults, pcpos);
+        if (FFlag::LuauCodegenSplitFloat && FFlag::LuauCodegenFloatOps)
+            return translateBuiltinVectorMap1(build, IrCmd::ABS_FLOAT, nparams, ra, arg, args, arg3, nresults, pcpos);
+        else
+            return translateBuiltinVectorMap1(build, IrCmd::ABS_NUM, nparams, ra, arg, args, arg3, nresults, pcpos);
     case LBF_VECTOR_SIGN:
-        return translateBuiltinVectorMap1(build, IrCmd::SIGN_NUM, nparams, ra, arg, args, arg3, nresults, pcpos);
+        if (FFlag::LuauCodegenSplitFloat && FFlag::LuauCodegenFloatOps)
+            return translateBuiltinVectorMap1(build, IrCmd::SIGN_FLOAT, nparams, ra, arg, args, arg3, nresults, pcpos);
+        else
+            return translateBuiltinVectorMap1(build, IrCmd::SIGN_NUM, nparams, ra, arg, args, arg3, nresults, pcpos);
     case LBF_VECTOR_CLAMP:
         return translateBuiltinVectorClamp(build, nparams, ra, arg, args, arg3, nresults, fallback, pcpos);
     case LBF_VECTOR_MIN:
-        return translateBuiltinVectorMap2(build, IrCmd::MIN_NUM, nparams, ra, arg, args, arg3, nresults, pcpos);
+        if (FFlag::LuauCodegenSplitFloat && FFlag::LuauCodegenFloatOps)
+            return translateBuiltinVectorMap2(build, IrCmd::MIN_FLOAT, nparams, ra, arg, args, arg3, nresults, pcpos);
+        else
+            return translateBuiltinVectorMap2(build, IrCmd::MIN_NUM, nparams, ra, arg, args, arg3, nresults, pcpos);
     case LBF_VECTOR_MAX:
-        return translateBuiltinVectorMap2(build, IrCmd::MAX_NUM, nparams, ra, arg, args, arg3, nresults, pcpos);
+        if (FFlag::LuauCodegenSplitFloat && FFlag::LuauCodegenFloatOps)
+            return translateBuiltinVectorMap2(build, IrCmd::MAX_FLOAT, nparams, ra, arg, args, arg3, nresults, pcpos);
+        else
+            return translateBuiltinVectorMap2(build, IrCmd::MAX_NUM, nparams, ra, arg, args, arg3, nresults, pcpos);
     case LBF_VECTOR_LERP:
         return translateBuiltinVectorLerp(build, nparams, ra, arg, args, arg3, nresults, pcpos);
     case LBF_MATH_LERP:

--- a/CodeGen/src/OptimizeDeadStore.cpp
+++ b/CodeGen/src/OptimizeDeadStore.cpp
@@ -10,6 +10,8 @@
 #include "lobject.h"
 
 LUAU_FASTFLAGVARIABLE(LuauCodegenGcoDse)
+LUAU_FASTFLAG(LuauCodegenNumIntFolds2)
+LUAU_FASTFLAG(LuauCodegenBufferRangeMerge)
 
 // TODO: optimization can be improved by knowing which registers are live in at each VM exit
 
@@ -800,7 +802,10 @@ static void markDeadStoresInInst(RemoveDeadStoreState& state, IrBuilder& build, 
         state.checkLiveIns(inst.b);
         break;
     case IrCmd::CHECK_BUFFER_LEN:
-        state.checkLiveIns(inst.d);
+        if (FFlag::LuauCodegenBufferRangeMerge && FFlag::LuauCodegenNumIntFolds2)
+            state.checkLiveIns(inst.f);
+        else
+            state.checkLiveIns(inst.d);
         break;
     case IrCmd::CHECK_USERDATA_TAG:
         state.checkLiveIns(inst.c);

--- a/Common/include/Luau/Bytecode.h
+++ b/Common/include/Luau/Bytecode.h
@@ -17,7 +17,7 @@
 //     E - least-significant byte for the opcode, followed by E (24-bit integer). E is a signed integer that commonly specifies a jump offset
 //
 // Instruction word is sometimes followed by one extra word, indicated as AUX - this is just a 32-bit word and is decoded according to the specification for each opcode.
-// For each opcode the encoding is *static* - that is, based on the opcode you know a-priory how large the instruction is, with the exception of NEWCLOSURE
+// For each opcode the encoding is *static* - that is, based on the opcode you know apriori how large the instruction is, with the exception of NEWCLOSURE
 
 // # Bytecode indices
 // Bytecode instructions commonly refer to integer values that define offsets or indices for various entities. For each type, there's a maximum encodable value.

--- a/Compiler/src/BuiltinFolding.cpp
+++ b/Compiler/src/BuiltinFolding.cpp
@@ -7,7 +7,6 @@
 #include <array>
 #include <math.h>
 
-LUAU_FASTFLAGVARIABLE(LuauCompileTypeofFold)
 LUAU_FASTFLAGVARIABLE(LuauCompileStringCharSubFold)
 
 namespace Luau
@@ -504,7 +503,7 @@ Constant foldBuiltin(AstNameTable& stringTable, int bfid, const Constant* args, 
 
     case LBF_TYPEOF:
         if (count == 1 && args[0].type != Constant::Type_Unknown)
-            return FFlag::LuauCompileTypeofFold ? ctypeof(args[0]) : ctype(args[0]);
+            return ctypeof(args[0]);
         break;
 
     case LBF_STRING_SUB:

--- a/Compiler/src/Compiler.cpp
+++ b/Compiler/src/Compiler.cpp
@@ -27,7 +27,7 @@ LUAU_FASTINTVARIABLE(LuauCompileInlineThreshold, 25)
 LUAU_FASTINTVARIABLE(LuauCompileInlineThresholdMaxBoost, 300)
 LUAU_FASTINTVARIABLE(LuauCompileInlineDepth, 5)
 
-LUAU_FASTFLAG(LuauExplicitTypeExpressionInstantiation)
+LUAU_FASTFLAG(LuauExplicitTypeInstantiationSyntax)
 LUAU_FASTFLAGVARIABLE(LuauCompileCallCostModel)
 
 namespace Luau
@@ -1157,9 +1157,9 @@ struct Compiler
 
             // it's technically safe to share closures whenever all upvalues are immutable
             // this is because of a runtime equality check in DUPCLOSURE.
-            // however, this results in frequent deoptimization and increases the set of reachable objects, making some temporary objects permanent
+            // however, this results in frequent de-optimization and increases the set of reachable objects, making some temporary objects permanent
             // instead we apply a heuristic: we share closures if they refer to top-level upvalues, or closures that refer to top-level upvalues
-            // this will only deoptimize (outside of fenv changes) if top level code is executed twice with different results.
+            // this will only de-optimize (outside of fenv changes) if top level code is executed twice with different results.
             if (uv->functionDepth != 0 || uv->loopDepth != 0)
             {
                 AstExprFunction* uf = ul->init ? ul->init->as<AstExprFunction>() : nullptr;
@@ -2525,7 +2525,7 @@ struct Compiler
         }
         else if (AstExprInstantiate* expr = node->as<AstExprInstantiate>())
         {
-            LUAU_ASSERT(FFlag::LuauExplicitTypeExpressionInstantiation);
+            LUAU_ASSERT(FFlag::LuauExplicitTypeInstantiationSyntax);
             compileExpr(expr->expr, target, targetTemp);
         }
         else
@@ -2955,7 +2955,7 @@ struct Compiler
 
         setDebugLine(stat->condition);
 
-        // Note: this is using JUMPBACK, not JUMP, since JUMPBACK is interruptible and we want all loops to have at least one interruptible
+        // Note: this is using JUMPBACK, not JUMP, since JUMPBACK is interruptable and we want all loops to have at least one interruptable
         // instruction
         bytecode.emitAD(LOP_JUMPBACK, 0, 0);
 
@@ -3045,7 +3045,7 @@ struct Compiler
 
             size_t backLabel = bytecode.emitLabel();
 
-            // Note: this is using JUMPBACK, not JUMP, since JUMPBACK is interruptible and we want all loops to have at least one interruptible
+            // Note: this is using JUMPBACK, not JUMP, since JUMPBACK is interruptable and we want all loops to have at least one interruptable
             // instruction
             bytecode.emitAD(LOP_JUMPBACK, 0, 0);
 
@@ -4442,7 +4442,7 @@ void compileOrThrow(BytecodeBuilder& bytecode, const ParseResult& parseResult, A
         root->visit(&fenvVisitor);
     }
 
-    // builtin folding is enabled on optimization level 2 since we can't deoptimize folding at runtime
+    // builtin folding is enabled on optimization level 2 since we can't de-optimize folding at runtime
     if (options.optimizationLevel >= 2 && (!compiler.getfenvUsed && !compiler.setfenvUsed))
     {
         compiler.builtinsFold = &compiler.builtins;

--- a/Compiler/src/ConstantFolding.cpp
+++ b/Compiler/src/ConstantFolding.cpp
@@ -7,7 +7,7 @@
 #include <vector>
 #include <math.h>
 
-LUAU_FASTFLAG(LuauExplicitTypeExpressionInstantiation)
+LUAU_FASTFLAG(LuauExplicitTypeInstantiationSyntax)
 
 namespace Luau
 {
@@ -613,7 +613,7 @@ struct ConstantVisitor : AstVisitor
         }
         else if (AstExprInstantiate* expr = node->as<AstExprInstantiate>())
         {
-            LUAU_ASSERT(FFlag::LuauExplicitTypeExpressionInstantiation);
+            LUAU_ASSERT(FFlag::LuauExplicitTypeInstantiationSyntax);
             result = analyze(expr->expr);
         }
         else

--- a/Compiler/src/CostModel.cpp
+++ b/Compiler/src/CostModel.cpp
@@ -9,7 +9,7 @@
 
 #include <limits.h>
 
-LUAU_FASTFLAG(LuauExplicitTypeExpressionInstantiation)
+LUAU_FASTFLAG(LuauExplicitTypeInstantiationSyntax)
 LUAU_FASTFLAG(LuauCompileCallCostModel)
 
 namespace Luau
@@ -219,7 +219,7 @@ struct CostVisitor : AstVisitor
         }
         else if (AstExprInstantiate* expr = node->as<AstExprInstantiate>())
         {
-            LUAU_ASSERT(FFlag::LuauExplicitTypeExpressionInstantiation);
+            LUAU_ASSERT(FFlag::LuauExplicitTypeInstantiationSyntax);
             return model(expr->expr);
         }
         else

--- a/Sources.cmake
+++ b/Sources.cmake
@@ -224,6 +224,7 @@ target_sources(Luau.Analysis PRIVATE
     Analysis/include/Luau/Scope.h
     Analysis/include/Luau/Set.h
     Analysis/include/Luau/Simplify.h
+    Analysis/include/Luau/StructuralTypeEquality.h
     Analysis/include/Luau/Substitution.h
     Analysis/include/Luau/Subtyping.h
     Analysis/include/Luau/SubtypingVariance.h
@@ -302,6 +303,7 @@ target_sources(Luau.Analysis PRIVATE
     Analysis/src/RequireTracer.cpp
     Analysis/src/Scope.cpp
     Analysis/src/Simplify.cpp
+    Analysis/src/StructuralTypeEquality.cpp
     Analysis/src/Substitution.cpp
     Analysis/src/Subtyping.cpp
     Analysis/src/Symbol.cpp

--- a/VM/src/lbuiltins.cpp
+++ b/VM/src/lbuiltins.cpp
@@ -1839,7 +1839,7 @@ static bool luau_hassse41()
     __cpuid(1, cpuinfo[0], cpuinfo[1], cpuinfo[2], cpuinfo[3]);
 #endif
 
-    // We requre SSE4.1 support for ROUNDSD
+    // We require SSE4.1 support for ROUNDSD
     // https://en.wikipedia.org/wiki/CPUID#EAX=1:_Processor_Info_and_Feature_Bits
     return (cpuinfo[2] & (1 << 19)) != 0;
 }

--- a/VM/src/lstate.h
+++ b/VM/src/lstate.h
@@ -175,7 +175,7 @@ typedef struct global_State
     GCObject* grayagain; // list of objects to be traversed atomically
     GCObject* weak;      // list of weak tables (to be cleared)
 
-    size_t GCthreshold;                       // when totalbytes > GCthreshold, run GC step
+    size_t GCthreshold;                       // when totalbytes >= GCthreshold, run GC step
     size_t totalbytes;                        // number of bytes currently allocated
 
     int gcgoal;                               // see LUAI_GCGOAL

--- a/VM/src/lstrlib.cpp
+++ b/VM/src/lstrlib.cpp
@@ -1324,7 +1324,7 @@ static KOption getoption(Header* h, const char** fmt, int* size)
 ** Read, classify, and fill other details about the next option.
 ** 'psize' is filled with option's size, 'notoalign' with its
 ** alignment requirements.
-** Local variable 'size' gets the size to be aligned. (Kpadal option
+** Local variable 'size' gets the size to be aligned. (Kpaddalign option
 ** always gets its full alignment, other options are limited by
 ** the maximum alignment ('maxalign'). Kchar option needs no alignment
 ** despite its size.

--- a/VM/src/lvmexecute.cpp
+++ b/VM/src/lvmexecute.cpp
@@ -16,7 +16,7 @@
 
 #include <string.h>
 
-// Disable c99-designator to avoid the warning in CGOTO dispatch table
+// Disable c99-designator to avoid the warning in computed goto dispatch table
 #ifdef __clang__
 #if __has_warning("-Wc99-designator")
 #pragma clang diagnostic ignored "-Wc99-designator"
@@ -32,7 +32,7 @@
 // ra/rb/rc!
 // 4. When copying an object to any existing object as a field, generally speaking you need to call luaC_barrier! Be careful with all setobj calls
 // 5. To make 4 easier to follow, please use setobj2s for copies to stack, setobj2t for writes to tables, and setobj for other copies.
-// 6. You can define HARDSTACKTESTS in llimits.h which will aggressively realloc stack; with address sanitizer this should be effective at finding
+// 6. You can define HARDSTACKTESTS in luaconf.h which will aggressively realloc stack; with address sanitizer this should be effective at finding
 // stack corruption bugs
 // 7. Many external Lua functions can call GC! GC will *not* traverse pointers to new objects that aren't reachable from Lua root. Be careful when
 // creating new Lua objects, store them to stack soon.

--- a/tests/AssemblyBuilderA64.test.cpp
+++ b/tests/AssemblyBuilderA64.test.cpp
@@ -108,10 +108,10 @@ TEST_CASE_FIXTURE(AssemblyBuilderA64Fixture, "Binary")
     SINGLE_COMPARE(tst(x0, x1), 0xEA01001F);
 
     // reg, imm
-    SINGLE_COMPARE(add(x3, x7, 78), 0x910138E3);
-    SINGLE_COMPARE(add(w3, w7, 78), 0x110138E3);
-    SINGLE_COMPARE(sub(w3, w7, 78), 0x510138E3);
-    SINGLE_COMPARE(cmp(w0, 42), 0x7100A81F);
+    SINGLE_COMPARE(add(x3, x7, uint16_t(78)), 0x910138E3);
+    SINGLE_COMPARE(add(w3, w7, uint16_t(78)), 0x110138E3);
+    SINGLE_COMPARE(sub(w3, w7, uint16_t(78)), 0x510138E3);
+    SINGLE_COMPARE(cmp(w0, uint16_t(42)), 0x7100A81F);
 }
 
 TEST_CASE_FIXTURE(AssemblyBuilderA64Fixture, "BinaryExtended")
@@ -333,11 +333,11 @@ TEST_CASE_FIXTURE(AssemblyBuilderA64Fixture, "StackOps")
     SINGLE_COMPARE(mov(x0, sp), 0x910003E0);
     SINGLE_COMPARE(mov(sp, x0), 0x9100001F);
 
-    SINGLE_COMPARE(add(sp, sp, 4), 0x910013FF);
-    SINGLE_COMPARE(sub(sp, sp, 4), 0xD10013FF);
+    SINGLE_COMPARE(add(sp, sp, uint16_t(4)), 0x910013FF);
+    SINGLE_COMPARE(sub(sp, sp, uint16_t(4)), 0xD10013FF);
 
-    SINGLE_COMPARE(add(x0, sp, 4), 0x910013E0);
-    SINGLE_COMPARE(sub(sp, x0, 4), 0xD100101F);
+    SINGLE_COMPARE(add(x0, sp, uint16_t(4)), 0x910013E0);
+    SINGLE_COMPARE(sub(sp, x0, uint16_t(4)), 0xD100101F);
 
     SINGLE_COMPARE(ldr(x0, mem(sp, 8)), 0xF94007E0);
     SINGLE_COMPARE(str(x0, mem(sp, 8)), 0xF90007E0);
@@ -411,6 +411,11 @@ TEST_CASE_FIXTURE(AssemblyBuilderA64Fixture, "FPMath")
     SINGLE_COMPARE(frinta(d1, d2), 0x1E664041);
     SINGLE_COMPARE(frintm(d1, d2), 0x1E654041);
     SINGLE_COMPARE(frintp(d1, d2), 0x1E64C041);
+
+    SINGLE_COMPARE(frintm(s1, s2), 0x1E254041);
+    SINGLE_COMPARE(frintp(s1, s2), 0x1E24C041);
+
+    SINGLE_COMPARE(frintm(q1, q2), 0x4E219841);
 
     SINGLE_COMPARE(fcvt(s1, d2), 0x1E624041);
     SINGLE_COMPARE(fcvt(d1, s2), 0x1E22C041);
@@ -556,12 +561,12 @@ TEST_CASE("LogTest")
 {
     AssemblyBuilderA64 build(/* logText= */ true);
 
-    build.add(sp, sp, 4);
+    build.add(sp, sp, uint16_t(4));
     build.add(w0, w1, w2);
     build.add(x0, x1, x2, 2);
     build.add(x0, x1, x2, -2);
-    build.add(w7, w8, 5);
-    build.add(x7, x8, 5);
+    build.add(w7, w8, uint16_t(5));
+    build.add(x7, x8, uint16_t(5));
     build.ldr(x7, x8);
     build.ldr(x7, mem(x8, 8));
     build.ldr(x7, mem(x8, x9));

--- a/tests/AssemblyBuilderX64.test.cpp
+++ b/tests/AssemblyBuilderX64.test.cpp
@@ -590,6 +590,11 @@ TEST_CASE_FIXTURE(AssemblyBuilderX64Fixture, "AVXTernaryInstructionForms")
         vroundsd(xmm8, xmm13, xmmword[r13 + rdx], RoundingModeX64::RoundToPositiveInfinity), 0xc4, 0x43, 0x11, 0x0b, 0x44, 0x15, 0x00, 0x0a
     );
     SINGLE_COMPARE(vroundsd(xmm9, xmm14, xmmword[rcx + r10], RoundingModeX64::RoundToZero), 0xc4, 0x23, 0x09, 0x0b, 0x0c, 0x11, 0x0b);
+
+    SINGLE_COMPARE(vroundps(xmm1, xmm3, RoundingModeX64::RoundToNegativeInfinity), 0xc4, 0xe3, 0x79, 0x08, 0xcb, 0x09);
+    SINGLE_COMPARE(vroundps(xmm12, xmm14, RoundingModeX64::RoundToNegativeInfinity), 0xc4, 0x43, 0x79, 0x08, 0xe6, 0x09);
+    SINGLE_COMPARE(vroundps(xmm12, xmmword[rax + r13], RoundingModeX64::RoundToNegativeInfinity), 0xc4, 0x23, 0x79, 0x08, 0x24, 0x28, 0x09);
+
     SINGLE_COMPARE(vblendvpd(xmm7, xmm12, xmmword[rcx + r10], xmm5), 0xc4, 0xa3, 0x19, 0x4b, 0x3c, 0x11, 0x50);
 
     SINGLE_COMPARE(vpshufps(xmm7, xmm12, xmmword[rcx + r10], 0b11010100), 0xc4, 0xa1, 0x18, 0xc6, 0x3c, 0x11, 0xd4);
@@ -662,6 +667,7 @@ TEST_CASE("LogTest")
     build.imul(rcx, rdx);
     build.imul(rcx, rdx, 8);
     build.vroundsd(xmm1, xmm2, xmm3, RoundingModeX64::RoundToNearestEven);
+    build.vroundps(xmm1, xmm12, RoundingModeX64::RoundToNegativeInfinity);
     build.add(rdx, qword[rcx - 12]);
     build.pop(r12);
     build.cmov(ConditionX64::AboveEqual, rax, rbx);
@@ -709,6 +715,7 @@ TEST_CASE("LogTest")
  imul        rcx,rdx
  imul        rcx,rdx,8
  vroundsd    xmm1,xmm2,xmm3,8
+ vroundps    xmm1,xmm12,9
  add         rdx,qword ptr [rcx-0Ch]
  pop         r12
  cmovae      rax,rbx

--- a/tests/Autocomplete.test.cpp
+++ b/tests/Autocomplete.test.cpp
@@ -21,7 +21,6 @@ LUAU_DYNAMIC_FASTINT(LuauSubtypingRecursionLimit)
 LUAU_FASTFLAG(LuauTraceTypesInNonstrictMode2)
 LUAU_FASTFLAG(LuauSetMetatableDoesNotTimeTravel)
 LUAU_FASTINT(LuauTypeInferRecursionLimit)
-LUAU_FASTFLAG(LuauDoNotSuggestGenericsInAnonFuncs)
 LUAU_FASTFLAG(LuauAutocompleteSingletonsInIndexer)
 
 using namespace Luau;
@@ -4375,8 +4374,6 @@ foo(@1)
 
 TEST_CASE_FIXTURE(ACFixture, "anonymous_autofilled_generic_type_pack_vararg")
 {
-    ScopedFastFlag sff{FFlag::LuauDoNotSuggestGenericsInAnonFuncs, true};
-
     check(R"(
 local function foo<A>(a: (...A) -> number, ...: A)
 	return a(...)
@@ -4398,8 +4395,6 @@ foo(@1)
 
 TEST_CASE_FIXTURE(ACFixture, "anonymous_autofilled_generic_named_arg")
 {
-    ScopedFastFlag sff{FFlag::LuauDoNotSuggestGenericsInAnonFuncs, true};
-
     check(R"(
 local function foo<A>(f: (a: A) -> number, a: A)
 	return f(a)
@@ -4421,8 +4416,6 @@ foo(@1)
 
 TEST_CASE_FIXTURE(ACFixture, "anonymous_autofilled_generic_return_type")
 {
-    ScopedFastFlag sff{FFlag::LuauDoNotSuggestGenericsInAnonFuncs, true};
-
     check(R"(
 local function foo<A>(f: () -> A)
 	return f()

--- a/tests/CodeAllocator.test.cpp
+++ b/tests/CodeAllocator.test.cpp
@@ -801,7 +801,7 @@ TEST_CASE("GeneratedCodeExecutionA64")
     build.ldrb(w2, x2);
     build.sub(x1, x1, x2);
 
-    build.add(x1, x1, 2);
+    build.add(x1, x1, uint16_t(2));
     build.add(x0, x0, x1, /* LSL */ 1);
 
     build.ret();
@@ -854,19 +854,19 @@ TEST_CASE("GeneratedCodeExecutionWithThrowA64")
 
     unwind->startInfo(UnwindBuilder::A64);
 
-    build.sub(sp, sp, 32);
+    build.sub(sp, sp, uint16_t(32));
     build.stp(x29, x30, mem(sp));
     build.str(x28, mem(sp, 16));
     build.mov(x29, sp);
 
     Label prologueEnd = build.setLabel();
 
-    build.add(x0, x0, 15);
+    build.add(x0, x0, uint16_t(15));
     build.blr(x1);
 
     build.ldr(x28, mem(sp, 16));
     build.ldp(x29, x30, mem(sp));
-    build.add(sp, sp, 32);
+    build.add(sp, sp, uint16_t(32));
 
     build.ret();
 

--- a/tests/Compiler.test.cpp
+++ b/tests/Compiler.test.cpp
@@ -24,7 +24,6 @@ LUAU_FASTINT(LuauCompileLoopUnrollThreshold)
 LUAU_FASTINT(LuauCompileLoopUnrollThresholdMaxBoost)
 LUAU_FASTINT(LuauRecursionLimit)
 LUAU_FASTFLAG(LuauCompileStringCharSubFold)
-LUAU_FASTFLAG(LuauCompileTypeofFold)
 LUAU_FASTFLAG(LuauCompileMathIsNanInfFinite)
 LUAU_FASTFLAG(LuauCompileCallCostModel)
 
@@ -8385,7 +8384,7 @@ RETURN R1 -1
 
 TEST_CASE("BuiltinFolding")
 {
-    ScopedFastFlag _[]{{FFlag::LuauCompileTypeofFold, true}, {FFlag::LuauCompileMathIsNanInfFinite, true}};
+    ScopedFastFlag _[]{{FFlag::LuauCompileMathIsNanInfFinite, true}};
 
     CHECK_EQ(
         "\n" + compileFunction(
@@ -8521,8 +8520,6 @@ RETURN R0 59
 
 TEST_CASE("BuiltinFoldingProhibited")
 {
-    ScopedFastFlag luauCompileTypeofFold{FFlag::LuauCompileTypeofFold, true};
-
     CHECK_EQ(
         "\n" + compileFunction(
                    R"(

--- a/tests/Conformance.test.cpp
+++ b/tests/Conformance.test.cpp
@@ -35,7 +35,7 @@ void luaC_validate(lua_State* L);
 void luau_callhook(lua_State* L, lua_Hook hook, void* userdata);
 
 LUAU_FASTFLAG(DebugLuauAbortingChecks)
-LUAU_FASTFLAG(LuauExplicitTypeExpressionInstantiation)
+LUAU_FASTFLAG(LuauExplicitTypeInstantiationSyntax)
 LUAU_FASTINT(CodegenHeuristicsInstructionLimit)
 LUAU_FASTFLAG(LuauStacklessPcall)
 LUAU_FASTFLAG(LuauMathIsNanInfFinite)
@@ -1048,7 +1048,7 @@ TEST_CASE("Pack")
 
 TEST_CASE("ExplicitTypeInstantiations")
 {
-    ScopedFastFlag sff{FFlag::LuauExplicitTypeExpressionInstantiation, true};
+    ScopedFastFlag sff{FFlag::LuauExplicitTypeInstantiationSyntax, true};
     runConformance("explicit_type_instantiations.luau");
 }
 

--- a/tests/Fixture.cpp
+++ b/tests/Fixture.cpp
@@ -903,10 +903,10 @@ void registerHiddenTypes(Frontend& frontend)
 
     unfreeze(globals.globalTypes);
 
-    TypeId t = globals.globalTypes.addType(GenericType{"T"});
+    TypeId t = globals.globalTypes.addType(GenericType{"T", Polarity::Mixed});
     GenericTypeDefinition genericT{t};
 
-    TypeId u = globals.globalTypes.addType(GenericType{"U"});
+    TypeId u = globals.globalTypes.addType(GenericType{"U", Polarity::Mixed});
     GenericTypeDefinition genericU{u};
 
     ScopePtr globalScope = globals.globalScope;

--- a/tests/FragmentAutocomplete.test.cpp
+++ b/tests/FragmentAutocomplete.test.cpp
@@ -29,7 +29,6 @@ LUAU_FASTINT(LuauParseErrorLimit)
 LUAU_FASTFLAG(LuauBetterReverseDependencyTracking)
 LUAU_FASTFLAG(LuauFragmentRequiresCanBeResolvedToAModule)
 LUAU_FASTFLAG(LuauNumericUnaryOpsDontProduceNegationRefinements)
-LUAU_FASTFLAG(LuauDoNotSuggestGenericsInAnonFuncs)
 LUAU_FASTFLAG(LuauForInRangesConsiderInLocation)
 LUAU_FASTFLAG(LuauAutocompleteSingletonsInIndexer)
 
@@ -4618,8 +4617,6 @@ end
 
 TEST_CASE_FIXTURE(FragmentAutocompleteFixture, "anonymous_autofilled_generic_type_pack_vararg")
 {
-    ScopedFastFlag sff{FFlag::LuauDoNotSuggestGenericsInAnonFuncs, true};
-
     std::string source = R"(
 local function foo<A>(a: (...A) -> number, ...: A)
 	return a(...)
@@ -4653,8 +4650,6 @@ foo(@1)
 
 TEST_CASE_FIXTURE(FragmentAutocompleteFixture, "anonymous_autofilled_generic_named_arg")
 {
-    ScopedFastFlag sff{FFlag::LuauDoNotSuggestGenericsInAnonFuncs, true};
-
     std::string source = R"(
 local function foo<A>(f: (a: A) -> number, a: A)
 	return f(a)
@@ -4688,8 +4683,6 @@ foo(@1)
 
 TEST_CASE_FIXTURE(FragmentAutocompleteFixture, "anonymous_autofilled_generic_return_type")
 {
-    ScopedFastFlag sff{FFlag::LuauDoNotSuggestGenericsInAnonFuncs, true};
-
     std::string source = R"(
 local function foo<A>(f: () -> A)
 	return f()

--- a/tests/InferPolarity.test.cpp
+++ b/tests/InferPolarity.test.cpp
@@ -40,7 +40,7 @@ TEST_CASE_FIXTURE(Fixture, "T where T = { m: <a>(a) -> T }")
         }
     );
 
-    inferGenericPolarities(NotNull{&arena}, NotNull{globalScope.get()}, tType);
+    inferGenericPolarities_DEPRECATED(NotNull{&arena}, NotNull{globalScope.get()}, tType);
 
     const GenericType* aGeneric = get<GenericType>(aType);
     REQUIRE(aGeneric);
@@ -69,7 +69,7 @@ TEST_CASE_FIXTURE(Fixture, "<a, b>({ read x: a, write x: b }) -> ()")
         }
     );
 
-    inferGenericPolarities(NotNull{&arena}, NotNull{globalScope.get()}, mType);
+    inferGenericPolarities_DEPRECATED(NotNull{&arena}, NotNull{globalScope.get()}, mType);
 
     const GenericType* aGeneric = get<GenericType>(aType);
     REQUIRE(aGeneric);

--- a/tests/IrLowering.test.cpp
+++ b/tests/IrLowering.test.cpp
@@ -17,22 +17,31 @@
 #include <string_view>
 
 LUAU_FASTFLAG(LuauCompileUnusedUdataFix)
+LUAU_FASTFLAG(LuauCodegenVecOpGvn)
+LUAU_FASTFLAG(LuauCodegenLibmGvn)
 LUAU_FASTFLAG(LuauCodegenLoopStepDetectFix)
 LUAU_FASTFLAG(LuauCodegenFloatLoadStoreProp)
 LUAU_FASTFLAG(LuauCodegenLoadFloatSubstituteLast)
 LUAU_FASTFLAG(LuauCodegenBlockSafeEnv)
 LUAU_FASTFLAG(LuauCodegenChainLink)
+LUAU_FASTFLAG(LuauCodegenInterruptIsNotForWrites)
 LUAU_FASTFLAG(LuauCodegenIntegerAddSub)
 LUAU_FASTFLAG(LuauCodegenSetBlockEntryState)
 LUAU_FASTFLAG(LuauCodegenBetterSccRemoval)
 LUAU_FASTFLAG(LuauCodegenLinearAndOr)
 LUAU_FASTFLAG(LuauCodegenHydrateLoadWithTag)
 LUAU_FASTFLAG(LuauCodegenUpvalueLoadProp)
+LUAU_FASTFLAG(LuauCodegenVectorIdiv)
 LUAU_FASTFLAG(LuauCodegenGcoDse)
 LUAU_FASTFLAG(LuauCodegenBufferLoadProp2)
 LUAU_FASTFLAG(LuauCodegenNumIntFolds2)
 LUAU_FASTFLAG(LuauCodegenNumToUintFoldRange)
 LUAU_FASTFLAG(LuauCodegenSplitFloat)
+LUAU_FASTFLAG(LuauCodegenTruncateFold)
+LUAU_FASTFLAG(LuauCodegenVectorCreateXy)
+LUAU_FASTFLAG(LuauCodegenFloatOps)
+LUAU_FASTFLAG(LuauCodegenSplitFloatExtra)
+LUAU_FASTFLAG(LuauCodegenBufferRangeMerge)
 
 static void luauLibraryConstantLookup(const char* library, const char* member, Luau::CompileConstant* constant)
 {
@@ -272,6 +281,8 @@ TEST_SUITE_BEGIN("IrLowering");
 TEST_CASE("VectorReciprocal")
 {
     ScopedFastFlag luauCodegenHydrateLoadWithTag{FFlag::LuauCodegenHydrateLoadWithTag, true};
+    ScopedFastFlag luauCodegenSplitFloat{FFlag::LuauCodegenSplitFloat, true};
+    ScopedFastFlag luauCodegenSplitFloatExtra{FFlag::LuauCodegenSplitFloatExtra, true};
 
     CHECK_EQ(
         "\n" + getCodegenAssembly(R"(
@@ -287,11 +298,11 @@ bb_0:
 bb_2:
   JUMP bb_bytecode_1
 bb_bytecode_1:
-  %6 = NUM_TO_VEC 1
-  %7 = LOAD_TVALUE R0, 0i, tvector
-  %8 = DIV_VEC %6, %7
-  %9 = TAG_VECTOR %8
-  STORE_TVALUE R1, %9
+  %7 = FLOAT_TO_VEC 1
+  %8 = LOAD_TVALUE R0, 0i, tvector
+  %9 = DIV_VEC %7, %8
+  %10 = TAG_VECTOR %9
+  STORE_TVALUE R1, %10
   INTERRUPT 1u
   RETURN R1, 1i
 )"
@@ -461,6 +472,8 @@ bb_bytecode_1:
 TEST_CASE("VectorMulDivMixed")
 {
     ScopedFastFlag luauCodegenHydrateLoadWithTag{FFlag::LuauCodegenHydrateLoadWithTag, true};
+    ScopedFastFlag luauCodegenSplitFloat{FFlag::LuauCodegenSplitFloat, true};
+    ScopedFastFlag luauCodegenSplitFloatExtra{FFlag::LuauCodegenSplitFloatExtra, true};
 
     CHECK_EQ(
         "\n" + getCodegenAssembly(R"(
@@ -480,22 +493,22 @@ bb_2:
   JUMP bb_bytecode_1
 bb_bytecode_1:
   %12 = LOAD_TVALUE R0, 0i, tvector
-  %13 = NUM_TO_VEC 2
-  %14 = MUL_VEC %12, %13
-  %19 = LOAD_TVALUE R1, 0i, tvector
-  %20 = NUM_TO_VEC 4
-  %21 = DIV_VEC %19, %20
-  %30 = ADD_VEC %14, %21
-  %40 = NUM_TO_VEC 0.5
-  %41 = LOAD_TVALUE R2, 0i, tvector
-  %42 = MUL_VEC %40, %41
-  %51 = ADD_VEC %30, %42
-  %56 = NUM_TO_VEC 40
-  %57 = LOAD_TVALUE R3, 0i, tvector
-  %58 = DIV_VEC %56, %57
-  %67 = ADD_VEC %51, %58
-  %68 = TAG_VECTOR %67
-  STORE_TVALUE R4, %68
+  %14 = FLOAT_TO_VEC 2
+  %15 = MUL_VEC %12, %14
+  %20 = LOAD_TVALUE R1, 0i, tvector
+  %22 = FLOAT_TO_VEC 4
+  %23 = DIV_VEC %20, %22
+  %32 = ADD_VEC %15, %23
+  %43 = FLOAT_TO_VEC 0.5
+  %44 = LOAD_TVALUE R2, 0i, tvector
+  %45 = MUL_VEC %43, %44
+  %54 = ADD_VEC %32, %45
+  %60 = FLOAT_TO_VEC 40
+  %61 = LOAD_TVALUE R3, 0i, tvector
+  %62 = DIV_VEC %60, %61
+  %71 = ADD_VEC %54, %62
+  %72 = TAG_VECTOR %71
+  STORE_TVALUE R4, %72
   INTERRUPT 8u
   RETURN R4, 1i
 )"
@@ -506,7 +519,9 @@ TEST_CASE("VectorLerp")
 {
     ScopedFastFlag _[]{
         {FFlag::LuauCodegenBlockSafeEnv, true},
-        {FFlag::LuauCodegenHydrateLoadWithTag, true}
+        {FFlag::LuauCodegenHydrateLoadWithTag, true},
+        {FFlag::LuauCodegenSplitFloat, true},
+        {FFlag::LuauCodegenSplitFloatExtra, true}
     };
     CHECK_EQ(
         "\n" + getCodegenAssembly(R"(
@@ -528,13 +543,14 @@ bb_bytecode_1:
   %15 = LOAD_TVALUE R0, 0i, tvector
   %16 = LOAD_TVALUE R1, 0i, tvector
   %17 = LOAD_DOUBLE R2
-  %18 = NUM_TO_VEC %17
-  %19 = NUM_TO_VEC 1
-  %20 = SUB_VEC %16, %15
-  MULADD_VEC %20, %18, %15
-  SELECT_VEC %21, %16, %18, %19
-  %23 = TAG_VECTOR %22
-  STORE_TVALUE R3, %23
+  %18 = NUM_TO_FLOAT %17
+  %19 = FLOAT_TO_VEC %18
+  %20 = FLOAT_TO_VEC 1
+  %21 = SUB_VEC %16, %15
+  MULADD_VEC %21, %19, %15
+  SELECT_VEC %22, %16, %19, %20
+  %24 = TAG_VECTOR %23
+  STORE_TVALUE R3, %24
   INTERRUPT 8u
   RETURN R3, 1i
 )"
@@ -1144,6 +1160,7 @@ bb_6:
 TEST_CASE("VectorCustomAccess")
 {
     ScopedFastFlag luauCodegenSplitFloat{FFlag::LuauCodegenSplitFloat, true};
+    ScopedFastFlag luauCodegenFloatOps{FFlag::LuauCodegenFloatOps, true};
 
     CHECK_EQ(
         "\n" + getCodegenAssembly(R"(
@@ -1162,17 +1179,15 @@ bb_bytecode_1:
   %6 = LOAD_FLOAT R0, 0i
   %7 = LOAD_FLOAT R0, 4i
   %8 = LOAD_FLOAT R0, 8i
-  %9 = FLOAT_TO_NUM %6
-  %10 = FLOAT_TO_NUM %7
-  %11 = FLOAT_TO_NUM %8
-  %12 = MUL_NUM %9, %9
-  %13 = MUL_NUM %10, %10
-  %14 = MUL_NUM %11, %11
-  %15 = ADD_NUM %12, %13
-  %16 = ADD_NUM %15, %14
-  %17 = SQRT_NUM %16
-  %23 = MUL_NUM %17, 3
-  STORE_DOUBLE R1, %23
+  %9 = MUL_FLOAT %6, %6
+  %10 = MUL_FLOAT %7, %7
+  %11 = MUL_FLOAT %8, %8
+  %12 = ADD_FLOAT %9, %10
+  %13 = ADD_FLOAT %12, %11
+  %14 = SQRT_FLOAT %13
+  %15 = FLOAT_TO_NUM %14
+  %21 = MUL_NUM %15, 3
+  STORE_DOUBLE R1, %21
   STORE_TAG R1, tnumber
   INTERRUPT 3u
   RETURN R1, 1i
@@ -1186,6 +1201,7 @@ TEST_CASE("VectorCustomNamecall")
     ScopedFastFlag luauCodegenUpvalueLoadProp{FFlag::LuauCodegenUpvalueLoadProp, true};
     ScopedFastFlag luauCodegenFloatLoadStoreProp{FFlag::LuauCodegenFloatLoadStoreProp, true};
     ScopedFastFlag luauCodegenSplitFloat{FFlag::LuauCodegenSplitFloat, true};
+    ScopedFastFlag luauCodegenFloatOps{FFlag::LuauCodegenFloatOps, true};
 
     CHECK_EQ(
         "\n" + getCodegenAssembly(R"(
@@ -1205,22 +1221,17 @@ bb_bytecode_1:
   %6 = LOAD_TVALUE R1, 0i, tvector
   %12 = LOAD_FLOAT R0, 0i
   %13 = EXTRACT_VEC %6, 0i
-  %14 = FLOAT_TO_NUM %12
-  %15 = FLOAT_TO_NUM %13
-  %16 = MUL_NUM %14, %15
-  %17 = LOAD_FLOAT R0, 4i
-  %18 = EXTRACT_VEC %6, 1i
-  %19 = FLOAT_TO_NUM %17
-  %20 = FLOAT_TO_NUM %18
-  %21 = MUL_NUM %19, %20
-  %22 = LOAD_FLOAT R0, 8i
-  %23 = EXTRACT_VEC %6, 2i
-  %24 = FLOAT_TO_NUM %22
-  %25 = FLOAT_TO_NUM %23
-  %26 = MUL_NUM %24, %25
-  %27 = ADD_NUM %16, %21
-  %28 = ADD_NUM %27, %26
-  STORE_DOUBLE R2, %28
+  %14 = MUL_FLOAT %12, %13
+  %15 = LOAD_FLOAT R0, 4i
+  %16 = EXTRACT_VEC %6, 1i
+  %17 = MUL_FLOAT %15, %16
+  %18 = LOAD_FLOAT R0, 8i
+  %19 = EXTRACT_VEC %6, 2i
+  %20 = MUL_FLOAT %18, %19
+  %21 = ADD_FLOAT %14, %17
+  %22 = ADD_FLOAT %21, %20
+  %23 = FLOAT_TO_NUM %22
+  STORE_DOUBLE R2, %23
   STORE_TAG R2, tnumber
   INTERRUPT 4u
   RETURN R2, 1i
@@ -1233,6 +1244,7 @@ TEST_CASE("VectorCustomNamecall2")
     ScopedFastFlag luauCodegenUpvalueLoadProp{FFlag::LuauCodegenUpvalueLoadProp, true};
     ScopedFastFlag luauCodegenFloatLoadStoreProp{FFlag::LuauCodegenFloatLoadStoreProp, true};
     ScopedFastFlag luauCodegenSplitFloat{FFlag::LuauCodegenSplitFloat, true};
+    ScopedFastFlag luauCodegenFloatOps{FFlag::LuauCodegenFloatOps, true};
 
     CHECK_EQ(
         "\n" + getCodegenAssembly(R"(
@@ -1249,16 +1261,14 @@ bb_2:
   JUMP bb_bytecode_1
 bb_bytecode_1:
   %10 = LOAD_FLOAT R0, 0i
-  %12 = FLOAT_TO_NUM %10
-  %15 = LOAD_FLOAT R0, 4i
-  %17 = FLOAT_TO_NUM %15
-  %19 = ADD_NUM %17, %17
-  %20 = LOAD_FLOAT R0, 8i
-  %22 = FLOAT_TO_NUM %20
-  %24 = MUL_NUM %22, 3
-  %25 = ADD_NUM %12, %19
-  %26 = ADD_NUM %25, %24
-  STORE_DOUBLE R1, %26
+  %13 = LOAD_FLOAT R0, 4i
+  %15 = ADD_FLOAT %13, %13
+  %16 = LOAD_FLOAT R0, 8i
+  %18 = MUL_FLOAT %16, 3
+  %19 = ADD_FLOAT %10, %15
+  %20 = ADD_FLOAT %19, %18
+  %21 = FLOAT_TO_NUM %20
+  STORE_DOUBLE R1, %21
   STORE_TAG R1, tnumber
   INTERRUPT 4u
   RETURN R1, 1i
@@ -1270,6 +1280,8 @@ TEST_CASE("VectorCustomAccessChain")
 {
     ScopedFastFlag luauCodegenHydrateLoadWithTag{FFlag::LuauCodegenHydrateLoadWithTag, true};
     ScopedFastFlag luauCodegenSplitFloat{FFlag::LuauCodegenSplitFloat, true};
+    ScopedFastFlag luauCodegenSplitFloatExtra{FFlag::LuauCodegenSplitFloatExtra, true};
+    ScopedFastFlag luauCodegenFloatOps{FFlag::LuauCodegenFloatOps, true};
 
     CHECK_EQ(
         "\n" + getCodegenAssembly(R"(
@@ -1289,41 +1301,32 @@ bb_bytecode_1:
   %8 = LOAD_FLOAT R0, 0i
   %9 = LOAD_FLOAT R0, 4i
   %10 = LOAD_FLOAT R0, 8i
-  %11 = FLOAT_TO_NUM %8
-  %12 = FLOAT_TO_NUM %9
-  %13 = FLOAT_TO_NUM %10
-  %14 = MUL_NUM %11, %11
-  %15 = MUL_NUM %12, %12
-  %16 = MUL_NUM %13, %13
-  %17 = ADD_NUM %14, %15
-  %18 = ADD_NUM %17, %16
-  %19 = SQRT_NUM %18
-  %20 = DIV_NUM 1, %19
-  %21 = MUL_NUM %11, %20
-  %22 = MUL_NUM %12, %20
-  %23 = MUL_NUM %13, %20
-  %24 = NUM_TO_FLOAT %21
-  %25 = NUM_TO_FLOAT %22
-  %26 = NUM_TO_FLOAT %23
-  STORE_VECTOR R3, %24, %25, %26
+  %11 = MUL_FLOAT %8, %8
+  %12 = MUL_FLOAT %9, %9
+  %13 = MUL_FLOAT %10, %10
+  %14 = ADD_FLOAT %11, %12
+  %15 = ADD_FLOAT %14, %13
+  %16 = SQRT_FLOAT %15
+  %17 = DIV_FLOAT 1, %16
+  %18 = MUL_FLOAT %8, %17
+  %19 = MUL_FLOAT %9, %17
+  %20 = MUL_FLOAT %10, %17
+  STORE_VECTOR R3, %18, %19, %20
   STORE_TAG R3, tvector
-  %31 = LOAD_FLOAT R1, 0i
-  %32 = LOAD_FLOAT R1, 4i
-  %33 = LOAD_FLOAT R1, 8i
-  %34 = FLOAT_TO_NUM %31
-  %35 = FLOAT_TO_NUM %32
-  %36 = FLOAT_TO_NUM %33
-  %37 = MUL_NUM %34, %34
-  %38 = MUL_NUM %35, %35
-  %39 = MUL_NUM %36, %36
-  %40 = ADD_NUM %37, %38
-  %41 = ADD_NUM %40, %39
-  %42 = SQRT_NUM %41
-  %49 = LOAD_TVALUE R3, 0i, tvector
-  %51 = NUM_TO_VEC %42
-  %52 = MUL_VEC %49, %51
-  %53 = TAG_VECTOR %52
-  STORE_TVALUE R2, %53
+  %25 = LOAD_FLOAT R1, 0i
+  %26 = LOAD_FLOAT R1, 4i
+  %27 = LOAD_FLOAT R1, 8i
+  %28 = MUL_FLOAT %25, %25
+  %29 = MUL_FLOAT %26, %26
+  %30 = MUL_FLOAT %27, %27
+  %31 = ADD_FLOAT %28, %29
+  %32 = ADD_FLOAT %31, %30
+  %33 = SQRT_FLOAT %32
+  %41 = LOAD_TVALUE R3, 0i, tvector
+  %44 = FLOAT_TO_VEC %33
+  %45 = MUL_VEC %41, %44
+  %46 = TAG_VECTOR %45
+  STORE_TVALUE R2, %46
   INTERRUPT 5u
   RETURN R2, 1i
 )"
@@ -1336,6 +1339,7 @@ TEST_CASE("VectorCustomNamecallChain")
     ScopedFastFlag luauCodegenUpvalueLoadProp{FFlag::LuauCodegenUpvalueLoadProp, true};
     ScopedFastFlag luauCodegenFloatLoadStoreProp{FFlag::LuauCodegenFloatLoadStoreProp, true};
     ScopedFastFlag luauCodegenSplitFloat{FFlag::LuauCodegenSplitFloat, true};
+    ScopedFastFlag luauCodegenFloatOps{FFlag::LuauCodegenFloatOps, true};
 
     CHECK_EQ(
         "\n" + getCodegenAssembly(R"(
@@ -1360,41 +1364,32 @@ bb_bytecode_1:
   %17 = EXTRACT_VEC %8, 1i
   %18 = LOAD_FLOAT R0, 8i
   %19 = EXTRACT_VEC %8, 2i
-  %20 = FLOAT_TO_NUM %14
-  %21 = FLOAT_TO_NUM %15
-  %22 = FLOAT_TO_NUM %16
-  %23 = FLOAT_TO_NUM %17
-  %24 = FLOAT_TO_NUM %18
-  %25 = FLOAT_TO_NUM %19
-  %26 = MUL_NUM %22, %25
-  %27 = MUL_NUM %24, %23
-  %28 = SUB_NUM %26, %27
-  %29 = MUL_NUM %24, %21
-  %30 = MUL_NUM %20, %25
-  %31 = SUB_NUM %29, %30
-  %32 = MUL_NUM %20, %23
-  %33 = MUL_NUM %22, %21
-  %34 = SUB_NUM %32, %33
-  %35 = NUM_TO_FLOAT %28
-  %36 = NUM_TO_FLOAT %31
-  %37 = NUM_TO_FLOAT %34
-  %40 = LOAD_TVALUE R1, 0i, tvector
-  %47 = EXTRACT_VEC %40, 0i
-  %48 = FLOAT_TO_NUM %35
-  %49 = FLOAT_TO_NUM %47
-  %50 = MUL_NUM %48, %49
-  %52 = EXTRACT_VEC %40, 1i
-  %53 = FLOAT_TO_NUM %36
-  %54 = FLOAT_TO_NUM %52
-  %55 = MUL_NUM %53, %54
-  %57 = EXTRACT_VEC %40, 2i
-  %58 = FLOAT_TO_NUM %37
-  %59 = FLOAT_TO_NUM %57
-  %60 = MUL_NUM %58, %59
-  %61 = ADD_NUM %50, %55
-  %62 = ADD_NUM %61, %60
-  %68 = ADD_NUM %62, 1
-  STORE_DOUBLE R3, %68
+  %20 = MUL_FLOAT %16, %19
+  %21 = MUL_FLOAT %18, %17
+  %22 = SUB_FLOAT %20, %21
+  %23 = MUL_FLOAT %18, %15
+  %24 = MUL_FLOAT %14, %19
+  %25 = SUB_FLOAT %23, %24
+  %26 = MUL_FLOAT %14, %17
+  %27 = MUL_FLOAT %16, %15
+  %28 = SUB_FLOAT %26, %27
+  STORE_VECTOR R4, %22, %25, %28
+  STORE_TAG R4, tvector
+  %31 = LOAD_TVALUE R1, 0i, tvector
+  %37 = LOAD_FLOAT R4, 0i
+  %38 = EXTRACT_VEC %31, 0i
+  %39 = MUL_FLOAT %37, %38
+  %40 = LOAD_FLOAT R4, 4i
+  %41 = EXTRACT_VEC %31, 1i
+  %42 = MUL_FLOAT %40, %41
+  %43 = LOAD_FLOAT R4, 8i
+  %44 = EXTRACT_VEC %31, 2i
+  %45 = MUL_FLOAT %43, %44
+  %46 = ADD_FLOAT %39, %42
+  %47 = ADD_FLOAT %46, %45
+  %48 = FLOAT_TO_NUM %47
+  %54 = ADD_NUM %48, 1
+  STORE_DOUBLE R3, %54
   STORE_TAG R3, tnumber
   INTERRUPT 9u
   RETURN R3, 1i
@@ -1409,6 +1404,7 @@ TEST_CASE("VectorCustomNamecallChain2")
     ScopedFastFlag luauCodegenFloatLoadStoreProp{FFlag::LuauCodegenFloatLoadStoreProp, true};
     ScopedFastFlag luauCodegenHydrateLoadWithTag{FFlag::LuauCodegenHydrateLoadWithTag, true};
     ScopedFastFlag luauCodegenSplitFloat{FFlag::LuauCodegenSplitFloat, true};
+    ScopedFastFlag luauCodegenFloatOps{FFlag::LuauCodegenFloatOps, true};
 
     CHECK_EQ(
         "\n" + getCodegenAssembly(R"(
@@ -1443,53 +1439,39 @@ bb_4:
   %25 = EXTRACT_VEC %16, 1i
   %26 = LOAD_FLOAT R3, 8i
   %27 = EXTRACT_VEC %16, 2i
-  %28 = FLOAT_TO_NUM %22
-  %29 = FLOAT_TO_NUM %23
-  %30 = FLOAT_TO_NUM %24
-  %31 = FLOAT_TO_NUM %25
-  %32 = FLOAT_TO_NUM %26
-  %33 = FLOAT_TO_NUM %27
-  %34 = MUL_NUM %30, %33
-  %35 = MUL_NUM %32, %31
-  %36 = SUB_NUM %34, %35
-  %37 = MUL_NUM %32, %29
-  %38 = MUL_NUM %28, %33
-  %39 = SUB_NUM %37, %38
-  %40 = MUL_NUM %28, %31
-  %41 = MUL_NUM %30, %29
-  %42 = SUB_NUM %40, %41
-  %43 = NUM_TO_FLOAT %36
-  %44 = NUM_TO_FLOAT %39
-  %45 = NUM_TO_FLOAT %42
-  STORE_VECTOR R3, %43, %44, %45
-  %50 = LOAD_POINTER R0
-  %51 = GET_SLOT_NODE_ADDR %50, 6u, K3 ('b')
-  CHECK_SLOT_MATCH %51, K3 ('b'), bb_fallback_5
-  %53 = LOAD_TVALUE %51, 0i
-  STORE_TVALUE R5, %53
+  %28 = MUL_FLOAT %24, %27
+  %29 = MUL_FLOAT %26, %25
+  %30 = SUB_FLOAT %28, %29
+  %31 = MUL_FLOAT %26, %23
+  %32 = MUL_FLOAT %22, %27
+  %33 = SUB_FLOAT %31, %32
+  %34 = MUL_FLOAT %22, %25
+  %35 = MUL_FLOAT %24, %23
+  %36 = SUB_FLOAT %34, %35
+  STORE_VECTOR R3, %30, %33, %36
+  %41 = LOAD_POINTER R0
+  %42 = GET_SLOT_NODE_ADDR %41, 6u, K3 ('b')
+  CHECK_SLOT_MATCH %42, K3 ('b'), bb_fallback_5
+  %44 = LOAD_TVALUE %42, 0i
+  STORE_TVALUE R5, %44
   JUMP bb_6
 bb_6:
   CHECK_TAG R3, tvector, exit(8)
   CHECK_TAG R5, tvector, exit(8)
-  %62 = LOAD_FLOAT R3, 0i
-  %63 = LOAD_FLOAT R5, 0i
-  %64 = FLOAT_TO_NUM %62
-  %65 = FLOAT_TO_NUM %63
-  %66 = MUL_NUM %64, %65
-  %67 = LOAD_FLOAT R3, 4i
-  %68 = LOAD_FLOAT R5, 4i
-  %69 = FLOAT_TO_NUM %67
-  %70 = FLOAT_TO_NUM %68
-  %71 = MUL_NUM %69, %70
-  %72 = LOAD_FLOAT R3, 8i
-  %73 = LOAD_FLOAT R5, 8i
-  %74 = FLOAT_TO_NUM %72
-  %75 = FLOAT_TO_NUM %73
-  %76 = MUL_NUM %74, %75
-  %77 = ADD_NUM %66, %71
-  %78 = ADD_NUM %77, %76
-  %84 = ADD_NUM %78, 1
-  STORE_DOUBLE R2, %84
+  %53 = LOAD_FLOAT R3, 0i
+  %54 = LOAD_FLOAT R5, 0i
+  %55 = MUL_FLOAT %53, %54
+  %56 = LOAD_FLOAT R3, 4i
+  %57 = LOAD_FLOAT R5, 4i
+  %58 = MUL_FLOAT %56, %57
+  %59 = LOAD_FLOAT R3, 8i
+  %60 = LOAD_FLOAT R5, 8i
+  %61 = MUL_FLOAT %59, %60
+  %62 = ADD_FLOAT %55, %58
+  %63 = ADD_FLOAT %62, %61
+  %64 = FLOAT_TO_NUM %63
+  %70 = ADD_NUM %64, 1
+  STORE_DOUBLE R2, %70
   STORE_TAG R2, tnumber
   INTERRUPT 12u
   RETURN R2, 1i
@@ -1502,6 +1484,8 @@ TEST_CASE("VectorLibraryChain")
     ScopedFastFlag luauCodegenBlockSafeEnv{FFlag::LuauCodegenBlockSafeEnv, true};
     ScopedFastFlag luauCodegenHydrateLoadWithTag{FFlag::LuauCodegenHydrateLoadWithTag, true};
     ScopedFastFlag luauCodegenSplitFloat{FFlag::LuauCodegenSplitFloat, true};
+    ScopedFastFlag luauCodegenSplitFloatExtra{FFlag::LuauCodegenSplitFloatExtra, true};
+    ScopedFastFlag luauCodegenFloatOps{FFlag::LuauCodegenFloatOps, true};
 
     CHECK_EQ(
         "\n" + getCodegenAssembly(R"(
@@ -1521,24 +1505,66 @@ bb_bytecode_1:
   implicit CHECK_SAFE_ENV exit(0)
   %9 = LOAD_TVALUE R0, 0i, tvector
   %10 = DOT_VEC %9, %9
-  %11 = FLOAT_TO_NUM %10
-  %12 = SQRT_NUM %11
-  %13 = DIV_NUM 1, %12
-  %14 = NUM_TO_VEC %13
-  %15 = MUL_VEC %9, %14
-  %21 = LOAD_TVALUE R1, 0i, tvector
-  %22 = DOT_VEC %21, %21
+  %11 = SQRT_FLOAT %10
+  %12 = DIV_FLOAT 1, %11
+  %13 = FLOAT_TO_VEC %12
+  %14 = MUL_VEC %9, %13
+  %20 = LOAD_TVALUE R1, 0i, tvector
+  %21 = DOT_VEC %20, %20
+  %22 = SQRT_FLOAT %21
   %23 = FLOAT_TO_NUM %22
-  %24 = SQRT_NUM %23
-  %34 = DOT_VEC %9, %21
-  %35 = FLOAT_TO_NUM %34
-  %44 = ADD_NUM %24, %35
-  %53 = NUM_TO_VEC %44
-  %54 = MUL_VEC %15, %53
+  %33 = DOT_VEC %9, %20
+  %34 = FLOAT_TO_NUM %33
+  %43 = ADD_NUM %23, %34
+  %52 = NUM_TO_FLOAT %43
+  %53 = FLOAT_TO_VEC %52
+  %54 = MUL_VEC %14, %53
   %55 = TAG_VECTOR %54
   STORE_TVALUE R2, %55
   INTERRUPT 19u
   RETURN R2, 1i
+)"
+    );
+}
+
+TEST_CASE("VectorIdiv")
+{
+    ScopedFastFlag luauCodegenHydrateLoadWithTag{FFlag::LuauCodegenHydrateLoadWithTag, true};
+    ScopedFastFlag luauCodegenSplitFloat{FFlag::LuauCodegenSplitFloat, true};
+    ScopedFastFlag luauCodegenSplitFloatExtra{FFlag::LuauCodegenSplitFloatExtra, true};
+    ScopedFastFlag luauCodegenVectorIdiv{FFlag::LuauCodegenVectorIdiv, true};
+
+    CHECK_EQ(
+        "\n" + getCodegenAssembly(
+                   R"(
+local function foo(x: vector): vector
+    x *= 1.5
+    x -= x // 1
+    x -= vector.create(0.5, 0.5, 0.5)
+    return x
+end
+)"
+               ),
+        R"(
+; function foo($arg0) line 2
+bb_0:
+  CHECK_TAG R0, tvector, exit(entry)
+  JUMP bb_2
+bb_2:
+  JUMP bb_bytecode_1
+bb_bytecode_1:
+  %6 = LOAD_TVALUE R0, 0i, tvector
+  %8 = FLOAT_TO_VEC 1.5
+  %9 = MUL_VEC %6, %8
+  %16 = FLOAT_TO_VEC 1
+  %17 = IDIV_VEC %9, %16
+  %26 = SUB_VEC %9, %17
+  %29 = LOAD_TVALUE K2 (0.5, 0.5, 0.5), 0i, tvector
+  %37 = SUB_VEC %26, %29
+  %38 = TAG_VECTOR %37
+  STORE_TVALUE R0, %38
+  INTERRUPT 5u
+  RETURN R0, 1i
 )"
     );
 }
@@ -2287,8 +2313,8 @@ TEST_CASE("ResolveVectorNamecalls")
     ScopedFastFlag luauCodegenHydrateLoadWithTag{FFlag::LuauCodegenHydrateLoadWithTag, true};
     ScopedFastFlag luauCodegenUpvalueLoadProp{FFlag::LuauCodegenUpvalueLoadProp, true};
     ScopedFastFlag luauCodegenFloatLoadStoreProp{FFlag::LuauCodegenFloatLoadStoreProp, true};
-
     ScopedFastFlag luauCodegenSplitFloat{FFlag::LuauCodegenSplitFloat, true};
+    ScopedFastFlag luauCodegenFloatOps{FFlag::LuauCodegenFloatOps, true};
 
     CHECK_EQ(
         "\n" + getCodegenAssembly(
@@ -2335,17 +2361,15 @@ bb_6:
   STORE_TVALUE R4, %31
   CHECK_TAG R2, tvector, exit(4)
   %37 = LOAD_FLOAT R2, 0i
-  %39 = FLOAT_TO_NUM %37
-  %41 = MUL_NUM %39, 0.7070000171661377
-  %42 = LOAD_FLOAT R2, 4i
-  %44 = FLOAT_TO_NUM %42
-  %46 = MUL_NUM %44, 0
-  %47 = LOAD_FLOAT R2, 8i
-  %49 = FLOAT_TO_NUM %47
-  %51 = MUL_NUM %49, 0.7070000171661377
-  %52 = ADD_NUM %41, %46
-  %53 = ADD_NUM %52, %51
-  STORE_DOUBLE R2, %53
+  %39 = MUL_FLOAT %37, 0.7070000171661377
+  %40 = LOAD_FLOAT R2, 4i
+  %42 = MUL_FLOAT %40, 0
+  %43 = LOAD_FLOAT R2, 8i
+  %45 = MUL_FLOAT %43, 0.7070000171661377
+  %46 = ADD_FLOAT %39, %42
+  %47 = ADD_FLOAT %46, %45
+  %48 = FLOAT_TO_NUM %47
+  STORE_DOUBLE R2, %48
   STORE_TAG R2, tnumber
   ADJUST_STACK_TO_REG R2, 1i
   INTERRUPT 7u
@@ -2357,6 +2381,8 @@ bb_6:
 TEST_CASE("ImmediateTypeAnnotationHelp")
 {
     ScopedFastFlag luauCodegenHydrateLoadWithTag{FFlag::LuauCodegenHydrateLoadWithTag, true};
+    ScopedFastFlag luauCodegenSplitFloat{FFlag::LuauCodegenSplitFloat, true};
+    ScopedFastFlag luauCodegenSplitFloatExtra{FFlag::LuauCodegenSplitFloatExtra, true};
 
     CHECK_EQ(
         "\n" + getCodegenAssembly(
@@ -2386,10 +2412,10 @@ bb_bytecode_0:
 bb_2:
   CHECK_TAG R3, tvector, exit(1)
   %19 = LOAD_TVALUE R3, 0i, tvector
-  %20 = NUM_TO_VEC 5
-  %21 = DIV_VEC %19, %20
-  %22 = TAG_VECTOR %21
-  STORE_TVALUE R2, %22
+  %21 = FLOAT_TO_VEC 5
+  %22 = DIV_VEC %19, %21
+  %23 = TAG_VECTOR %22
+  STORE_TVALUE R2, %23
   INTERRUPT 2u
   RETURN R2, 1i
 )"
@@ -2919,12 +2945,12 @@ TEST_CASE("CustomUserdataMetamethod")
     ScopedFastFlag luauCodegenBufferLoadProp{FFlag::LuauCodegenBufferLoadProp2, true};
     ScopedFastFlag luauCodegenGcoDse{FFlag::LuauCodegenGcoDse, true};
     ScopedFastFlag luauCodegenSplitFloat{FFlag::LuauCodegenSplitFloat, true};
+    ScopedFastFlag luauCodegenFloatOps{FFlag::LuauCodegenFloatOps, true};
 
     // This test requires runtime component to be present
     if (!Luau::CodeGen::isSupported())
         return;
 
-    // TODO: opportunity - with float load/store separated from float/double conversion, reads at the end can be removed
     CHECK_EQ(
         "\n" + getCodegenAssembly(
                    R"(
@@ -2951,46 +2977,30 @@ bb_bytecode_1:
   CHECK_USERDATA_TAG %10, 12i, exit(0)
   %12 = BUFFER_READF32 %10, 0i, tuserdata
   %13 = BUFFER_READF32 %10, 4i, tuserdata
-  %14 = FLOAT_TO_NUM %12
-  %15 = FLOAT_TO_NUM %13
-  %16 = UNM_NUM %14
-  %17 = UNM_NUM %15
-  %18 = NUM_TO_FLOAT %16
-  %19 = NUM_TO_FLOAT %17
+  %14 = UNM_FLOAT %12
+  %15 = UNM_FLOAT %13
   CHECK_GC
-  %21 = NEW_USERDATA 8i, 12i
-  BUFFER_WRITEF32 %21, 0i, %18, tuserdata
-  BUFFER_WRITEF32 %21, 4i, %19, tuserdata
-  STORE_POINTER R4, %21
+  %17 = NEW_USERDATA 8i, 12i
+  BUFFER_WRITEF32 %17, 0i, %14, tuserdata
+  BUFFER_WRITEF32 %17, 4i, %15, tuserdata
+  STORE_POINTER R4, %17
   STORE_TAG R4, tuserdata
-  %30 = LOAD_POINTER R0
-  CHECK_USERDATA_TAG %30, 12i, exit(1)
-  %32 = LOAD_POINTER R1
-  CHECK_USERDATA_TAG %32, 12i, exit(1)
-  %34 = BUFFER_READF32 %30, 0i, tuserdata
-  %35 = BUFFER_READF32 %32, 0i, tuserdata
-  %36 = FLOAT_TO_NUM %34
-  %37 = FLOAT_TO_NUM %35
-  %38 = MUL_NUM %36, %37
-  %39 = BUFFER_READF32 %30, 4i, tuserdata
-  %40 = BUFFER_READF32 %32, 4i, tuserdata
-  %41 = FLOAT_TO_NUM %39
-  %42 = FLOAT_TO_NUM %40
-  %43 = MUL_NUM %41, %42
-  %44 = NUM_TO_FLOAT %38
-  %45 = NUM_TO_FLOAT %43
-  %62 = FLOAT_TO_NUM %18
-  %63 = FLOAT_TO_NUM %44
-  %64 = ADD_NUM %62, %63
-  %67 = FLOAT_TO_NUM %19
-  %68 = FLOAT_TO_NUM %45
-  %69 = ADD_NUM %67, %68
-  %70 = NUM_TO_FLOAT %64
-  %71 = NUM_TO_FLOAT %69
-  %73 = NEW_USERDATA 8i, 12i
-  BUFFER_WRITEF32 %73, 0i, %70, tuserdata
-  BUFFER_WRITEF32 %73, 4i, %71, tuserdata
-  STORE_POINTER R3, %73
+  %26 = LOAD_POINTER R0
+  CHECK_USERDATA_TAG %26, 12i, exit(1)
+  %28 = LOAD_POINTER R1
+  CHECK_USERDATA_TAG %28, 12i, exit(1)
+  %30 = BUFFER_READF32 %26, 0i, tuserdata
+  %31 = BUFFER_READF32 %28, 0i, tuserdata
+  %32 = MUL_FLOAT %30, %31
+  %33 = BUFFER_READF32 %26, 4i, tuserdata
+  %34 = BUFFER_READF32 %28, 4i, tuserdata
+  %35 = MUL_FLOAT %33, %34
+  %52 = ADD_FLOAT %14, %32
+  %55 = ADD_FLOAT %15, %35
+  %57 = NEW_USERDATA 8i, 12i
+  BUFFER_WRITEF32 %57, 0i, %52, tuserdata
+  BUFFER_WRITEF32 %57, 4i, %55, tuserdata
+  STORE_POINTER R3, %57
   STORE_TAG R3, tuserdata
   INTERRUPT 3u
   RETURN R3, 1i
@@ -3362,6 +3372,41 @@ bb_bytecode_1:
     );
 }
 
+TEST_CASE("VectorCreateXY")
+{
+    ScopedFastFlag luauCodegenBlockSafeEnv{FFlag::LuauCodegenBlockSafeEnv, true};
+    ScopedFastFlag luauCodegenSplitFloat{FFlag::LuauCodegenSplitFloat, true};
+    ScopedFastFlag luauCodegenVectorCreateXy{FFlag::LuauCodegenVectorCreateXy, true};
+
+    CHECK_EQ(
+        "\n" + getCodegenAssembly(
+                   R"(
+local function foo(a: number): vector
+    return vector.create(a, a * 2.0)
+end
+)"
+               ),
+        R"(
+; function foo($arg0) line 2
+bb_0:
+  CHECK_TAG R0, tnumber, exit(entry)
+  JUMP bb_2
+bb_2:
+  JUMP bb_bytecode_1
+bb_bytecode_1:
+  implicit CHECK_SAFE_ENV exit(0)
+  %6 = LOAD_DOUBLE R0
+  %7 = ADD_NUM %6, %6
+  %17 = NUM_TO_FLOAT %6
+  %18 = NUM_TO_FLOAT %7
+  STORE_VECTOR R1, %17, %18, 0
+  STORE_TAG R1, tvector
+  INTERRUPT 7u
+  RETURN R1, 1i
+)"
+    );
+}
+
 TEST_CASE("VectorLoadStoreOnlySamePrecision")
 {
     ScopedFastFlag luauCodegenBlockSafeEnv{FFlag::LuauCodegenBlockSafeEnv, true};
@@ -3402,10 +3447,748 @@ bb_bytecode_1:
     );
 }
 
+TEST_CASE("BufferRelatedIndicesPositiveBase")
+{
+    ScopedFastFlag luauCodegenBlockSafeEnv{FFlag::LuauCodegenBlockSafeEnv, true};
+    ScopedFastFlag luauCodegenNumIntFolds{FFlag::LuauCodegenNumIntFolds2, true};
+    ScopedFastFlag luauCodegenBufferRangeMerge{FFlag::LuauCodegenBufferRangeMerge, true};
+
+    CHECK_EQ(
+        "\n" + getCodegenAssembly(R"(
+local function foo(buf: buffer, a: number)
+    return buffer.readi32(buf, a) + buffer.readi32(buf, a + 4) + buffer.readi32(buf, a + 8)
+end
+)"),
+        R"(
+; function foo($arg0, $arg1) line 2
+bb_0:
+  CHECK_TAG R0, tbuffer, exit(entry)
+  CHECK_TAG R1, tnumber, exit(entry)
+  JUMP bb_2
+bb_2:
+  JUMP bb_bytecode_1
+bb_bytecode_1:
+  implicit CHECK_SAFE_ENV exit(0)
+  %11 = LOAD_POINTER R0
+  %12 = LOAD_DOUBLE R1
+  %13 = NUM_TO_INT %12
+  CHECK_BUFFER_LEN %11, %13, 0i, 12i, %12, exit(2)
+  %15 = BUFFER_READI32 %11, %13
+  %16 = INT_TO_NUM %15
+  %32 = ADD_INT %13, 4i
+  %34 = BUFFER_READI32 %11, %32
+  %35 = INT_TO_NUM %34
+  %44 = ADD_NUM %16, %35
+  %60 = ADD_INT %13, 8i
+  %62 = BUFFER_READI32 %11, %60
+  %63 = INT_TO_NUM %62
+  %72 = ADD_NUM %44, %63
+  STORE_DOUBLE R2, %72
+  STORE_TAG R2, tnumber
+  INTERRUPT 23u
+  RETURN R2, 1i
+)"
+    );
+}
+
+TEST_CASE("BufferRelatedIndicesPositiveBaseInverted")
+{
+    ScopedFastFlag luauCodegenBlockSafeEnv{FFlag::LuauCodegenBlockSafeEnv, true};
+    ScopedFastFlag luauCodegenNumIntFolds{FFlag::LuauCodegenNumIntFolds2, true};
+    ScopedFastFlag luauCodegenBufferRangeMerge{FFlag::LuauCodegenBufferRangeMerge, true};
+
+    CHECK_EQ(
+        "\n" + getCodegenAssembly(R"(
+local function foo(buf: buffer, a: number)
+    return buffer.readi32(buf, a + 8) + buffer.readi32(buf, a + 4) + buffer.readi32(buf, a + 0)
+end
+)"),
+        R"(
+; function foo($arg0, $arg1) line 2
+bb_0:
+  CHECK_TAG R0, tbuffer, exit(entry)
+  CHECK_TAG R1, tnumber, exit(entry)
+  JUMP bb_2
+bb_2:
+  JUMP bb_bytecode_1
+bb_bytecode_1:
+  implicit CHECK_SAFE_ENV exit(0)
+  %8 = LOAD_DOUBLE R1
+  %9 = ADD_NUM %8, 8
+  STORE_DOUBLE R6, %9
+  STORE_TAG R6, tnumber
+  %17 = LOAD_POINTER R0
+  %19 = NUM_TO_INT %9
+  CHECK_BUFFER_LEN %17, %19, -8i, 4i, %9, exit(3)
+  %21 = BUFFER_READI32 %17, %19
+  %22 = INT_TO_NUM %21
+  %38 = ADD_INT %19, -4i
+  %40 = BUFFER_READI32 %17, %38
+  %41 = INT_TO_NUM %40
+  %50 = ADD_NUM %22, %41
+  %66 = ADD_INT %19, -8i
+  %68 = BUFFER_READI32 %17, %66
+  %69 = INT_TO_NUM %68
+  %78 = ADD_NUM %50, %69
+  STORE_DOUBLE R2, %78
+  STORE_TAG R2, tnumber
+  INTERRUPT 23u
+  RETURN R2, 1i
+)"
+    );
+}
+TEST_CASE("BufferRelatedIndicesPositiveDynamicBase")
+{
+    ScopedFastFlag luauCodegenBlockSafeEnv{FFlag::LuauCodegenBlockSafeEnv, true};
+    ScopedFastFlag luauCodegenSplitFloat{FFlag::LuauCodegenSplitFloat, true};
+    ScopedFastFlag luauCodegenNumIntFolds{FFlag::LuauCodegenNumIntFolds2, true};
+    ScopedFastFlag luauCodegenBufferRangeMerge{FFlag::LuauCodegenBufferRangeMerge, true};
+
+    CHECK_EQ(
+        "\n" + getCodegenAssembly(R"(
+local function foo(index: buffer, data: buffer, a: number)
+    local i = buffer.readi32(index, a)
+    return buffer.readf32(data, i + 0) * buffer.readf32(data, i + 4) * buffer.readf32(data, i + 8)
+end
+)"),
+        R"(
+; function foo($arg0, $arg1, $arg2) line 2
+bb_0:
+  CHECK_TAG R0, tbuffer, exit(entry)
+  CHECK_TAG R1, tbuffer, exit(entry)
+  CHECK_TAG R2, tnumber, exit(entry)
+  JUMP bb_2
+bb_2:
+  JUMP bb_bytecode_1
+bb_bytecode_1:
+  implicit CHECK_SAFE_ENV exit(0)
+  %13 = LOAD_POINTER R0
+  %14 = LOAD_DOUBLE R2
+  %15 = NUM_TO_INT %14
+  CHECK_BUFFER_LEN %13, %15, 0i, 4i, undef, exit(2)
+  %17 = BUFFER_READI32 %13, %15
+  %18 = INT_TO_NUM %17
+  STORE_DOUBLE R3, %18
+  STORE_TAG R3, tnumber
+  %24 = ADD_NUM %18, 0
+  STORE_DOUBLE R8, %24
+  STORE_TAG R8, tnumber
+  %32 = LOAD_POINTER R1
+  %34 = NUM_TO_INT %18
+  CHECK_BUFFER_LEN %32, %34, 0i, 12i, %18, exit(10)
+  %36 = BUFFER_READF32 %32, %34
+  %37 = FLOAT_TO_NUM %36
+  %53 = ADD_INT %34, 4i
+  %55 = BUFFER_READF32 %32, %53
+  %56 = FLOAT_TO_NUM %55
+  %65 = MUL_NUM %37, %56
+  %81 = ADD_INT %34, 8i
+  %83 = BUFFER_READF32 %32, %81
+  %84 = FLOAT_TO_NUM %83
+  %93 = MUL_NUM %65, %84
+  STORE_DOUBLE R4, %93
+  STORE_TAG R4, tnumber
+  INTERRUPT 30u
+  RETURN R4, 1i
+)"
+    );
+}
+
+TEST_CASE("BufferRelatedIndicesPositiveLoopRangeBase")
+{
+    ScopedFastFlag luauCodegenBlockSafeEnv{FFlag::LuauCodegenBlockSafeEnv, true};
+    ScopedFastFlag luauCodegenHydrateLoadWithTag{FFlag::LuauCodegenHydrateLoadWithTag, true};
+    ScopedFastFlag luauCodegenInterruptIsNotForWrites{FFlag::LuauCodegenInterruptIsNotForWrites, true};
+    ScopedFastFlag luauCodegenSplitFloat{FFlag::LuauCodegenSplitFloat, true};
+    ScopedFastFlag luauCodegenLoopStepDetectFix{FFlag::LuauCodegenLoopStepDetectFix, true};
+    ScopedFastFlag luauCodegenSetBlockEntryState{FFlag::LuauCodegenSetBlockEntryState, true};
+    ScopedFastFlag luauCodegenNumIntFolds{FFlag::LuauCodegenNumIntFolds2, true};
+    ScopedFastFlag luauCodegenBufferRangeMerge{FFlag::LuauCodegenBufferRangeMerge, true};
+
+    // TODO: opportunity 1 - lifting the R2 tag check at the start of the block will eliminate many dead stores
+    // TODO: opportunity 2 - buffer.len is not a fastcall, but under safe env we can treat it like one and read buffer len field
+    // TODO: opportunity 3 - range of 'i' is known, we can check it in loop header
+    CHECK_EQ(
+        "\n" + getCodegenAssembly(R"(
+local function foo(buf: buffer, a: number)
+    local s = 0
+    for i = 0, buffer.len(buf) - 1, 12 do
+        s += buffer.readf32(buf, i) * buffer.readf32(buf, i + 4) * buffer.readf32(buf, i + 8)
+    end
+    return s
+end
+)"),
+        R"(
+; function foo($arg0, $arg1) line 2
+bb_0:
+  CHECK_TAG R0, tbuffer, exit(entry)
+  CHECK_TAG R1, tnumber, exit(entry)
+  JUMP bb_4
+bb_4:
+  JUMP bb_bytecode_1
+bb_bytecode_1:
+  implicit CHECK_SAFE_ENV exit(0)
+  STORE_DOUBLE R2, 0
+  STORE_TAG R2, tnumber
+  STORE_DOUBLE R5, 0
+  STORE_TAG R5, tnumber
+  GET_CACHED_IMPORT R6, K3 (nil), 2148534272u ('buffer'.'len'), 3u
+  %12 = LOAD_TVALUE R0, 0i, tbuffer
+  STORE_TVALUE R7, %12
+  INTERRUPT 5u
+  SET_SAVEDPC 6u
+  CALL R6, 1i, 1i
+  CHECK_TAG R6, tnumber, bb_fallback_5
+  %19 = LOAD_DOUBLE R6
+  %20 = SUB_NUM %19, 1
+  STORE_DOUBLE R3, %20
+  STORE_TAG R3, tnumber
+  JUMP bb_6
+bb_6:
+  STORE_DOUBLE R4, 12
+  STORE_TAG R4, tnumber
+  CHECK_TAG R3, tnumber, exit(8)
+  CHECK_TAG R5, tnumber, exit(8)
+  %33 = LOAD_DOUBLE R3
+  JUMP_CMP_NUM R5, %33, not_le, bb_bytecode_3, bb_bytecode_2
+bb_bytecode_2:
+  implicit CHECK_SAFE_ENV exit(9)
+  INTERRUPT 9u
+  CHECK_TAG R5, tnumber, exit(11)
+  %42 = LOAD_POINTER R0
+  %43 = LOAD_DOUBLE R5
+  %44 = NUM_TO_INT %43
+  CHECK_BUFFER_LEN %42, %44, 0i, 12i, %43, exit(11)
+  %46 = BUFFER_READF32 %42, %44
+  %47 = FLOAT_TO_NUM %46
+  %53 = ADD_NUM %43, 4
+  STORE_DOUBLE R11, %53
+  STORE_TAG R11, tnumber
+  %63 = ADD_INT %44, 4i
+  %65 = BUFFER_READF32 %42, %63
+  %66 = FLOAT_TO_NUM %65
+  STORE_DOUBLE R9, %66
+  STORE_TAG R9, tnumber
+  %75 = MUL_NUM %47, %66
+  STORE_DOUBLE R7, %75
+  STORE_TAG R7, tnumber
+  %81 = ADD_NUM %43, 8
+  STORE_DOUBLE R10, %81
+  STORE_TAG R10, tnumber
+  %91 = ADD_INT %44, 8i
+  %93 = BUFFER_READF32 %42, %91
+  %94 = FLOAT_TO_NUM %93
+  STORE_SPLIT_TVALUE R8, tnumber, %94
+  %103 = MUL_NUM %75, %94
+  STORE_DOUBLE R6, %103
+  STORE_TAG R6, tnumber
+  CHECK_TAG R2, tnumber, exit(32)
+  %110 = LOAD_DOUBLE R2
+  %112 = ADD_NUM %110, %103
+  STORE_DOUBLE R2, %112
+  %114 = LOAD_DOUBLE R3
+  %116 = ADD_NUM %43, 12
+  STORE_DOUBLE R5, %116
+  JUMP_CMP_NUM %116, %114, le, bb_bytecode_2, bb_bytecode_3
+bb_bytecode_3:
+  INTERRUPT 34u
+  RETURN R2, 1i
+)"
+    );
+}
+
+TEST_CASE("BufferRelatedIndicesPositiveAdvancingBase")
+{
+    ScopedFastFlag luauCodegenBlockSafeEnv{FFlag::LuauCodegenBlockSafeEnv, true};
+    ScopedFastFlag luauCodegenNumIntFolds{FFlag::LuauCodegenNumIntFolds2, true};
+    ScopedFastFlag luauCodegenBufferRangeMerge{FFlag::LuauCodegenBufferRangeMerge, true};
+
+    CHECK_EQ(
+        "\n" + getCodegenAssembly(R"(
+local function foo(buf: buffer, pos: number, a: number, b: number, c: number)
+    buffer.writei32(buf, pos, a)
+    pos += 4
+    buffer.writei32(buf, pos, b)
+    pos += 4
+    buffer.writei32(buf, pos, c)
+    pos += 4
+
+    return pos
+end
+)"),
+        R"(
+; function foo($arg0, $arg1, $arg2, $arg3, $arg4) line 2
+bb_0:
+  CHECK_TAG R0, tbuffer, exit(entry)
+  CHECK_TAG R1, tnumber, exit(entry)
+  CHECK_TAG R2, tnumber, exit(entry)
+  CHECK_TAG R3, tnumber, exit(entry)
+  CHECK_TAG R4, tnumber, exit(entry)
+  JUMP bb_2
+bb_2:
+  JUMP bb_bytecode_1
+bb_bytecode_1:
+  implicit CHECK_SAFE_ENV exit(0)
+  %19 = LOAD_POINTER R0
+  %20 = LOAD_DOUBLE R1
+  %21 = NUM_TO_INT %20
+  CHECK_BUFFER_LEN %19, %21, 0i, 12i, %20, exit(2)
+  %23 = LOAD_DOUBLE R2
+  %24 = NUM_TO_UINT %23
+  BUFFER_WRITEI32 %19, %21, %24
+  %29 = ADD_NUM %20, 4
+  %40 = ADD_INT %21, 4i
+  %42 = LOAD_DOUBLE R3
+  %43 = NUM_TO_UINT %42
+  BUFFER_WRITEI32 %19, %40, %43
+  %48 = ADD_NUM %29, 4
+  %59 = ADD_INT %21, 8i
+  %61 = LOAD_DOUBLE R4
+  %62 = NUM_TO_UINT %61
+  BUFFER_WRITEI32 %19, %59, %62
+  %67 = ADD_NUM %48, 4
+  STORE_DOUBLE R1, %67
+  INTERRUPT 27u
+  RETURN R1, 1i
+)"
+    );
+}
+
+TEST_CASE("BufferRelatedIndicesNegativeBase")
+{
+    ScopedFastFlag luauCodegenBlockSafeEnv{FFlag::LuauCodegenBlockSafeEnv, true};
+    ScopedFastFlag luauCodegenNumIntFolds{FFlag::LuauCodegenNumIntFolds2, true};
+    ScopedFastFlag luauCodegenBufferRangeMerge{FFlag::LuauCodegenBufferRangeMerge, true};
+
+    CHECK_EQ(
+        "\n" + getCodegenAssembly(R"(
+local function foo(buf: buffer, a: number)
+    return buffer.readi32(buf, a - 8) + buffer.readi32(buf, a - 4) + buffer.readi32(buf, a - 0)
+end
+)"),
+        R"(
+; function foo($arg0, $arg1) line 2
+bb_0:
+  CHECK_TAG R0, tbuffer, exit(entry)
+  CHECK_TAG R1, tnumber, exit(entry)
+  JUMP bb_2
+bb_2:
+  JUMP bb_bytecode_1
+bb_bytecode_1:
+  implicit CHECK_SAFE_ENV exit(0)
+  %8 = LOAD_DOUBLE R1
+  %9 = SUB_NUM %8, 8
+  STORE_DOUBLE R6, %9
+  STORE_TAG R6, tnumber
+  %17 = LOAD_POINTER R0
+  %19 = NUM_TO_INT %9
+  CHECK_BUFFER_LEN %17, %19, 0i, 12i, %9, exit(3)
+  %21 = BUFFER_READI32 %17, %19
+  %22 = INT_TO_NUM %21
+  %38 = ADD_INT %19, 4i
+  %40 = BUFFER_READI32 %17, %38
+  %41 = INT_TO_NUM %40
+  %50 = ADD_NUM %22, %41
+  %66 = ADD_INT %19, 8i
+  %68 = BUFFER_READI32 %17, %66
+  %69 = INT_TO_NUM %68
+  %78 = ADD_NUM %50, %69
+  STORE_DOUBLE R2, %78
+  STORE_TAG R2, tnumber
+  INTERRUPT 23u
+  RETURN R2, 1i
+)"
+    );
+}
+
+TEST_CASE("BufferRelatedIndicesMixedBase")
+{
+    ScopedFastFlag luauCodegenBlockSafeEnv{FFlag::LuauCodegenBlockSafeEnv, true};
+    ScopedFastFlag luauCodegenNumIntFolds{FFlag::LuauCodegenNumIntFolds2, true};
+    ScopedFastFlag luauCodegenBufferRangeMerge{FFlag::LuauCodegenBufferRangeMerge, true};
+
+    CHECK_EQ(
+        "\n" + getCodegenAssembly(R"(
+local function foo(buf: buffer, a: number)
+    return buffer.readi32(buf, a) + buffer.readi32(buf, a - 4) + buffer.readi32(buf, a + 4)
+end
+)"),
+        R"(
+; function foo($arg0, $arg1) line 2
+bb_0:
+  CHECK_TAG R0, tbuffer, exit(entry)
+  CHECK_TAG R1, tnumber, exit(entry)
+  JUMP bb_2
+bb_2:
+  JUMP bb_bytecode_1
+bb_bytecode_1:
+  implicit CHECK_SAFE_ENV exit(0)
+  %11 = LOAD_POINTER R0
+  %12 = LOAD_DOUBLE R1
+  %13 = NUM_TO_INT %12
+  CHECK_BUFFER_LEN %11, %13, -4i, 8i, %12, exit(2)
+  %15 = BUFFER_READI32 %11, %13
+  %16 = INT_TO_NUM %15
+  %32 = ADD_INT %13, -4i
+  %34 = BUFFER_READI32 %11, %32
+  %35 = INT_TO_NUM %34
+  %44 = ADD_NUM %16, %35
+  %60 = ADD_INT %13, 4i
+  %62 = BUFFER_READI32 %11, %60
+  %63 = INT_TO_NUM %62
+  %72 = ADD_NUM %44, %63
+  STORE_DOUBLE R2, %72
+  STORE_TAG R2, tnumber
+  INTERRUPT 23u
+  RETURN R2, 1i
+)"
+    );
+}
+
+TEST_CASE("BufferSanityPositive")
+{
+    ScopedFastFlag luauCodegenBlockSafeEnv{FFlag::LuauCodegenBlockSafeEnv, true};
+    ScopedFastFlag luauCodegenNumIntFolds{FFlag::LuauCodegenNumIntFolds2, true};
+    ScopedFastFlag luauCodegenBufferRangeMerge{FFlag::LuauCodegenBufferRangeMerge, true};
+
+    CHECK_EQ(
+        "\n" + getCodegenAssembly(R"(
+local function foo(zero: number, b1: buffer, b2: buffer)
+    buffer.writei8(b1, zero + 0, buffer.readi8(b1, zero + 0))
+    buffer.writeu8(b1, zero + 0, buffer.readu8(b1, zero + 0))
+
+    buffer.writei8(b2, zero + 0, buffer.readi8(b2, zero + 0))
+    buffer.writeu8(b2, zero + 0, buffer.readu8(b2, zero + 0))
+    buffer.writei8(b2, zero + 1, buffer.readi8(b2, zero + 1))
+    buffer.writeu8(b2, zero + 1, buffer.readu8(b2, zero + 1))
+    buffer.writei16(b2, zero + 0, buffer.readi16(b2, zero + 0))
+    buffer.writeu16(b2, zero + 0, buffer.readu16(b2, zero + 0))
+end
+)"),
+        R"(
+; function foo($arg0, $arg1, $arg2) line 2
+bb_0:
+  CHECK_TAG R0, tnumber, exit(entry)
+  CHECK_TAG R1, tbuffer, exit(entry)
+  CHECK_TAG R2, tbuffer, exit(entry)
+  JUMP bb_2
+bb_2:
+  JUMP bb_bytecode_1
+bb_bytecode_1:
+  implicit CHECK_SAFE_ENV exit(0)
+  %10 = LOAD_DOUBLE R0
+  %11 = ADD_NUM %10, 0
+  STORE_DOUBLE R5, %11
+  STORE_TAG R5, tnumber
+  STORE_DOUBLE R8, %11
+  STORE_TAG R8, tnumber
+  %25 = LOAD_POINTER R1
+  %27 = NUM_TO_INT %10
+  CHECK_BUFFER_LEN %25, %27, 0i, 1i, undef, exit(4)
+  %29 = BUFFER_READI8 %25, %27
+  BUFFER_WRITEI8 %25, %27, %29
+  %68 = BUFFER_READU8 %25, %27
+  %69 = INT_TO_NUM %68
+  STORE_SPLIT_TVALUE R6, tnumber, %69
+  BUFFER_WRITEI8 %25, %27, %68
+  STORE_DOUBLE R5, %11
+  STORE_DOUBLE R8, %11
+  %103 = LOAD_POINTER R2
+  CHECK_BUFFER_LEN %103, %27, 0i, 2i, %10, exit(32)
+  %107 = BUFFER_READI8 %103, %27
+  BUFFER_WRITEI8 %103, %27, %107
+  %146 = BUFFER_READU8 %103, %27
+  BUFFER_WRITEI8 %103, %27, %146
+  %183 = ADD_INT %27, 1i
+  %185 = BUFFER_READI8 %103, %183
+  BUFFER_WRITEI8 %103, %183, %185
+  %224 = BUFFER_READU8 %103, %183
+  BUFFER_WRITEI8 %103, %183, %224
+  %263 = BUFFER_READI16 %103, %27
+  BUFFER_WRITEI16 %103, %27, %263
+  %302 = BUFFER_READU16 %103, %27
+  BUFFER_WRITEI16 %103, %27, %302
+  INTERRUPT 112u
+  RETURN R0, 0i
+)"
+    );
+}
+
+TEST_CASE("BufferSanityNegative")
+{
+    ScopedFastFlag luauCodegenBlockSafeEnv{FFlag::LuauCodegenBlockSafeEnv, true};
+    ScopedFastFlag luauCodegenNumIntFolds{FFlag::LuauCodegenNumIntFolds2, true};
+    ScopedFastFlag luauCodegenBufferRangeMerge{FFlag::LuauCodegenBufferRangeMerge, true};
+
+    CHECK_EQ(
+        "\n" + getCodegenAssembly(R"(
+local function foo(one: number, b1: buffer, b2: buffer)
+    buffer.writei8(b1, one - 1, buffer.readi8(b1, one - 1))
+    buffer.writeu8(b1, one - 1, buffer.readu8(b1, one - 1))
+
+    buffer.writei8(b2, one - 1, buffer.readi8(b2, one - 1))
+    buffer.writeu8(b2, one - 1, buffer.readu8(b2, one - 1))
+    buffer.writei8(b2, one - 0, buffer.readi8(b2, one - 0))
+    buffer.writeu8(b2, one - 0, buffer.readu8(b2, one - 0))
+    buffer.writei16(b2, one - 1, buffer.readi16(b2, one - 1))
+    buffer.writeu16(b2, one - 1, buffer.readu16(b2, one - 1))
+end
+)"),
+        R"(
+; function foo($arg0, $arg1, $arg2) line 2
+bb_0:
+  CHECK_TAG R0, tnumber, exit(entry)
+  CHECK_TAG R1, tbuffer, exit(entry)
+  CHECK_TAG R2, tbuffer, exit(entry)
+  JUMP bb_2
+bb_2:
+  JUMP bb_bytecode_1
+bb_bytecode_1:
+  implicit CHECK_SAFE_ENV exit(0)
+  %10 = LOAD_DOUBLE R0
+  %11 = SUB_NUM %10, 1
+  STORE_DOUBLE R5, %11
+  STORE_TAG R5, tnumber
+  STORE_DOUBLE R8, %11
+  STORE_TAG R8, tnumber
+  %25 = LOAD_POINTER R1
+  %27 = NUM_TO_INT %11
+  CHECK_BUFFER_LEN %25, %27, 0i, 1i, undef, exit(4)
+  %29 = BUFFER_READI8 %25, %27
+  BUFFER_WRITEI8 %25, %27, %29
+  %68 = BUFFER_READU8 %25, %27
+  %69 = INT_TO_NUM %68
+  STORE_SPLIT_TVALUE R6, tnumber, %69
+  BUFFER_WRITEI8 %25, %27, %68
+  STORE_DOUBLE R5, %11
+  STORE_DOUBLE R8, %11
+  %103 = LOAD_POINTER R2
+  CHECK_BUFFER_LEN %103, %27, 0i, 2i, %11, exit(32)
+  %107 = BUFFER_READI8 %103, %27
+  BUFFER_WRITEI8 %103, %27, %107
+  %146 = BUFFER_READU8 %103, %27
+  BUFFER_WRITEI8 %103, %27, %146
+  %183 = ADD_INT %27, 1i
+  %185 = BUFFER_READI8 %103, %183
+  BUFFER_WRITEI8 %103, %183, %185
+  %224 = BUFFER_READU8 %103, %183
+  BUFFER_WRITEI8 %103, %183, %224
+  %263 = BUFFER_READI16 %103, %27
+  BUFFER_WRITEI16 %103, %27, %263
+  %302 = BUFFER_READU16 %103, %27
+  BUFFER_WRITEI16 %103, %27, %302
+  INTERRUPT 112u
+  RETURN R0, 0i
+)"
+    );
+}
+
+TEST_CASE("NumericConversionReplacementCheck")
+{
+    ScopedFastFlag luauCodegenBlockSafeEnv{FFlag::LuauCodegenBlockSafeEnv, true};
+    ScopedFastFlag luauCodegenNumIntFolds{FFlag::LuauCodegenNumIntFolds2, true};
+    ScopedFastFlag luauCodegenBufferRangeMerge{FFlag::LuauCodegenBufferRangeMerge, true};
+
+    CHECK_EQ(
+        "\n" + getCodegenAssembly(R"(
+local function foo(buf: buffer, a: number)
+    math.ldexp(a, a) -- generate NUM_TO_INT early
+
+    -- range checks cannot make NUM_TO_INT exit to VM at a later location
+    return buffer.readi32(buf, a) + buffer.readi32(buf, a + 4)
+end
+)"),
+        R"(
+; function foo($arg0, $arg1) line 2
+bb_0:
+  CHECK_TAG R0, tbuffer, exit(entry)
+  CHECK_TAG R1, tnumber, exit(entry)
+  JUMP bb_2
+bb_2:
+  JUMP bb_bytecode_1
+bb_bytecode_1:
+  implicit CHECK_SAFE_ENV exit(0)
+  %11 = LOAD_DOUBLE R1
+  %13 = NUM_TO_INT %11
+  %14 = INVOKE_LIBM 15u, %11, %13
+  STORE_DOUBLE R2, %14
+  STORE_TAG R2, tnumber
+  %22 = LOAD_POINTER R0
+  CHECK_BUFFER_LEN %22, %13, 0i, 8i, %11, exit(9)
+  %26 = BUFFER_READI32 %22, %13
+  %27 = INT_TO_NUM %26
+  %43 = ADD_INT %13, 4i
+  %45 = BUFFER_READI32 %22, %43
+  %46 = INT_TO_NUM %45
+  %55 = ADD_NUM %27, %46
+  STORE_DOUBLE R2, %55
+  INTERRUPT 22u
+  RETURN R2, 1i
+)"
+    );
+}
+
+TEST_CASE("BufferRelatedIndicesPositiveMultBase")
+{
+    ScopedFastFlag luauCodegenBlockSafeEnv{FFlag::LuauCodegenBlockSafeEnv, true};
+    ScopedFastFlag luauCodegenNumIntFolds{FFlag::LuauCodegenNumIntFolds2, true};
+    ScopedFastFlag luauCodegenBufferRangeMerge{FFlag::LuauCodegenBufferRangeMerge, true};
+
+    CHECK_EQ(
+        "\n" + getCodegenAssembly(R"(
+local function foo(buf: buffer, a: number)
+    return buffer.readi32(buf, a * 4) + buffer.readi32(buf, (a + 1) * 4) + buffer.readi32(buf, (a + 2) * 4)
+end
+)"),
+        R"(
+; function foo($arg0, $arg1) line 2
+bb_0:
+  CHECK_TAG R0, tbuffer, exit(entry)
+  CHECK_TAG R1, tnumber, exit(entry)
+  JUMP bb_2
+bb_2:
+  JUMP bb_bytecode_1
+bb_bytecode_1:
+  implicit CHECK_SAFE_ENV exit(0)
+  %8 = LOAD_DOUBLE R1
+  %9 = MUL_NUM %8, 4
+  STORE_DOUBLE R6, %9
+  STORE_TAG R6, tnumber
+  %17 = LOAD_POINTER R0
+  %19 = NUM_TO_INT %9
+  CHECK_BUFFER_LEN %17, %19, 0i, 12i, %9, exit(3)
+  %21 = BUFFER_READI32 %17, %19
+  %22 = INT_TO_NUM %21
+  %44 = ADD_INT %19, 4i
+  %46 = BUFFER_READI32 %17, %44
+  %47 = INT_TO_NUM %46
+  %56 = ADD_NUM %22, %47
+  %78 = ADD_INT %19, 8i
+  %80 = BUFFER_READI32 %17, %78
+  %81 = INT_TO_NUM %80
+  %90 = ADD_NUM %56, %81
+  STORE_DOUBLE R2, %90
+  STORE_TAG R2, tnumber
+  INTERRUPT 25u
+  RETURN R2, 1i
+)"
+    );
+}
+
+TEST_CASE("BufferRelatedIndicesPositiveMultBase2")
+{
+    ScopedFastFlag luauCodegenBlockSafeEnv{FFlag::LuauCodegenBlockSafeEnv, true};
+    ScopedFastFlag luauCodegenNumIntFolds{FFlag::LuauCodegenNumIntFolds2, true};
+    ScopedFastFlag luauCodegenBufferRangeMerge{FFlag::LuauCodegenBufferRangeMerge, true};
+
+    // Different index multipliers are not merged
+    CHECK_EQ(
+        "\n" + getCodegenAssembly(R"(
+local function foo(buf: buffer, a: number)
+    return buffer.readi32(buf, a * 4) + buffer.readi32(buf, (a + 1) * 8)
+end
+)"),
+        R"(
+; function foo($arg0, $arg1) line 2
+bb_0:
+  CHECK_TAG R0, tbuffer, exit(entry)
+  CHECK_TAG R1, tnumber, exit(entry)
+  JUMP bb_2
+bb_2:
+  JUMP bb_bytecode_1
+bb_bytecode_1:
+  implicit CHECK_SAFE_ENV exit(0)
+  %8 = LOAD_DOUBLE R1
+  %9 = MUL_NUM %8, 4
+  STORE_DOUBLE R5, %9
+  STORE_TAG R5, tnumber
+  %17 = LOAD_POINTER R0
+  %19 = NUM_TO_INT %9
+  CHECK_BUFFER_LEN %17, %19, 0i, 4i, undef, exit(3)
+  %21 = BUFFER_READI32 %17, %19
+  %22 = INT_TO_NUM %21
+  STORE_DOUBLE R3, %22
+  STORE_TAG R3, tnumber
+  %28 = ADD_NUM %8, 1
+  STORE_DOUBLE R7, %28
+  STORE_TAG R7, tnumber
+  %34 = MUL_NUM %28, 8
+  STORE_DOUBLE R6, %34
+  STORE_TAG R6, tnumber
+  %44 = NUM_TO_INT %34
+  CHECK_BUFFER_LEN %17, %44, 0i, 4i, undef, exit(11)
+  %46 = BUFFER_READI32 %17, %44
+  %47 = INT_TO_NUM %46
+  %56 = ADD_NUM %22, %47
+  STORE_DOUBLE R2, %56
+  STORE_TAG R2, tnumber
+  INTERRUPT 16u
+  RETURN R2, 1i
+)"
+    );
+}
+
+TEST_CASE("BufferRelatedIndicesPositiveMultBaseInt")
+{
+    ScopedFastFlag luauCodegenBlockSafeEnv{FFlag::LuauCodegenBlockSafeEnv, true};
+    ScopedFastFlag luauCodegenIntegerAddSub{FFlag::LuauCodegenIntegerAddSub, true};
+    ScopedFastFlag luauCodegenNumIntFolds{FFlag::LuauCodegenNumIntFolds2, true};
+    ScopedFastFlag luauCodegenBufferRangeMerge{FFlag::LuauCodegenBufferRangeMerge, true};
+
+    CHECK_EQ(
+        "\n" + getCodegenAssembly(R"(
+local function foo(buf: buffer, a: number)
+    -- trying to be helpful
+    local t1 = bit32.bor(a, 0)
+    local t2 = bit32.bor(t1 + 8, 0)
+    local t3 = bit32.bor(t1 + 16, 0)
+    return buffer.readf64(buf, t1) + buffer.readf64(buf, t2) + buffer.readf64(buf, t3)
+end
+)"),
+        R"(
+; function foo($arg0, $arg1) line 2
+bb_0:
+  CHECK_TAG R0, tbuffer, exit(entry)
+  CHECK_TAG R1, tnumber, exit(entry)
+  JUMP bb_2
+bb_2:
+  JUMP bb_bytecode_1
+bb_bytecode_1:
+  implicit CHECK_SAFE_ENV exit(0)
+  %9 = LOAD_DOUBLE R1
+  %10 = NUM_TO_UINT %9
+  %13 = UINT_TO_NUM %10
+  STORE_DOUBLE R2, %13
+  STORE_TAG R2, tnumber
+  %26 = ADD_INT %10, 8i
+  %29 = UINT_TO_NUM %26
+  STORE_DOUBLE R3, %29
+  STORE_TAG R3, tnumber
+  %35 = ADD_NUM %13, 16
+  STORE_DOUBLE R5, %35
+  STORE_TAG R5, tnumber
+  %42 = ADD_INT %10, 16i
+  %45 = UINT_TO_NUM %42
+  STORE_SPLIT_TVALUE R4, tnumber, %45
+  %53 = LOAD_POINTER R0
+  %55 = TRUNCATE_UINT %10
+  CHECK_BUFFER_LEN %53, %55, 0i, 24i, undef, exit(23)
+  %57 = BUFFER_READF64 %53, %55
+  %69 = BUFFER_READF64 %53, %26
+  %78 = ADD_NUM %57, %69
+  %90 = BUFFER_READF64 %53, %42
+  %99 = ADD_NUM %78, %90
+  STORE_DOUBLE R5, %99
+  INTERRUPT 44u
+  RETURN R5, 1i
+)"
+    );
+}
+
 TEST_CASE("Bit32NoDoubleTemporariesAdd")
 {
-    ScopedFastFlag luauCodegenIntegerAddSub{FFlag::LuauCodegenIntegerAddSub, true};
     ScopedFastFlag luauCodegenBlockSafeEnv{FFlag::LuauCodegenBlockSafeEnv, true};
+    ScopedFastFlag luauCodegenIntegerAddSub{FFlag::LuauCodegenIntegerAddSub, true};
 
     CHECK_EQ(
         "\n" + getCodegenAssembly(R"(
@@ -3989,6 +4772,22 @@ end
     );
 }
 
+TEST_CASE("FuzzTest9")
+{
+    ScopedFastFlag luauCodegenTruncateFold{FFlag::LuauCodegenTruncateFold, true};
+
+    // Check that this compiles with no assertions
+    CHECK(
+        getCodegenAssembly(R"(
+local function f(...)
+    local _ = bit32.lshift
+    local _ = nil,bit32(l0(_(_(8200202,0,_),nil),_),_),_(_,1752395619),{_=_(_,0),},_(_(_(8200202,0,_),0,""),0),_[_]
+end
+)")
+.size() > 0
+);
+}
+
 TEST_CASE("UpvalueAccessLoadStore1")
 {
     ScopedFastFlag luauCodegenBlockSafeEnv{FFlag::LuauCodegenBlockSafeEnv, true};
@@ -4276,6 +5075,8 @@ TEST_CASE("BufferLoadStoreProp1")
     ScopedFastFlag luauCodegenBlockSafeEnv{FFlag::LuauCodegenBlockSafeEnv, true};
     ScopedFastFlag luauCodegenBufferLoadProp{FFlag::LuauCodegenBufferLoadProp2, true};
     ScopedFastFlag luauCodegenSplitFloat{FFlag::LuauCodegenSplitFloat, true};
+    ScopedFastFlag luauCodegenNumIntFolds{FFlag::LuauCodegenNumIntFolds2, true};
+    ScopedFastFlag luauCodegenBufferRangeMerge{FFlag::LuauCodegenBufferRangeMerge, true};
 
     CHECK_EQ(
         "\n" + getCodegenAssembly(R"(
@@ -4293,7 +5094,7 @@ bb_2:
 bb_bytecode_1:
   implicit CHECK_SAFE_ENV exit(0)
   %7 = LOAD_POINTER R0
-  CHECK_BUFFER_LEN %7, 4i, 4i, exit(2)
+  CHECK_BUFFER_LEN %7, 0i, 0i, 8i, undef, exit(2)
   %10 = BUFFER_READF32 %7, 0i
   %11 = FLOAT_TO_NUM %10
   %30 = MUL_NUM %11, %11
@@ -4314,6 +5115,8 @@ TEST_CASE("BufferLoadStoreProp2")
     ScopedFastFlag luauCodegenBlockSafeEnv{FFlag::LuauCodegenBlockSafeEnv, true};
     ScopedFastFlag luauCodegenChainLink{FFlag::LuauCodegenChainLink, true};
     ScopedFastFlag luauCodegenBufferLoadProp{FFlag::LuauCodegenBufferLoadProp2, true};
+    ScopedFastFlag luauCodegenNumIntFolds{FFlag::LuauCodegenNumIntFolds2, true};
+    ScopedFastFlag luauCodegenBufferRangeMerge{FFlag::LuauCodegenBufferRangeMerge, true};
 
     CHECK_EQ(
         "\n" + getCodegenAssembly(R"(
@@ -4343,7 +5146,7 @@ bb_bytecode_1:
   STORE_DOUBLE R4, 32
   STORE_TAG R4, tnumber
   %15 = LOAD_POINTER R0
-  CHECK_BUFFER_LEN %15, 14i, 1i, exit(4)
+  CHECK_BUFFER_LEN %15, 10i, 0i, 5i, undef, exit(4)
   BUFFER_WRITEI8 %15, 10i, 32i
   JUMP bb_bytecode_3
 bb_bytecode_3:
@@ -4368,6 +5171,8 @@ TEST_CASE("BufferLoadStoreProp3")
     ScopedFastFlag luauCodegenChainLink{FFlag::LuauCodegenChainLink, true};
     ScopedFastFlag luauCodegenNumToUintFoldRange{FFlag::LuauCodegenNumToUintFoldRange, true};
     ScopedFastFlag luauCodegenBufferLoadProp{FFlag::LuauCodegenBufferLoadProp2, true};
+    ScopedFastFlag luauCodegenNumIntFolds{FFlag::LuauCodegenNumIntFolds2, true};
+    ScopedFastFlag luauCodegenBufferRangeMerge{FFlag::LuauCodegenBufferRangeMerge, true};
 
     CHECK_EQ(
         "\n" + getCodegenAssembly(R"(
@@ -4411,10 +5216,8 @@ bb_bytecode_1:
   STORE_DOUBLE R4, 4294967295
   STORE_TAG R4, tnumber
   %15 = LOAD_POINTER R0
-  CHECK_BUFFER_LEN %15, 0i, 4i, exit(4)
+  CHECK_BUFFER_LEN %15, 0i, 0i, 4i, undef, exit(4)
   BUFFER_WRITEI32 %15, 0i, -1i
-  STORE_TAG R2, tboolean
-  STORE_INT R2, 1i
   JUMP bb_bytecode_3
 bb_bytecode_3:
   JUMP bb_30
@@ -4432,9 +5235,6 @@ bb_37:
 bb_bytecode_9:
   JUMP bb_40
 bb_40:
-  STORE_DOUBLE R3, 0
-  STORE_DOUBLE R4, 65535
-  CHECK_BUFFER_LEN %15, 0i, 2i, exit(80)
   BUFFER_WRITEI16 %15, 0i, 65535i
   JUMP bb_bytecode_11
 bb_bytecode_11:
@@ -4453,9 +5253,6 @@ bb_51:
 bb_bytecode_17:
   JUMP bb_54
 bb_54:
-  STORE_DOUBLE R3, 0
-  STORE_DOUBLE R4, 4294967295
-  CHECK_BUFFER_LEN %15, 0i, 1i, exit(156)
   BUFFER_WRITEI8 %15, 0i, -1i
   JUMP bb_bytecode_19
 bb_bytecode_19:
@@ -4488,8 +5285,8 @@ TEST_CASE("BufferLoadStoreProp4")
     ScopedFastFlag luauCodegenIntegerAddSub{FFlag::LuauCodegenIntegerAddSub, true};
     ScopedFastFlag luauCodegenBufferLoadProp{FFlag::LuauCodegenBufferLoadProp2, true};
     ScopedFastFlag luauCodegenSplitFloat{FFlag::LuauCodegenSplitFloat, true};
+    ScopedFastFlag luauCodegenBufferRangeMerge{FFlag::LuauCodegenBufferRangeMerge, true};
 
-    // TODO: opportunity - CHECK_BUFFER_LEN with different access sizes can be merged
     CHECK_EQ(
         "\n" + getCodegenAssembly(R"(
 local function test(b: buffer, n: number, f: number)
@@ -4546,16 +5343,12 @@ bb_bytecode_1:
   STORE_DOUBLE R5, 0
   STORE_TAG R5, tnumber
   %17 = LOAD_POINTER R0
-  CHECK_BUFFER_LEN %17, 125i, 1i, exit(3)
+  CHECK_BUFFER_LEN %17, 0i, 0i, 212i, undef, exit(3)
   %21 = LOAD_DOUBLE R1
   %22 = NUM_TO_UINT %21
   BUFFER_WRITEI8 %17, 0i, %22
-  STORE_DOUBLE R5, 100
   %32 = SEXTI8_INT %22
   %33 = INT_TO_NUM %32
-  STORE_DOUBLE R6, %33
-  STORE_TAG R6, tnumber
-  CHECK_BUFFER_LEN %17, 204i, 8i, exit(18)
   BUFFER_WRITEF64 %17, 100i, %33
   BUFFER_WRITEI8 %17, 108i, %22
   BUFFER_WRITEI8 %17, 109i, %22
@@ -4564,10 +5357,7 @@ bb_bytecode_1:
   %126 = INT_TO_NUM %125
   BUFFER_WRITEF64 %17, 116i, %126
   BUFFER_WRITEI8 %17, 124i, %22
-  STORE_DOUBLE R6, %126
   BUFFER_WRITEI8 %17, 125i, %22
-  STORE_DOUBLE R5, 4
-  CHECK_BUFFER_LEN %17, 158i, 2i, exit(103)
   BUFFER_WRITEI16 %17, 4i, %22
   %218 = SEXTI16_INT %22
   %219 = INT_TO_NUM %218
@@ -4579,10 +5369,7 @@ bb_bytecode_1:
   %312 = INT_TO_NUM %311
   BUFFER_WRITEF64 %17, 148i, %312
   BUFFER_WRITEI16 %17, 156i, %22
-  STORE_DOUBLE R6, %312
   BUFFER_WRITEI16 %17, 158i, %22
-  STORE_DOUBLE R5, 12
-  CHECK_BUFFER_LEN %17, 204i, 4i, exit(203)
   BUFFER_WRITEI32 %17, 12i, %22
   %404 = TRUNCATE_UINT %22
   %405 = INT_TO_NUM %404
@@ -4744,6 +5531,7 @@ TEST_CASE("UintSourceSanity")
 {
     ScopedFastFlag luauCodegenBlockSafeEnv{FFlag::LuauCodegenBlockSafeEnv, true};
     ScopedFastFlag luauCodegenNumIntFolds{FFlag::LuauCodegenNumIntFolds2, true};
+    ScopedFastFlag luauCodegenBufferRangeMerge{FFlag::LuauCodegenBufferRangeMerge, true};
 
     // TODO: opportunity - many conversions and stores remain because of VM exits
     CHECK_EQ(
@@ -4776,17 +5564,17 @@ bb_bytecode_1:
   STORE_TAG R5, tnumber
   %23 = LOAD_POINTER R0
   %25 = TRUNCATE_UINT %12
-  CHECK_BUFFER_LEN %23, %25, 4i, exit(9)
+  CHECK_BUFFER_LEN %23, %25, 0i, 4i, undef, exit(9)
   %27 = BUFFER_READI32 %23, %25
   %28 = INT_TO_NUM %27
   STORE_DOUBLE R3, %28
   STORE_TAG R3, tnumber
-  CHECK_BUFFER_LEN %23, %27, 4i, exit(15)
+  CHECK_BUFFER_LEN %23, %27, 0i, 4i, undef, exit(15)
   %40 = BUFFER_READI32 %23, %27
   %41 = UINT_TO_NUM %40
   STORE_DOUBLE R4, %41
   STORE_TAG R4, tnumber
-  CHECK_BUFFER_LEN %23, %40, 4i, exit(22)
+  CHECK_BUFFER_LEN %23, %40, 0i, 4i, undef, exit(22)
   %53 = BUFFER_READI32 %23, %40
   %54 = INT_TO_NUM %53
   STORE_DOUBLE R5, %54
@@ -4795,13 +5583,169 @@ bb_bytecode_1:
   %62 = INT_TO_NUM %61
   STORE_DOUBLE R8, %62
   STORE_TAG R8, tnumber
-  CHECK_BUFFER_LEN %23, %61, 4i, exit(34)
+  CHECK_BUFFER_LEN %23, %61, 0i, 4i, undef, exit(34)
   %74 = BUFFER_READI32 %23, %61
   %75 = UINT_TO_NUM %74
   STORE_DOUBLE R6, %75
   STORE_TAG R6, tnumber
   INTERRUPT 38u
   RETURN R3, 4i
+)"
+    );
+}
+
+TEST_CASE("LibmIsPure")
+{
+    ScopedFastFlag luauCodegenBlockSafeEnv{FFlag::LuauCodegenBlockSafeEnv, true};
+    ScopedFastFlag luauCodegenFloatLoadStoreProp{FFlag::LuauCodegenFloatLoadStoreProp, true};
+    ScopedFastFlag luauCodegenBufferLoadProp{FFlag::LuauCodegenBufferLoadProp2, true};
+    ScopedFastFlag luauCodegenSplitFloat{FFlag::LuauCodegenSplitFloat, true};
+    ScopedFastFlag luauCodegenLibmGvn{FFlag::LuauCodegenLibmGvn, true};
+
+    CHECK_EQ(
+        "\n" + getCodegenAssembly(
+                   R"(
+local function foo(p: vector, v: vector): vector
+    return vector.create(
+        math.cos(0.6 * p.x + 0.4 * math.sin(v.y) + 0),
+        math.cos(0.6 * p.x + 0.4 * math.sin(v.y) + 1),
+        math.cos(0.6 * p.x + 0.4 * math.sin(v.y) + 2)
+    )
+end
+)"
+               ),
+        R"(
+; function foo($arg0, $arg1) line 2
+bb_0:
+  CHECK_TAG R0, tvector, exit(entry)
+  CHECK_TAG R1, tvector, exit(entry)
+  JUMP bb_2
+bb_2:
+  JUMP bb_bytecode_1
+bb_bytecode_1:
+  implicit CHECK_SAFE_ENV exit(0)
+  %10 = LOAD_FLOAT R0, 0i
+  %11 = FLOAT_TO_NUM %10
+  %20 = MUL_NUM 0.59999999999999998, %11
+  %25 = LOAD_FLOAT R1, 4i
+  %26 = FLOAT_TO_NUM %25
+  %33 = INVOKE_LIBM 24u, %26
+  %39 = MUL_NUM %33, 0.40000000000000002
+  %48 = ADD_NUM %20, %39
+  %54 = ADD_NUM %48, 0
+  %61 = INVOKE_LIBM 9u, %54
+  %112 = ADD_NUM %48, 1
+  %119 = INVOKE_LIBM 9u, %112
+  %170 = ADD_NUM %48, 2
+  %177 = INVOKE_LIBM 9u, %170
+  %190 = NUM_TO_FLOAT %61
+  %191 = NUM_TO_FLOAT %119
+  %192 = NUM_TO_FLOAT %177
+  STORE_VECTOR R2, %190, %191, %192
+  STORE_TAG R2, tvector
+  INTERRUPT 55u
+  RETURN R2, 1i
+)"
+    );
+}
+
+TEST_CASE("VecOpReuse")
+{
+    ScopedFastFlag luauCodegenBlockSafeEnv{FFlag::LuauCodegenBlockSafeEnv, true};
+    ScopedFastFlag luauCodegenHydrateLoadWithTag{FFlag::LuauCodegenHydrateLoadWithTag, true};
+    ScopedFastFlag luauCodegenFloatLoadStoreProp{FFlag::LuauCodegenFloatLoadStoreProp, true};
+    ScopedFastFlag luauCodegenBufferLoadProp{FFlag::LuauCodegenBufferLoadProp2, true};
+    ScopedFastFlag luauCodegenSplitFloat{FFlag::LuauCodegenSplitFloat, true};
+    ScopedFastFlag luauCodegenFloatOps{FFlag::LuauCodegenFloatOps, true};
+    ScopedFastFlag luauCodegenVecOpGvn{FFlag::LuauCodegenVecOpGvn, true};
+
+    CHECK_EQ(
+        "\n" + getCodegenAssembly(
+                   R"(
+local function foo(c: vector): vector
+    return vector.create(
+        math.sin(3.0 * vector.magnitude(c) + 6.0),
+        math.sin(3.0 * vector.magnitude(c) + 1.0),
+        math.sin(3.0 * vector.magnitude(c) + 2.0)
+    )
+end
+)"
+               ),
+        R"(
+; function foo($arg0) line 2
+bb_0:
+  CHECK_TAG R0, tvector, exit(entry)
+  JUMP bb_2
+bb_2:
+  JUMP bb_bytecode_1
+bb_bytecode_1:
+  implicit CHECK_SAFE_ENV exit(0)
+  %7 = LOAD_TVALUE R0, 0i, tvector
+  %8 = DOT_VEC %7, %7
+  %9 = SQRT_FLOAT %8
+  %10 = FLOAT_TO_NUM %9
+  %16 = MUL_NUM %10, 3
+  %22 = ADD_NUM %16, 6
+  %29 = INVOKE_LIBM 24u, %22
+  %50 = ADD_NUM %16, 1
+  %57 = INVOKE_LIBM 24u, %50
+  %78 = ADD_NUM %16, 2
+  %85 = INVOKE_LIBM 24u, %78
+  %98 = NUM_TO_FLOAT %29
+  %99 = NUM_TO_FLOAT %57
+  %100 = NUM_TO_FLOAT %85
+  STORE_VECTOR R1, %98, %99, %100
+  STORE_TAG R1, tvector
+  INTERRUPT 37u
+  RETURN R1, 1i
+)"
+    );
+}
+
+TEST_CASE("VecOpReuse2")
+{
+    ScopedFastFlag luauCodegenBlockSafeEnv{FFlag::LuauCodegenBlockSafeEnv, true};
+    ScopedFastFlag luauCodegenHydrateLoadWithTag{FFlag::LuauCodegenHydrateLoadWithTag, true};
+    ScopedFastFlag luauCodegenFloatLoadStoreProp{FFlag::LuauCodegenFloatLoadStoreProp, true};
+    ScopedFastFlag luauCodegenBufferLoadProp{FFlag::LuauCodegenBufferLoadProp2, true};
+    ScopedFastFlag luauCodegenSplitFloat{FFlag::LuauCodegenSplitFloat, true};
+    ScopedFastFlag luauCodegenSplitFloatExtra{FFlag::LuauCodegenSplitFloatExtra, true};
+    ScopedFastFlag luauCodegenFloatOps{FFlag::LuauCodegenFloatOps, true};
+    ScopedFastFlag luauCodegenVecOpGvn{FFlag::LuauCodegenVecOpGvn, true};
+
+    CHECK_EQ(
+        "\n" + getCodegenAssembly(
+                   R"(
+local function foo(c: vector, d: vector): vector
+    return {2 * c + d, 2 * c + d}
+end
+)"
+               ),
+        R"(
+; function foo($arg0, $arg1) line 2
+bb_0:
+  CHECK_TAG R0, tvector, exit(entry)
+  CHECK_TAG R1, tvector, exit(entry)
+  JUMP bb_2
+bb_2:
+  JUMP bb_bytecode_1
+bb_bytecode_1:
+  SET_SAVEDPC 1u
+  %7 = NEW_TABLE 2u, 0u
+  STORE_POINTER R2, %7
+  STORE_TAG R2, ttable
+  CHECK_GC
+  %19 = FLOAT_TO_VEC 2
+  %20 = LOAD_TVALUE R0, 0i, tvector
+  %21 = MUL_VEC %19, %20
+  %29 = LOAD_TVALUE R1, 0i, tvector
+  %30 = ADD_VEC %21, %29
+  %31 = TAG_VECTOR %30
+  STORE_TVALUE R3, %31
+  STORE_TVALUE R4, %31
+  SETLIST 8u, R2, R3, 2i, 1u, 2u
+  INTERRUPT 10u
+  RETURN R2, 1i
 )"
     );
 }

--- a/tests/Linter.test.cpp
+++ b/tests/Linter.test.cpp
@@ -7,8 +7,9 @@
 
 #include "doctest.h"
 
-LUAU_FASTFLAG(LuauSolverV2);
-LUAU_FASTFLAG(LuauUnknownGlobalFixSuggestion)
+LUAU_FASTFLAG(LuauSolverV2)
+
+LUAU_FASTFLAG(LuauExplicitTypeInstantiationSyntax)
 
 using namespace Luau;
 
@@ -40,7 +41,6 @@ end
 
 TEST_CASE_FIXTURE(Fixture, "UnknownGlobal")
 {
-    ScopedFastFlag sff{FFlag::LuauUnknownGlobalFixSuggestion, true};
     LintResult result = lint("--!nocheck\nreturn foo");
 
     REQUIRE(1 == result.warnings.size());
@@ -2545,6 +2545,21 @@ f(3)(4)
 
     CHECK_EQ(result.warnings[1].text, "native attribute on a function is redundant in a native module; consider removing it");
     CHECK_EQ(result.warnings[1].location, Location(Position(5, 4), Position(5, 11)));
+}
+
+TEST_CASE_FIXTURE(Fixture, "type_instantiation_lints")
+{
+    ScopedFastFlag sff{FFlag::LuauExplicitTypeInstantiationSyntax, true};
+
+    LintResult result = lint(R"(
+local function a<b>(cool: b)
+    print(cool)
+end
+
+a<<"hi">>("hi")
+)");
+
+    REQUIRE(0 == result.warnings.size());
 }
 
 TEST_SUITE_END();

--- a/tests/Module.test.cpp
+++ b/tests/Module.test.cpp
@@ -99,7 +99,7 @@ TEST_CASE_FIXTURE(Fixture, "deepClone_non_persistent_primitive")
     TypeId newNumber = clone(oldNumber, dest, cloneState);
 
     CHECK_NE(newNumber, oldNumber);
-    CHECK_EQ(*oldNumber, *newNumber);
+    CHECK_EQ("number", toString(oldNumber));
     CHECK_EQ("number", toString(newNumber));
     CHECK_EQ(1, dest.types.size());
 }

--- a/tests/NonStrictTypeChecker.test.cpp
+++ b/tests/NonStrictTypeChecker.test.cpp
@@ -20,9 +20,9 @@ LUAU_DYNAMIC_FASTINT(LuauConstraintGeneratorRecursionLimit)
 LUAU_FASTINT(LuauNonStrictTypeCheckerRecursionLimit)
 LUAU_FASTINT(LuauCheckRecursionLimit)
 LUAU_FASTFLAG(LuauUnreducedTypeFunctionsDontTriggerWarnings)
-LUAU_FASTFLAG(LuauNewNonStrictBetterCheckedFunctionErrorMessage)
 LUAU_FASTFLAG(LuauAddRecursionCounterToNonStrictTypeChecker)
-LUAU_FASTFLAG(LuauExplicitTypeExpressionInstantiation)
+LUAU_FASTFLAG(LuauExplicitTypeInstantiationSyntax)
+LUAU_FASTFLAG(LuauExplicitTypeInstantiationSupport)
 
 using namespace Luau;
 
@@ -392,10 +392,7 @@ end}
 )");
 
     LUAU_REQUIRE_ERROR_COUNT(1, result);
-    if (FFlag::LuauNewNonStrictBetterCheckedFunctionErrorMessage)
-        CHECK(toString(result.errors[0]) == "the argument 'x' is used in a way that will error at runtime");
-    else
-        CHECK(toString(result.errors[0]) == "Argument x with type 'unknown' is used in a way that will run time error");
+    CHECK(toString(result.errors[0]) == "the argument 'x' is used in a way that will error at runtime");
 }
 
 TEST_CASE_FIXTURE(NonStrictTypeCheckerFixture, "local_fn_produces_error")
@@ -466,7 +463,8 @@ end
 
 TEST_CASE_FIXTURE(NonStrictTypeCheckerFixture, "generic_type_instantiation")
 {
-    ScopedFastFlag sff{FFlag::LuauExplicitTypeExpressionInstantiation, true};
+    ScopedFastFlag syntax{FFlag::LuauExplicitTypeInstantiationSyntax, true};
+    ScopedFastFlag semantics{FFlag::LuauExplicitTypeInstantiationSupport, true};
 
     CheckResult result = checkNonStrict(R"(
         function array<T>(): {T}
@@ -844,24 +842,15 @@ getAllTheArgsWrong(3, true, "what")
     CHECK(err1 != nullptr);
     CHECK(err2 != nullptr);
     CHECK(err3 != nullptr);
-    if (FFlag::LuauNewNonStrictBetterCheckedFunctionErrorMessage)
-    {
-        CHECK_EQ(
-            "the function 'getAllTheArgsWrong' expects to get a string as its 1st argument, but is being given a number", toString(result.errors[0])
-        );
-        CHECK_EQ(
-            "the function 'getAllTheArgsWrong' expects to get a number as its 2nd argument, but is being given a boolean", toString(result.errors[1])
-        );
-        CHECK_EQ(
-            "the function 'getAllTheArgsWrong' expects to get a boolean as its 3rd argument, but is being given a string", toString(result.errors[2])
-        );
-    }
-    else
-    {
-        CHECK_EQ("Function 'getAllTheArgsWrong' expects 'string' at argument #1, but got 'number'", toString(result.errors[0]));
-        CHECK_EQ("Function 'getAllTheArgsWrong' expects 'number' at argument #2, but got 'boolean'", toString(result.errors[1]));
-        CHECK_EQ("Function 'getAllTheArgsWrong' expects 'boolean' at argument #3, but got 'string'", toString(result.errors[2]));
-    }
+    CHECK_EQ(
+        "the function 'getAllTheArgsWrong' expects to get a string as its 1st argument, but is being given a number", toString(result.errors[0])
+    );
+    CHECK_EQ(
+        "the function 'getAllTheArgsWrong' expects to get a number as its 2nd argument, but is being given a boolean", toString(result.errors[1])
+    );
+    CHECK_EQ(
+        "the function 'getAllTheArgsWrong' expects to get a boolean as its 3rd argument, but is being given a string", toString(result.errors[2])
+    );
 }
 
 TEST_CASE_FIXTURE(NonStrictTypeCheckerFixture, "new_non_strict_skips_warnings_on_unreduced_typefunctions")

--- a/tests/NonstrictMode.test.cpp
+++ b/tests/NonstrictMode.test.cpp
@@ -68,7 +68,7 @@ TEST_CASE_FIXTURE(Fixture, "return_annotation_is_still_checked")
 
     LUAU_REQUIRE_ERROR_COUNT(1, result);
 
-    REQUIRE_NE(*getBuiltins()->anyType, *requireType("foo"));
+    CHECK("any" != toString(requireType("foo")));
 }
 
 TEST_CASE_FIXTURE(Fixture, "function_parameters_are_any")
@@ -111,7 +111,7 @@ TEST_CASE_FIXTURE(Fixture, "locals_are_any_by_default")
 
     LUAU_REQUIRE_NO_ERRORS(result);
 
-    CHECK_EQ(*getBuiltins()->anyType, *requireType("m"));
+    CHECK("any" == toString(requireType("m")));
 }
 
 TEST_CASE_FIXTURE(Fixture, "parameters_having_type_any_are_optional")
@@ -180,7 +180,7 @@ TEST_CASE_FIXTURE(Fixture, "table_props_are_any")
     TypeId fooProp = ttv->props["foo"].type_DEPRECATED();
     REQUIRE(fooProp != nullptr);
 
-    CHECK_EQ(*fooProp, *getBuiltins()->anyType);
+    CHECK("any" == toString(fooProp));
 }
 
 TEST_CASE_FIXTURE(Fixture, "inline_table_props_are_also_any")
@@ -200,8 +200,8 @@ TEST_CASE_FIXTURE(Fixture, "inline_table_props_are_also_any")
     TableType* ttv = getMutable<TableType>(requireType("T"));
     REQUIRE_MESSAGE(ttv, "Should be a table: " << toString(requireType("T")));
 
-    CHECK_EQ(*getBuiltins()->anyType, *ttv->props["one"].type_DEPRECATED());
-    CHECK_EQ(*getBuiltins()->anyType, *ttv->props["two"].type_DEPRECATED());
+    CHECK("any" == toString(ttv->props["one"].type_DEPRECATED()));
+    CHECK("any" == toString(ttv->props["two"].type_DEPRECATED()));
     CHECK_MESSAGE(
         get<FunctionType>(follow(ttv->props["three"].type_DEPRECATED())), "Should be a function: " << *ttv->props["three"].type_DEPRECATED()
     );

--- a/tests/Parser.test.cpp
+++ b/tests/Parser.test.cpp
@@ -18,7 +18,7 @@ LUAU_FASTINT(LuauTypeLengthLimit)
 LUAU_FASTINT(LuauParseErrorLimit)
 LUAU_FASTFLAG(LuauSolverV2)
 LUAU_DYNAMIC_FASTFLAG(DebugLuauReportReturnTypeVariadicWithTypeSuffix)
-LUAU_FASTFLAG(LuauExplicitTypeExpressionInstantiation)
+LUAU_FASTFLAG(LuauExplicitTypeInstantiationSyntax)
 LUAU_FASTFLAG(LuauCstStatDoWithStatsStart)
 
 // Clip with DebugLuauReportReturnTypeVariadicWithTypeSuffix
@@ -2848,7 +2848,7 @@ TEST_CASE_FIXTURE(Fixture, "for_loop_with_single_var_has_comma_positions_of_size
 
 TEST_CASE_FIXTURE(Fixture, "explicit_type_instantiation_expression_call")
 {
-    ScopedFastFlag sff{FFlag::LuauExplicitTypeExpressionInstantiation, true};
+    ScopedFastFlag sff{FFlag::LuauExplicitTypeInstantiationSyntax, true};
 
     std::string source = "local x = f<<T, U>>()";
 
@@ -2874,7 +2874,7 @@ TEST_CASE_FIXTURE(Fixture, "explicit_type_instantiation_expression_call")
 
 TEST_CASE_FIXTURE(Fixture, "explicit_type_instantiation_expression")
 {
-    ScopedFastFlag sff{FFlag::LuauExplicitTypeExpressionInstantiation, true};
+    ScopedFastFlag sff{FFlag::LuauExplicitTypeInstantiationSyntax, true};
 
     AstStat* stat = parse("local x = f<<T, U>>");
     REQUIRE(stat != nullptr);
@@ -2882,7 +2882,7 @@ TEST_CASE_FIXTURE(Fixture, "explicit_type_instantiation_expression")
 
 TEST_CASE_FIXTURE(Fixture, "explicit_type_instantiation_statement")
 {
-    ScopedFastFlag sff{FFlag::LuauExplicitTypeExpressionInstantiation, true};
+    ScopedFastFlag sff{FFlag::LuauExplicitTypeInstantiationSyntax, true};
 
     AstStat* stat = parse("f<<T, U>>()");
     REQUIRE(stat != nullptr);
@@ -2890,7 +2890,7 @@ TEST_CASE_FIXTURE(Fixture, "explicit_type_instantiation_statement")
 
 TEST_CASE_FIXTURE(Fixture, "explicit_type_instantiation_indexing")
 {
-    ScopedFastFlag sff{FFlag::LuauExplicitTypeExpressionInstantiation, true};
+    ScopedFastFlag sff{FFlag::LuauExplicitTypeInstantiationSyntax, true};
 
     AstStat* stat = parse(R"(
         t.f<<T, U>>()
@@ -2902,7 +2902,7 @@ TEST_CASE_FIXTURE(Fixture, "explicit_type_instantiation_indexing")
 
 TEST_CASE_FIXTURE(Fixture, "explicit_type_instantiation_empty_list")
 {
-    ScopedFastFlag sff{FFlag::LuauExplicitTypeExpressionInstantiation, true};
+    ScopedFastFlag sff{FFlag::LuauExplicitTypeInstantiationSyntax, true};
 
     AstStat* stat = parse(R"(
         f<<>>()
@@ -4597,7 +4597,7 @@ TEST_CASE_FIXTURE(Fixture, "parse_type_name")
 
 TEST_CASE_FIXTURE(Fixture, "explicit_type_instantiation_errors")
 {
-    ScopedFastFlag sff{FFlag::LuauExplicitTypeExpressionInstantiation, true};
+    ScopedFastFlag sff{FFlag::LuauExplicitTypeInstantiationSyntax, true};
 
     matchParseError("local a = x:a<<T>>", "Expected '(', '{' or <string> when parsing function call, got <eof>");
 }

--- a/tests/PrettyPrinter.test.cpp
+++ b/tests/PrettyPrinter.test.cpp
@@ -10,7 +10,7 @@
 
 #include "doctest.h"
 
-LUAU_FASTFLAG(LuauExplicitTypeExpressionInstantiation)
+LUAU_FASTFLAG(LuauExplicitTypeInstantiationSyntax)
 
 using namespace Luau;
 
@@ -2131,7 +2131,7 @@ TEST_CASE("prettyPrint_function_attributes")
 
 TEST_CASE("transpile_explicit_type_instantiations")
 {
-    ScopedFastFlag sff{FFlag::LuauExplicitTypeExpressionInstantiation, true};
+    ScopedFastFlag sff{FFlag::LuauExplicitTypeInstantiationSyntax, true};
 
     std::string code = "f<<A, B, C...>>() t.f<<A, B, C...>>() t:f<<A, B, C>>()";
     CHECK_EQ(code, prettyPrint(code, {}, true).code);

--- a/tests/RuntimeLimits.test.cpp
+++ b/tests/RuntimeLimits.test.cpp
@@ -27,7 +27,6 @@ LUAU_FASTFLAG(LuauIceLess)
 LUAU_FASTFLAG(LuauDontDynamicallyCreateRedundantSubtypeConstraints)
 LUAU_FASTFLAG(LuauUseNativeStackGuard)
 LUAU_FASTINT(LuauGenericCounterMaxSteps)
-LUAU_FASTFLAG(LuauGenericCounterStepsInsteadOfCount)
 
 struct LimitFixture : BuiltinsFixture
 {
@@ -542,10 +541,7 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "subtyping_should_cache_pairs_in_seen_set" * 
 
 TEST_CASE_FIXTURE(BuiltinsFixture, "test_generic_pruning_recursion_limit")
 {
-    ScopedFastFlag sffs[] = {
-        {FFlag::LuauSolverV2, true},
-        {FFlag::LuauGenericCounterStepsInsteadOfCount, true},
-    };
+    ScopedFastFlag _{FFlag::LuauSolverV2, true};
 
     ScopedFastInt sfi{FInt::LuauGenericCounterMaxSteps, 1};
 

--- a/tests/Simplify.test.cpp
+++ b/tests/Simplify.test.cpp
@@ -10,7 +10,6 @@ using namespace Luau;
 
 LUAU_FASTFLAG(LuauSolverV2)
 LUAU_DYNAMIC_FASTINT(LuauSimplificationComplexityLimit)
-LUAU_FASTFLAG(LuauSimplifyIntersectionNoTreeSet)
 
 namespace
 {
@@ -674,8 +673,6 @@ TEST_CASE_FIXTURE(SimplifyFixture, "{ read x: Child } & { x: Parent }")
 
 TEST_CASE_FIXTURE(SimplifyFixture, "intersect_parts_empty_table_non_empty")
 {
-    ScopedFastFlag _{FFlag::LuauSimplifyIntersectionNoTreeSet, true};
-
     TableType empty;
     empty.state = TableState::Sealed;
     TypeId emptyTable = arena->addType(std::move(empty));

--- a/tests/Subtyping.test.cpp
+++ b/tests/Subtyping.test.cpp
@@ -1767,9 +1767,9 @@ TEST_CASE_FIXTURE(SubtypeFixture, "substitute_a_generic_for_a_negation")
     // <A, B>(x: A, y: B) -> (A & ~(false?)) | B
     // (~(false?), ~(false?)) -> (~(false?) & ~(false?)) | ~(false?)
 
-    TypeId aTy = arena.addType(GenericType{"A"});
+    TypeId aTy = arena.addType(GenericType{"A", Polarity::Mixed});
     getMutable<GenericType>(aTy)->scope = moduleScope.get();
-    TypeId bTy = arena.addType(GenericType{"B"});
+    TypeId bTy = arena.addType(GenericType{"B", Polarity::Mixed});
     getMutable<GenericType>(bTy)->scope = moduleScope.get();
 
     TypeId genericFunctionTy = arena.addType(
@@ -1817,7 +1817,7 @@ TEST_CASE_FIXTURE(SubtypeFixture, "weird_cyclic_instantiation")
     TypeArena arena;
     Scope scope(getBuiltins()->anyTypePack);
 
-    TypeId genericT = arena.addType(GenericType{"T"});
+    TypeId genericT = arena.addType(GenericType{"T", Polarity::Mixed});
 
     TypeId idTy = arena.addType(
         FunctionType{/* generics */ {genericT},

--- a/tests/ToDot.test.cpp
+++ b/tests/ToDot.test.cpp
@@ -375,7 +375,7 @@ n1 [label="ErrorType 1"];
 
 TEST_CASE_FIXTURE(Fixture, "generic")
 {
-    Type type{TypeVariant{GenericType{"T"}}};
+    Type type{TypeVariant{GenericType{"T", Polarity::Mixed}}};
 
     ToDotOptions opts;
     opts.showPointers = false;

--- a/tests/ToString.test.cpp
+++ b/tests/ToString.test.cpp
@@ -482,7 +482,7 @@ TEST_CASE_FIXTURE(Fixture, "generic_packs_are_stringified_differently_from_gener
     TypePackVar tpv{GenericTypePack{"a"}};
     CHECK_EQ(toString(&tpv), "a...");
 
-    Type tv{GenericType{"a"}};
+    Type tv{GenericType{"a", Polarity::Mixed}};
     CHECK_EQ(toString(&tv), "a");
 }
 

--- a/tests/TxnLog.test.cpp
+++ b/tests/TxnLog.test.cpp
@@ -28,7 +28,7 @@ struct TxnLogFixture
     TypeId b = freshType(NotNull{&arena}, NotNull{&builtinTypes}, globalScope.get());
     TypeId c = freshType(NotNull{&arena}, NotNull{&builtinTypes}, childScope.get());
 
-    TypeId g = arena.addType(GenericType{"G"});
+    TypeId g = arena.addType(GenericType{"G", Polarity::Mixed});
 };
 
 TEST_SUITE_BEGIN("TxnLog");

--- a/tests/TypeFunction.test.cpp
+++ b/tests/TypeFunction.test.cpp
@@ -16,9 +16,11 @@ LUAU_FASTFLAG(LuauSolverV2)
 LUAU_DYNAMIC_FASTINT(LuauTypeFamilyApplicationCartesianProductLimit)
 LUAU_FASTFLAG(DebugLuauAssertOnForcedConstraint)
 LUAU_FASTFLAG(LuauBuiltinTypeFunctionsArentGlobal)
-LUAU_FASTFLAG(LuauGetmetatableError)
 LUAU_FASTFLAG(LuauBetterTypeMismatchErrors)
 LUAU_FASTFLAG(LuauSetmetatableWaitForPendingTypes)
+LUAU_FASTFLAG(LuauExplicitTypeInstantiationSyntax)
+LUAU_FASTFLAG(LuauExplicitTypeInstantiationSupport)
+LUAU_FASTFLAG(LuauReworkInfiniteTypeFinder)
 
 struct TypeFunctionFixture : Fixture
 {
@@ -56,7 +58,7 @@ struct TypeFunctionFixture : Fixture
                          }};
 
         unfreeze(getFrontend().globals.globalTypes);
-        TypeId t = getFrontend().globals.globalTypes.addType(GenericType{"T"});
+        TypeId t = getFrontend().globals.globalTypes.addType(GenericType{"T", Polarity::Negative});
         GenericTypeDefinition genericT{t};
 
         ScopePtr globalScope = getFrontend().globals.globalScope;
@@ -1828,8 +1830,8 @@ TEST_CASE_FIXTURE(TFFixture, "or<'a, 'b>")
 
 TEST_CASE_FIXTURE(TFFixture, "a_type_function_parameterized_on_generics_is_solved")
 {
-    TypeId a = arena->addType(GenericType{"A"});
-    TypeId b = arena->addType(GenericType{"B"});
+    TypeId a = arena->addType(GenericType{"A", Polarity::Negative});
+    TypeId b = arena->addType(GenericType{"B", Polarity::Negative});
 
     TypeId addTy = arena->addType(TypeFunctionInstanceType{getBuiltinTypeFunctions()->addFunc, {a, b}});
 
@@ -1843,8 +1845,8 @@ TEST_CASE_FIXTURE(TFFixture, "a_type_function_parameterized_on_generics_is_solve
 
 TEST_CASE_FIXTURE(TFFixture, "a_tf_parameterized_on_a_solved_tf_is_solved")
 {
-    TypeId a = arena->addType(GenericType{"A"});
-    TypeId b = arena->addType(GenericType{"B"});
+    TypeId a = arena->addType(GenericType{"A", Polarity::Negative});
+    TypeId b = arena->addType(GenericType{"B", Polarity::Negative});
 
     TypeId innerAddTy = arena->addType(TypeFunctionInstanceType{getBuiltinTypeFunctions()->addFunc, {a, b}});
 
@@ -1895,10 +1897,7 @@ TEST_CASE_FIXTURE(TFFixture, "reduce_degenerate_refinement")
 
 TEST_CASE_FIXTURE(TFFixture, "reduce_union_of_error_nil_table_with_table")
 {
-    ScopedFastFlag sffs[] = {
-        {FFlag::LuauSolverV2, true},
-        {FFlag::LuauGetmetatableError, true},
-    };
+    ScopedFastFlag _{FFlag::LuauSolverV2, true};
 
     TypeId refinement = arena->addType(TypeFunctionInstanceType{
         getBuiltinTypeFunctions()->refineFunc,
@@ -1950,6 +1949,34 @@ TEST_CASE_FIXTURE(TypeFunctionFixture, "recursive_restraint_violation3")
     LUAU_REQUIRE_ERROR_COUNT(1, result);
     CHECK(get<RecursiveRestraintViolation>(result.errors[0]));
 }
+
+TEST_CASE_FIXTURE(Fixture, "recursive_restraint_violation4")
+{
+    ScopedFastFlag _{FFlag::LuauReworkInfiniteTypeFinder, true};
+
+    LUAU_REQUIRE_NO_ERRORS(check(R"(
+        type A = { B<any> }
+
+        type B<T> = { method: (B<T>) -> () }
+    )"));
+}
+
+TEST_CASE_FIXTURE(Fixture, "recursive_restraint_violation_with_defaults")
+{
+    ScopedFastFlag _{FFlag::LuauReworkInfiniteTypeFinder, true};
+
+    // This is a fairly benign example, but the RFC claims it should be disallowed.
+    // See: https://github.com/luau-lang/luau/pull/68.
+    CheckResult result = check(R"(
+        type B<T = number> = { B<number> }
+    )");
+
+    LUAU_REQUIRE_ERROR_COUNT(1, result);
+    CHECK(get<RecursiveRestraintViolation>(result.errors[0]));
+    // Also check the location (marking the entire alias is bad).
+    CHECK_EQ(Location{{1, 31}, {1, 40}}, result.errors[0].location);
+}
+
 
 TEST_CASE_FIXTURE(BuiltinsFixture, "oss_2106_wait_for_pending_types_in_setmetatable_ex1")
 {
@@ -2011,6 +2038,58 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "oss_2106_wait_for_pending_types_in_setmetata
     )"));
 
     CHECK_EQ("string", toString(requireType("g")));
+}
+
+TEST_CASE_FIXTURE(BuiltinsFixture, "oss_2114_type_instantiation_on_type_function")
+{
+    ScopedFastFlag sffs[] = {
+        {FFlag::LuauSolverV2, true},
+        {FFlag::LuauExplicitTypeInstantiationSyntax, true},
+        {FFlag::LuauExplicitTypeInstantiationSupport, true},
+    };
+
+    LUAU_REQUIRE_NO_ERRORS(check(R"(
+        --!strict
+
+        type function id(t: type): type
+            return t
+        end
+
+        local function fn<T>(): id<T>
+            return nil :: any
+        end
+
+        local y = fn<<number>>()
+    )"));
+
+    CHECK_EQ("number", toString(requireType("y")));
+}
+
+TEST_CASE_FIXTURE(BuiltinsFixture, "oss_2144_type_instantiation_on_type_function")
+{
+    ScopedFastFlag sffs[] = {
+        {FFlag::LuauSolverV2, true},
+        {FFlag::LuauExplicitTypeInstantiationSyntax, true},
+        {FFlag::LuauExplicitTypeInstantiationSupport, true},
+    };
+
+    LUAU_REQUIRE_NO_ERRORS(check(R"(
+        --!strict
+
+        type ST = {
+            Member1: number,
+            Name: string
+        }
+
+        local function access<T>(t, field: T): index<ST, T>
+            return t[field]
+        end
+
+        local t: any = {}
+        local _b = access<<"Member1">>(t, "Member1")
+    )"));
+
+    CHECK_EQ("number", toString(requireType("_b")));
 }
 
 TEST_SUITE_END();

--- a/tests/TypeFunction.user.test.cpp
+++ b/tests/TypeFunction.user.test.cpp
@@ -10,12 +10,12 @@
 using namespace Luau;
 
 LUAU_FASTFLAG(LuauSolverV2)
-LUAU_FASTFLAG(LuauUnknownGlobalFixSuggestion)
 LUAU_FASTFLAG(LuauMorePermissiveNewtableType)
 LUAU_FASTFLAG(LuauBetterTypeMismatchErrors)
 LUAU_FASTFLAG(LuauUserTypeFunctionsNoUninhabitedError)
 LUAU_FASTFLAG(LuauUnionofIntersectionofFlattens)
 LUAU_FASTFLAG(LuauTypeFunctionDeserializationShouldNotCrashOnGenericPacks)
+LUAU_FASTFLAG(LuauDontIncludeVarargWithAnnotation)
 
 TEST_SUITE_BEGIN("UserDefinedTypeFunctionTests");
 
@@ -1167,7 +1167,6 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "udtf_calling_each_other_2")
 TEST_CASE_FIXTURE(BuiltinsFixture, "udtf_calling_each_other_3")
 {
     ScopedFastFlag newSolver{FFlag::LuauSolverV2, true};
-    ScopedFastFlag unknownGlobalFixSuggestion{FFlag::LuauUnknownGlobalFixSuggestion, true};
 
     CheckResult result = check(R"(
         -- this function should not see 'fourth' function when invoked from 'third' that sees it
@@ -1220,7 +1219,6 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "udtf_calling_each_other_unordered")
 TEST_CASE_FIXTURE(BuiltinsFixture, "udtf_no_shared_state")
 {
     ScopedFastFlag newSolver{FFlag::LuauSolverV2, true};
-    ScopedFastFlag unknownGlobalFixSuggestion{FFlag::LuauUnknownGlobalFixSuggestion, true};
 
     CheckResult result = check(R"(
         type function foo()
@@ -1298,7 +1296,6 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "udtf_optionify")
 TEST_CASE_FIXTURE(BuiltinsFixture, "udtf_calling_illegal_global")
 {
     ScopedFastFlag newSolver{FFlag::LuauSolverV2, true};
-    ScopedFastFlag unknownGlobalFixSuggestion{FFlag::LuauUnknownGlobalFixSuggestion, true};
 
     CheckResult result = check(R"(
         type function illegal(arg)
@@ -2524,7 +2521,6 @@ local y: Test.foo<{ a: string }> = "x"
 TEST_CASE_FIXTURE(ExternTypeFixture, "type_alias_not_too_many_globals")
 {
     ScopedFastFlag newSolver{FFlag::LuauSolverV2, true};
-    ScopedFastFlag unknownGlobalFixSuggestion{FFlag::LuauUnknownGlobalFixSuggestion, true};
 
     CheckResult result = check(R"(
 type function get()
@@ -2789,6 +2785,10 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "typeof_into_type_function_should_not_crash")
 {
     ScopedFastFlag sff{FFlag::LuauSolverV2, true};
     ScopedFastFlag noCrash{FFlag::LuauTypeFunctionDeserializationShouldNotCrashOnGenericPacks, true};
+    ScopedFastFlag noErrors[] = {
+        {FFlag::LuauUserTypeFunctionsNoUninhabitedError, true},
+        {FFlag::LuauDontIncludeVarargWithAnnotation, true},
+    };
 
     CheckResult results = check(R"(
         type function identity(t: type)
@@ -2800,16 +2800,7 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "typeof_into_type_function_should_not_crash")
         whomp(function(...) end :: func<any>)
     )");
 
-    // FIXME: this should not error at all, but type alias expansion is broken because we don't have proper instantiation
-    // LUAU_REQUIRE_NO_ERRORS(results);
-
-    if (FFlag::LuauUserTypeFunctionsNoUninhabitedError)
-        LUAU_REQUIRE_ERROR_COUNT(1, results);
-    else
-        LUAU_REQUIRE_ERROR_COUNT(2, results);
-    auto err = get<UserDefinedTypeFunctionError>(results.errors[0]);
-    REQUIRE(err);
-    CHECK_EQ("Encountered unexpected generic type pack", err->message);
+    LUAU_REQUIRE_NO_ERRORS(results);
 }
 
 

--- a/tests/TypeInfer.annotations.test.cpp
+++ b/tests/TypeInfer.annotations.test.cpp
@@ -276,8 +276,8 @@ TEST_CASE_FIXTURE(Fixture, "infer_type_of_value_a_via_typeof_with_assignment")
     }
     else
     {
-        CHECK_EQ(*getBuiltins()->numberType, *requireType("a"));
-        CHECK_EQ(*getBuiltins()->numberType, *requireType("b"));
+        CHECK("number" == toString(requireType("a")));
+        CHECK("number" == toString(requireType("b")));
 
         LUAU_REQUIRE_ERROR_COUNT(1, result);
         CHECK_EQ(

--- a/tests/TypeInfer.anyerror.test.cpp
+++ b/tests/TypeInfer.anyerror.test.cpp
@@ -14,7 +14,6 @@
 using namespace Luau;
 
 LUAU_FASTFLAG(LuauSolverV2)
-LUAU_FASTFLAG(LuauUnknownGlobalFixSuggestion)
 
 TEST_SUITE_BEGIN("TypeInferAnyError");
 
@@ -367,8 +366,6 @@ end
 
 TEST_CASE_FIXTURE(Fixture, "type_error_addition")
 {
-    ScopedFastFlag unknownGlobalFixSuggestion{FFlag::LuauUnknownGlobalFixSuggestion, true};
-
     CheckResult result = check(R"(
 --!strict
 local foo = makesandwich()

--- a/tests/TypeInfer.definitions.test.cpp
+++ b/tests/TypeInfer.definitions.test.cpp
@@ -502,8 +502,8 @@ TEST_CASE_FIXTURE(Fixture, "class_definition_indexer")
 
     REQUIRE(bool(etv->indexer));
 
-    CHECK_EQ(*etv->indexer->indexType, *getBuiltins()->numberType);
-    CHECK_EQ(*etv->indexer->indexResultType, *getBuiltins()->stringType);
+    CHECK("number" == toString(etv->indexer->indexType));
+    CHECK("string" == toString(etv->indexer->indexResultType));
 
     CHECK_EQ(toString(requireType("y")), "string");
 }

--- a/tests/TypeInfer.functions.test.cpp
+++ b/tests/TypeInfer.functions.test.cpp
@@ -20,17 +20,13 @@ LUAU_FASTFLAG(DebugLuauAssertOnForcedConstraint)
 LUAU_FASTFLAG(LuauInstantiateInSubtyping)
 LUAU_FASTFLAG(LuauSolverV2)
 LUAU_FASTINT(LuauTarjanChildLimit)
-LUAU_FASTFLAG(LuauCollapseShouldNotCrash)
 LUAU_FASTFLAG(LuauFormatUseLastPosition)
-LUAU_FASTFLAG(LuauNoScopeShallNotSubsumeAll)
-LUAU_FASTFLAG(LuauNewOverloadResolver2)
 LUAU_FASTFLAG(LuauBetterTypeMismatchErrors)
-LUAU_FASTFLAG(LuauPushTypeConstraintIntersection)
-LUAU_FASTFLAG(LuauPushTypeConstraintLambdas2)
-LUAU_FASTFLAG(LuauIncludeExplicitGenericPacks)
+LUAU_FASTFLAG(LuauPushTypeConstraintLambdas3)
 LUAU_FASTFLAG(LuauInstantiationUsesGenericPolarity2)
 LUAU_FASTFLAG(LuauPushTypeConstraintStripNilFromFunction)
 LUAU_FASTFLAG(LuauCheckFunctionStatementTypes)
+LUAU_FASTFLAG(LuauUnifier2HandleMismatchedPacks)
 
 TEST_SUITE_BEGIN("TypeInferFunctions");
 
@@ -148,7 +144,7 @@ TEST_CASE_FIXTURE(Fixture, "infer_return_type")
     std::vector<TypeId> retVec = flatten(takeFiveType->retTypes).first;
     REQUIRE(!retVec.empty());
 
-    REQUIRE_EQ(*follow(retVec[0]), *getBuiltins()->numberType);
+    CHECK("number" == toString(retVec[0]));
 }
 
 TEST_CASE_FIXTURE(Fixture, "infer_from_function_return_type")
@@ -156,7 +152,7 @@ TEST_CASE_FIXTURE(Fixture, "infer_from_function_return_type")
     CheckResult result = check("function take_five() return 5 end    local five = take_five()");
     LUAU_REQUIRE_NO_ERRORS(result);
 
-    CHECK_EQ(*getBuiltins()->numberType, *follow(requireType("five")));
+    CHECK("number" == toString(requireType("five")));
 }
 
 TEST_CASE_FIXTURE(Fixture, "infer_that_function_does_not_return_a_table")
@@ -829,8 +825,8 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "higher_order_function_4")
 
     std::vector<TypeId> arg1Args = flatten(arg1->argTypes).first;
 
-    CHECK_EQ(*arg0->indexer->indexResultType, *arg1Args[0]);
-    CHECK_EQ(*arg0->indexer->indexResultType, *arg1Args[1]);
+    CHECK(follow(arg0->indexer->indexResultType) == follow(arg1Args[0]));
+    CHECK(follow(arg0->indexer->indexResultType) == follow(arg1Args[1]));
 }
 
 TEST_CASE_FIXTURE(BuiltinsFixture, "mutual_recursion")
@@ -1237,8 +1233,6 @@ TEST_CASE_FIXTURE(Fixture, "record_matching_overload")
 
 TEST_CASE_FIXTURE(Fixture, "return_type_by_overload")
 {
-    ScopedFastFlag sff{FFlag::LuauNewOverloadResolver2, true};
-
     CheckResult result = check(R"(
         type Overload = ((string) -> string) & ((number, number) -> number)
         local abc: Overload
@@ -1461,7 +1455,6 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "infer_generic_lib_function_function_argument
 {
     ScopedFastFlag sffs[] = {
         {FFlag::LuauSolverV2, true},
-        {FFlag::LuauNoScopeShallNotSubsumeAll, true},
     };
 
     CheckResult result = check(R"(
@@ -2114,10 +2107,7 @@ u.b().foo()
         CHECK_EQ(toString(result.errors[2]), "Argument count mismatch. Function expects 1 to 3 arguments, but none are specified");
         CHECK_EQ(toString(result.errors[3]), "Argument count mismatch. Function expects 2 to 4 arguments, but none are specified");
         CHECK_EQ(toString(result.errors[4]), "Argument count mismatch. Function expects at least 1 argument, but none are specified");
-        if (FFlag::LuauNewOverloadResolver2)
-            CHECK_EQ(toString(result.errors[5]), "Argument count mismatch. Function expects 2 to 3 arguments, but only 1 is specified");
-        else
-            CHECK_EQ(toString(result.errors[5]), "Argument count mismatch. Function expects 3 arguments, but only 1 is specified");
+        CHECK_EQ(toString(result.errors[5]), "Argument count mismatch. Function expects 2 to 3 arguments, but only 1 is specified");
         CHECK_EQ(toString(result.errors[6]), "Argument count mismatch. Function expects at least 1 argument, but none are specified");
         CHECK_EQ(toString(result.errors[7]), "Argument count mismatch. Function expects at least 1 argument, but none are specified");
         CHECK_EQ(toString(result.errors[8]), "Argument count mismatch. Function expects at least 1 argument, but none are specified");
@@ -2512,10 +2502,7 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "attempt_to_call_an_intersection_of_tables_wi
 
 TEST_CASE_FIXTURE(Fixture, "generic_packs_are_not_variadic")
 {
-    ScopedFastFlag sffs[] = {
-        {FFlag::LuauSolverV2, true},
-        {FFlag::LuauIncludeExplicitGenericPacks, true},
-    };
+    ScopedFastFlag _{FFlag::LuauSolverV2, true};
 
     CheckResult result = check(R"(
         local function apply<a, b..., c...>(f: (a, b...) -> c..., x: a)
@@ -2529,21 +2516,9 @@ TEST_CASE_FIXTURE(Fixture, "generic_packs_are_not_variadic")
         apply(add, 5)
     )");
 
-    if (FFlag::LuauNewOverloadResolver2)
-    {
-        LUAU_REQUIRE_ERROR_COUNT(1, result);
-        CHECK(Location{{2, 21}, {2, 22}} == result.errors.at(0).location);
-        CHECK_MESSAGE(get<TypePackMismatch>(result.errors.at(0)), "Expected TypePackMismatch but got " << result.errors.at(0));
-    }
-    else
-    {
-        // CLI-179222: This should error, specifically on the `f(x)` line, as we
-        // cannot _know_ that `f` takes no additional arguments, it takes some
-        // generic pack.
-        //
-        // Previously this did error but for a nonsense reason.
-        LUAU_REQUIRE_NO_ERRORS(result);
-    }
+    LUAU_REQUIRE_ERROR_COUNT(1, result);
+    CHECK(Location{{2, 21}, {2, 22}} == result.errors.at(0).location);
+    CHECK_MESSAGE(get<TypePackMismatch>(result.errors.at(0)), "Expected TypePackMismatch but got " << result.errors.at(0));
 }
 
 TEST_CASE_FIXTURE(BuiltinsFixture, "num_is_solved_before_num_or_str")
@@ -3008,8 +2983,6 @@ return _
 
 TEST_CASE_FIXTURE(Fixture, "cannot_call_union_of_functions")
 {
-    ScopedFastFlag sff{FFlag::LuauNewOverloadResolver2, true};
-
     CheckResult result = check(R"(
          local f: (() -> ()) | (() -> () -> ()) = nil :: any
          f()
@@ -3390,8 +3363,6 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "function_calls_should_not_crash")
 {
     ScopedFastFlag sffs[] = {
         {FFlag::LuauSolverV2, true},
-        // crash only happens right now with eager generalization off
-        {FFlag::LuauCollapseShouldNotCrash, true},
     };
 
     CheckResult result = check(R"(
@@ -3509,8 +3480,7 @@ TEST_CASE_FIXTURE(Fixture, "oss_2065_bidirectional_inference_function_call")
 {
     ScopedFastFlag sffs[] = {
         {FFlag::LuauSolverV2, true},
-        {FFlag::LuauPushTypeConstraintLambdas2, true},
-        {FFlag::LuauPushTypeConstraintIntersection, true},
+        {FFlag::LuauPushTypeConstraintLambdas3, true},
         {FFlag::DebugLuauAssertOnForcedConstraint, true},
     };
 
@@ -3533,7 +3503,7 @@ TEST_CASE_FIXTURE(Fixture, "bidirectionally_infer_lambda_with_partially_resolved
 {
     ScopedFastFlag sffs[] = {
         {FFlag::LuauSolverV2, true},
-        {FFlag::LuauPushTypeConstraintLambdas2, true},
+        {FFlag::LuauPushTypeConstraintLambdas3, true},
         {FFlag::DebugLuauAssertOnForcedConstraint, true},
     };
 
@@ -3556,7 +3526,7 @@ TEST_CASE_FIXTURE(Fixture, "bidirectional_inference_goes_through_ifelse")
 {
     ScopedFastFlag sffs[] = {
         {FFlag::LuauSolverV2, true},
-        {FFlag::LuauPushTypeConstraintLambdas2, true},
+        {FFlag::LuauPushTypeConstraintLambdas3, true},
         {FFlag::DebugLuauAssertOnForcedConstraint, true},
     };
 
@@ -3570,10 +3540,7 @@ TEST_CASE_FIXTURE(Fixture, "bidirectional_inference_goes_through_ifelse")
 
 TEST_CASE_FIXTURE(Fixture, "overload_one_ok_one_potential")
 {
-    ScopedFastFlag sffs[] = {
-        {FFlag::LuauSolverV2, true},
-        {FFlag::LuauNewOverloadResolver2, true},
-    };
+    ScopedFastFlag _{FFlag::LuauSolverV2, true};
 
     auto result = check(R"(
         local f: ((number) -> "one") & ((string) -> "two")
@@ -3589,10 +3556,7 @@ TEST_CASE_FIXTURE(Fixture, "overload_one_ok_one_potential")
 
 TEST_CASE_FIXTURE(Fixture, "overload_selection_ambiguous_call")
 {
-    ScopedFastFlag sffs[] = {
-        {FFlag::LuauSolverV2, true},
-        {FFlag::LuauNewOverloadResolver2, true},
-    };
+    ScopedFastFlag _{FFlag::LuauSolverV2, true};
 
     auto result = check(R"(
         local f: ((number | string) -> "one") & ((number | boolean) -> "two")
@@ -3610,10 +3574,7 @@ TEST_CASE_FIXTURE(Fixture, "overload_selection_ambiguous_call")
 
 TEST_CASE_FIXTURE(Fixture, "overload_selection_pick_better_arity")
 {
-    ScopedFastFlag sffs[] = {
-        {FFlag::LuauSolverV2, true},
-        {FFlag::LuauNewOverloadResolver2, true},
-    };
+    ScopedFastFlag _{FFlag::LuauSolverV2, true};
 
     auto result = check(R"(
         local f: ((number) -> "one") & ((number, number) -> "two")
@@ -3633,10 +3594,7 @@ TEST_CASE_FIXTURE(Fixture, "overload_selection_pick_better_arity")
 
 TEST_CASE_FIXTURE(Fixture, "overload_selection_no_compatible_option")
 {
-    ScopedFastFlag sffs[] = {
-        {FFlag::LuauSolverV2, true},
-        {FFlag::LuauNewOverloadResolver2, true},
-    };
+    ScopedFastFlag _{FFlag::LuauSolverV2, true};
 
     auto result = check(R"(
         local f: ((number) -> "one") & ((boolean) -> "two")
@@ -3650,10 +3608,7 @@ TEST_CASE_FIXTURE(Fixture, "overload_selection_no_compatible_option")
 
 TEST_CASE_FIXTURE(Fixture, "overload_selection_bad_arity")
 {
-    ScopedFastFlag sffs[] = {
-        {FFlag::LuauSolverV2, true},
-        {FFlag::LuauNewOverloadResolver2, true},
-    };
+    ScopedFastFlag _{FFlag::LuauSolverV2, true};
 
     auto result = check(R"(
         local function foo<T>(f: ((number, number) -> "one") & T)
@@ -3676,10 +3631,7 @@ TEST_CASE_FIXTURE(Fixture, "overload_selection_bad_arity")
 
 TEST_CASE_FIXTURE(Fixture, "overload_selection_union_of_functions")
 {
-    ScopedFastFlag sffs[] = {
-        {FFlag::LuauSolverV2, true},
-        {FFlag::LuauNewOverloadResolver2, true},
-    };
+    ScopedFastFlag _{FFlag::LuauSolverV2, true};
 
     auto result = check(R"(
         local function foo(f: (() -> (number)) | (() -> (string)))
@@ -3702,10 +3654,7 @@ TEST_CASE_FIXTURE(Fixture, "overload_selection_union_of_functions")
 
 TEST_CASE_FIXTURE(Fixture, "overload_selection_needs_to_retry")
 {
-    ScopedFastFlag sffs[] = {
-        {FFlag::LuauSolverV2, true},
-        {FFlag::LuauNewOverloadResolver2, true},
-    };
+    ScopedFastFlag _{FFlag::LuauSolverV2, true};
 
     auto results = check(R"(
         type RGB = { r: number, b: number, g: number }
@@ -3724,10 +3673,7 @@ TEST_CASE_FIXTURE(Fixture, "overload_selection_needs_to_retry")
 
 TEST_CASE_FIXTURE(Fixture, "overload_selection_unambiguous_with_constraint")
 {
-    ScopedFastFlag sffs[] = {
-        {FFlag::LuauSolverV2, true},
-        {FFlag::LuauNewOverloadResolver2, true},
-    };
+    ScopedFastFlag _{FFlag::LuauSolverV2, true};
 
     LUAU_REQUIRE_NO_ERRORS(check(R"(
         local f: ((string, number) -> string) & ((number, boolean) -> number)
@@ -3807,7 +3753,7 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "bidirectional_lambda_inference_applies_nilab
 {
     ScopedFastFlag sffs[] = {
         {FFlag::LuauSolverV2, true},
-        {FFlag::LuauPushTypeConstraintLambdas2, true},
+        {FFlag::LuauPushTypeConstraintLambdas3, true},
         {FFlag::LuauPushTypeConstraintStripNilFromFunction, true},
         {FFlag::DebugLuauAssertOnForcedConstraint, true},
     };
@@ -3840,6 +3786,131 @@ TEST_CASE_FIXTURE(Fixture, "function_statement_with_incorrect_function_type")
     REQUIRE(err);
     CHECK_EQ("(number) -> number", toString(err->wantedType));
     CHECK_EQ("(string) -> boolean", toString(err->givenType));
+}
+
+TEST_CASE_FIXTURE(Fixture, "bidirectional_inference_allow_internal_generics")
+{
+    ScopedFastFlag sffs[] = {
+        {FFlag::LuauSolverV2, true},
+        {FFlag::LuauPushTypeConstraintLambdas3, true},
+        {FFlag::DebugLuauAssertOnForcedConstraint, true},
+    };
+
+    CheckResult result = check(R"(
+        type testsuite = { case: (self: testsuite, <T>(T) -> T) -> () }
+
+        local test1: { suite: (string, (testsuite) -> ()) -> () } = nil :: any
+
+        test1.suite("LuteTestCommand", function(suite)
+            suite:case(42)
+        end)
+    )");
+
+    LUAU_REQUIRE_ERROR_COUNT(1, result);
+    auto err = get<TypeMismatch>(result.errors[0]);
+    CHECK_EQ("<T>(T) -> T", toString(err->wantedType));
+    CHECK_EQ("number", toString(err->givenType));
+}
+
+TEST_CASE_FIXTURE(Fixture, "oss_2143")
+{
+    ScopedFastFlag _{FFlag::LuauUnifier2HandleMismatchedPacks, true};
+
+    CheckResult result = check(R"(
+        local function call<A..., R...>(c: (A...) -> R..., ...: A...): R...
+            return c(...)
+        end
+            
+        local function fn(a: number): { number }
+            return nil :: any
+        end
+            
+        local function fn2<T>(b: { T }, x: (T) -> ())
+            return b
+        end
+            
+        local values = call(fn, 2)
+
+        fn2(values, function(x: number)
+        end)
+            
+        local a = values[1]
+    )");
+
+    LUAU_REQUIRE_NO_ERRORS(result);
+}
+
+TEST_CASE_FIXTURE(Fixture, "apply_example_from_oss")
+{
+    ScopedFastFlag _{FFlag::LuauUnifier2HandleMismatchedPacks, true};
+
+    CheckResult result = check(R"(
+        type something = { Something: number }
+        type example = { Example: number }
+        local function test(a: something): example
+            return nil :: any
+        end
+        local function apply<T..., U...>(func: (T...) -> U..., ...: T...): (boolean, U...)
+            return nil :: any
+        end
+        local b, result = apply(test, {
+            Something = 1
+        })
+    )");
+
+    LUAU_REQUIRE_NO_ERRORS(result);
+
+    CHECK("{ Example: number }" == toString(requireType("result"), {true}));
+}
+
+TEST_CASE_FIXTURE(BuiltinsFixture, "oss_2109")
+{
+    ScopedFastFlag _{FFlag::LuauUnifier2HandleMismatchedPacks, true};
+
+    LUAU_REQUIRE_NO_ERRORS(check(R"(
+        local function Retry<T..., K...>(
+            MaxRetries: number,
+            RetryInterval: number,
+            Function: (T...) -> (K...),
+            ...: T...
+        ): K...
+            local Results
+            local CurrentRetry = 0
+
+            repeat
+                Results = {pcall(Function, ...)}
+
+                if not Results[1] then
+                    CurrentRetry += 1
+                end
+            until Results[1] or CurrentRetry == MaxRetries
+
+            return unpack(Results :: any, 2)
+        end
+
+        local function Test(a: number, b: number): number
+            return a + b
+        end
+
+        local a = Retry(5, 1, Test, 5, 10)
+    )"));
+    CHECK_EQ("number", toString(requireType("a")));
+}
+
+TEST_CASE_FIXTURE(BuiltinsFixture, "pcall_example")
+{
+    ScopedFastFlag _{FFlag::LuauUnifier2HandleMismatchedPacks, true};
+
+    LUAU_REQUIRE_NO_ERRORS(check(R"(
+        local function makestr(n: number): string
+            return tostring(n)
+        end
+
+        -- `s` now has type `string` and not `unknown`
+        local success, s = pcall(makestr, 42)
+    )"));
+
+    CHECK_EQ("string", toString(requireType("s")));
 }
 
 TEST_SUITE_END();

--- a/tests/TypeInfer.loops.test.cpp
+++ b/tests/TypeInfer.loops.test.cpp
@@ -16,7 +16,6 @@
 using namespace Luau;
 
 LUAU_FASTFLAG(LuauSolverV2)
-LUAU_FASTFLAG(LuauNoScopeShallNotSubsumeAll)
 LUAU_FASTFLAG(LuauCheckForInWithSubtyping3)
 LUAU_FASTFLAG(LuauInstantiationUsesGenericPolarity2)
 LUAU_FASTFLAG(LuauBetterTypeMismatchErrors)
@@ -42,7 +41,7 @@ TEST_CASE_FIXTURE(Fixture, "for_loop")
         CHECK("number?" == toString(requireType("q")));
     }
     else
-        CHECK_EQ(*getBuiltins()->numberType, *requireType("q"));
+        CHECK("number" == toString(requireType("q")));
 }
 
 TEST_CASE_FIXTURE(BuiltinsFixture, "iteration_no_table_passed")
@@ -153,8 +152,8 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "for_in_loop")
     }
     else
     {
-        CHECK_EQ(*getBuiltins()->numberType, *requireType("n"));
-        CHECK_EQ(*getBuiltins()->stringType, *requireType("s"));
+        CHECK("number" == toString(requireType("n")));
+        CHECK("string" == toString(requireType("s")));
     }
 }
 
@@ -181,8 +180,8 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "for_in_loop_with_next")
     }
     else
     {
-        CHECK_EQ(*getBuiltins()->numberType, *requireType("n"));
-        CHECK_EQ(*getBuiltins()->stringType, *requireType("s"));
+        CHECK("number" == toString(requireType("n")));
+        CHECK("string" == toString(requireType("s")));
     }
 }
 TEST_CASE_FIXTURE(BuiltinsFixture, "for_in_loop_with_next_and_multiple_elements")
@@ -208,8 +207,8 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "for_in_loop_with_next_and_multiple_elements"
     }
     else
     {
-        CHECK_EQ(*getBuiltins()->numberType, *requireType("n"));
-        CHECK_EQ(*getBuiltins()->stringType, *requireType("s"));
+        CHECK("number" == toString(requireType("n")));
+        CHECK("string" == toString(requireType("s")));
     }
 }
 
@@ -480,7 +479,7 @@ TEST_CASE_FIXTURE(Fixture, "while_loop")
     if (FFlag::LuauSolverV2)
         CHECK("number?" == toString(requireType("i")));
     else
-        CHECK_EQ(*getBuiltins()->numberType, *requireType("i"));
+        CHECK("number" == toString(requireType("i")));
 }
 
 TEST_CASE_FIXTURE(Fixture, "repeat_loop")
@@ -497,7 +496,7 @@ TEST_CASE_FIXTURE(Fixture, "repeat_loop")
     if (FFlag::LuauSolverV2)
         CHECK("string?" == toString(requireType("i")));
     else
-        CHECK_EQ(*getBuiltins()->stringType, *requireType("i"));
+        CHECK("string" == toString(requireType("i")));
 }
 
 TEST_CASE_FIXTURE(Fixture, "repeat_loop_condition_binds_to_its_block")
@@ -783,10 +782,6 @@ TEST_CASE_FIXTURE(Fixture, "fuzz_fail_missing_instantitation_follow")
 
 TEST_CASE_FIXTURE(BuiltinsFixture, "for_in_with_generic_next")
 {
-    ScopedFastFlag sff[] = {
-        {FFlag::LuauNoScopeShallNotSubsumeAll, true},
-    };
-
     CheckResult result = check(R"(
         for k: number, v: number in next, {1, 2, 3} do
         end
@@ -819,7 +814,7 @@ TEST_CASE_FIXTURE(Fixture, "loop_iter_basic")
         CHECK("number?" == toString(keyTy));
     }
     else
-        CHECK_EQ(*getBuiltins()->numberType, *requireType("key"));
+        CHECK("number" == toString(requireType("key")));
 }
 
 TEST_CASE_FIXTURE(Fixture, "loop_iter_trailing_nil")
@@ -836,7 +831,7 @@ TEST_CASE_FIXTURE(Fixture, "loop_iter_trailing_nil")
     )");
 
     LUAU_REQUIRE_ERROR_COUNT(0, result);
-    CHECK_EQ(*getBuiltins()->nilType, *requireType("extra"));
+    CHECK("nil" == toString(requireType("extra")));
 }
 
 TEST_CASE_FIXTURE(Fixture, "loop_iter_no_indexer_strict")

--- a/tests/TypeInfer.modules.test.cpp
+++ b/tests/TypeInfer.modules.test.cpp
@@ -16,6 +16,7 @@ LUAU_FASTFLAG(LuauSolverV2)
 LUAU_FASTFLAG(DebugLuauMagicTypes)
 LUAU_FASTINT(LuauSolverConstraintLimit)
 LUAU_FASTFLAG(LuauBetterTypeMismatchErrors)
+LUAU_FASTFLAG(LuauReworkInfiniteTypeFinder)
 
 using namespace Luau;
 
@@ -966,6 +967,8 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "invalid_local_alias_shouldnt_shadow_imported
 
 TEST_CASE_FIXTURE(BuiltinsFixture, "invalid_alias_should_export_as_error_type")
 {
+    ScopedFastFlag _{FFlag::LuauReworkInfiniteTypeFinder, true};
+
     fileResolver.source["game/A"] = R"(
         export type bad<T> = {bad<{T}>}
         return {}
@@ -984,10 +987,7 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "invalid_alias_should_export_as_error_type")
     REQUIRE(b != nullptr);
     std::optional<TypeId> fType = requireType(b, "f");
     REQUIRE(fType);
-    if (FFlag::LuauSolverV2)
-        CHECK(toString(*fType) == "*error-type*");
-    else
-        CHECK(toString(*fType) == "bad<number>");
+    CHECK(toString(*fType) == "bad<number>");
 }
 
 TEST_SUITE_END();

--- a/tests/TypeInfer.oop.test.cpp
+++ b/tests/TypeInfer.oop.test.cpp
@@ -17,7 +17,7 @@ using namespace Luau;
 
 LUAU_FASTFLAG(LuauHandleFunctionOversaturation)
 LUAU_FASTFLAG(LuauIndexInMetatableSubtyping)
-LUAU_FASTFLAG(LuauPushTypeConstraintLambdas2)
+LUAU_FASTFLAG(LuauPushTypeConstraintLambdas3)
 LUAU_FASTFLAG(LuauSolverV2)
 LUAU_FASTFLAG(LuauTrackFreeInteriorTypePacks)
 
@@ -174,7 +174,7 @@ TEST_CASE_FIXTURE(Fixture, "pass_too_many_arguments")
 {
     ScopedFastFlag sff[] = {
         {FFlag::LuauSolverV2, true},
-        {FFlag::LuauPushTypeConstraintLambdas2, true},
+        {FFlag::LuauPushTypeConstraintLambdas3, true},
         {FFlag::LuauHandleFunctionOversaturation, true},
     };
 

--- a/tests/TypeInfer.operators.test.cpp
+++ b/tests/TypeInfer.operators.test.cpp
@@ -18,10 +18,9 @@
 using namespace Luau;
 
 LUAU_FASTFLAG(LuauSolverV2)
-LUAU_FASTFLAG(LuauNoScopeShallNotSubsumeAll)
 LUAU_FASTFLAG(LuauSolverAgnosticStringification)
-LUAU_FASTFLAG(LuauUnknownGlobalFixSuggestion)
 LUAU_FASTFLAG(LuauBetterTypeMismatchErrors)
+LUAU_FASTFLAG(LuauTypeFunctionsUseSolveFunctionCall)
 
 TEST_SUITE_BEGIN("TypeInferOperators");
 
@@ -82,7 +81,7 @@ TEST_CASE_FIXTURE(Fixture, "or_joins_types_with_no_superfluous_union")
         CHECK("(string & ~(false?)) | string" == toString(requireType("s")));
     }
     else
-        CHECK_EQ(*requireType("s"), *getBuiltins()->stringType);
+        CHECK("string" == toString(requireType("s")));
 }
 
 TEST_CASE_FIXTURE(Fixture, "and_does_not_always_add_boolean")
@@ -102,7 +101,7 @@ TEST_CASE_FIXTURE(Fixture, "and_adds_boolean_no_superfluous_union")
         local x:boolean = s
     )");
     LUAU_REQUIRE_NO_ERRORS(result);
-    CHECK_EQ(*requireType("x"), *getBuiltins()->booleanType);
+    CHECK("boolean" == toString(requireType("x")));
 }
 
 TEST_CASE_FIXTURE(Fixture, "and_or_ternary")
@@ -129,9 +128,9 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "primitive_arith_no_metatable")
 
     std::optional<TypeId> retType = first(functionType->retTypes);
     REQUIRE(retType.has_value());
-    CHECK_EQ(getBuiltins()->numberType, follow(*retType));
-    CHECK_EQ(requireType("n"), getBuiltins()->numberType);
-    CHECK_EQ(requireType("s"), getBuiltins()->stringType);
+    CHECK("number" == toString(*retType));
+    CHECK("number" == toString(requireType("n")));
+    CHECK("string" == toString(requireType("s")));
 }
 
 TEST_CASE_FIXTURE(Fixture, "primitive_arith_no_metatable_with_follows")
@@ -411,7 +410,7 @@ TEST_CASE_FIXTURE(Fixture, "compound_assign_basic")
         s += 20
     )");
     CHECK_EQ(0, result.errors.size());
-    CHECK_EQ(toString(*requireType("s")), "number");
+    CHECK_EQ(toString(requireType("s")), "number");
 }
 
 TEST_CASE_FIXTURE(Fixture, "compound_assign_mismatch_op")
@@ -607,8 +606,8 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "typecheck_unary_minus")
 
         TypeMismatch* tm = get<TypeMismatch>(result.errors[1]);
         REQUIRE(tm);
-        CHECK_EQ(toString(tm->givenType), "bar");
-        CHECK_EQ(*tm->wantedType, *getBuiltins()->numberType);
+        CHECK("bar" == toString(tm->givenType));
+        CHECK("number" == toString(tm->wantedType));
     }
     else
     {
@@ -622,6 +621,8 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "typecheck_unary_minus")
 
 TEST_CASE_FIXTURE(BuiltinsFixture, "typecheck_unary_minus_error")
 {
+    ScopedFastFlag _{FFlag::LuauTypeFunctionsUseSolveFunctionCall, true};
+
     CheckResult result = check(R"(
         --!strict
         local mt = {}
@@ -639,15 +640,18 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "typecheck_unary_minus_error")
 
     if (FFlag::LuauSolverV2)
     {
-        LUAU_REQUIRE_ERROR_COUNT(1, result);
+        LUAU_REQUIRE_ERROR_COUNT(2, result);
 
-        CHECK("string" == toString(requireType("a")));
+        // FIXME CLI-183037
+        // This is not as nice but it's a consistent behavior (for now) as some
+        // operators depend on type function inhabitance for error checking.
+        CHECK("unm<foo>" == toString(requireType("a")));
 
-        TypeMismatch* tm = get<TypeMismatch>(result.errors[0]);
+        CHECK(get<UninhabitedTypeFunction>(result.errors[0]));
+
+        auto tm = get<TypeMismatch>(result.errors[1]);
         REQUIRE(tm);
-
-        // FIXME: This error is a bit weird.
-        CHECK("({ @metatable { __unm: (boolean) -> string }, { value: number } }) -> string" == toString(tm->wantedType, {true}));
+        CHECK("(foo) -> unm<foo>" == toString(tm->wantedType));
         CHECK("(boolean) -> string" == toString(tm->givenType));
     }
     else
@@ -657,7 +661,7 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "typecheck_unary_minus_error")
         CHECK_EQ("string", toString(requireType("a")));
 
         TypeMismatch* tm = get<TypeMismatch>(result.errors[0]);
-        REQUIRE_EQ(*tm->wantedType, *getBuiltins()->booleanType);
+        REQUIRE("boolean" == toString(tm->wantedType));
         // given type is the typeof(foo) which is complex to compare against
     }
 }
@@ -689,8 +693,8 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "typecheck_unary_len_error")
     TypeMismatch* tm = get<TypeMismatch>(result.errors[0]);
     REQUIRE_MESSAGE(tm, "Expected a TypeMismatch but got " << result.errors[0]);
 
-    REQUIRE_EQ(*tm->wantedType, *getBuiltins()->numberType);
-    REQUIRE_EQ(*tm->givenType, *getBuiltins()->stringType);
+    CHECK("number" == toString(tm->wantedType));
+    CHECK("string" == toString(tm->givenType));
 }
 
 TEST_CASE_FIXTURE(BuiltinsFixture, "unary_not_is_boolean")
@@ -749,8 +753,8 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "disallow_string_and_types_without_metatables
     {
         TypeMismatch* tm = get<TypeMismatch>(result.errors[0]);
         REQUIRE_MESSAGE(tm, "Expected a TypeMismatch but got " << result.errors[0]);
-        CHECK_EQ(*tm->wantedType, *getBuiltins()->numberType);
-        CHECK_EQ(*tm->givenType, *getBuiltins()->stringType);
+        CHECK("number" == toString(tm->wantedType));
+        CHECK("string" == toString(tm->givenType));
 
         GenericError* gen1 = get<GenericError>(result.errors[1]);
         REQUIRE(gen1);
@@ -761,8 +765,8 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "disallow_string_and_types_without_metatables
 
         TypeMismatch* tm2 = get<TypeMismatch>(result.errors[2]);
         REQUIRE(tm2);
-        CHECK_EQ(*tm2->wantedType, *getBuiltins()->numberType);
-        CHECK_EQ(*tm2->givenType, *requireType("foo"));
+        CHECK("number" == toString(tm2->wantedType));
+        CHECK(requireType("foo") == tm2->givenType);
     }
 }
 
@@ -934,8 +938,6 @@ TEST_CASE_FIXTURE(Fixture, "cli_38355_recursive_union")
 
 TEST_CASE_FIXTURE(BuiltinsFixture, "UnknownGlobalCompoundAssign")
 {
-    ScopedFastFlag unknownGlobalFixSuggestion{FFlag::LuauUnknownGlobalFixSuggestion, true};
-
     // In non-strict mode, global definition is still allowed
     {
         if (!FFlag::LuauSolverV2)
@@ -1444,11 +1446,7 @@ local function foo(arg: {name: string}?)
 end
     )");
 
-    // FIXME(CLI-165431): fixing subtyping revealed an overload selection problems
-    if (FFlag::LuauSolverV2 && FFlag::LuauNoScopeShallNotSubsumeAll)
-        LUAU_REQUIRE_NO_ERRORS(result);
-    else
-        LUAU_REQUIRE_NO_ERRORS(result);
+    LUAU_REQUIRE_NO_ERRORS(result);
 }
 
 TEST_CASE_FIXTURE(BuiltinsFixture, "luau_polyfill_is_array_simplified")

--- a/tests/TypeInfer.primitives.test.cpp
+++ b/tests/TypeInfer.primitives.test.cpp
@@ -55,7 +55,7 @@ TEST_CASE_FIXTURE(Fixture, "string_method")
     )");
 
     LUAU_REQUIRE_NO_ERRORS(result);
-    CHECK_EQ(*requireType("p"), *getBuiltins()->numberType);
+    CHECK("number" == toString(requireType("p")));
 }
 
 TEST_CASE_FIXTURE(Fixture, "string_function_indirect")
@@ -67,7 +67,7 @@ TEST_CASE_FIXTURE(Fixture, "string_function_indirect")
     )");
 
     LUAU_REQUIRE_NO_ERRORS(result);
-    CHECK_EQ(*requireType("p"), *getBuiltins()->stringType);
+    CHECK("string" == toString(requireType("p")));
 }
 
 TEST_CASE_FIXTURE(Fixture, "check_methods_of_number")

--- a/tests/TypeInfer.provisional.test.cpp
+++ b/tests/TypeInfer.provisional.test.cpp
@@ -17,9 +17,7 @@ LUAU_FASTINT(LuauTarjanChildLimit)
 LUAU_FASTINT(LuauTypeInferIterationLimit)
 LUAU_FASTINT(LuauTypeInferRecursionLimit)
 LUAU_FASTINT(LuauTypeInferTypePackLoopLimit)
-LUAU_FASTFLAG(LuauAddRefinementToAssertions)
 LUAU_FASTFLAG(LuauBetterTypeMismatchErrors)
-LUAU_FASTFLAG(LuauNewOverloadResolver2)
 
 TEST_SUITE_BEGIN("ProvisionalTests");
 
@@ -573,8 +571,6 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "for_in_loop_with_zero_iterators")
 // Ideally, we would not try to export a function type with generic types from incorrect scope
 TEST_CASE_FIXTURE(BuiltinsFixture, "generic_type_leak_to_module_interface")
 {
-    ScopedFastFlag sff{FFlag::LuauNewOverloadResolver2, true};
-
     fileResolver.source["game/A"] = R"(
 local wrapStrictTable
 
@@ -619,8 +615,6 @@ return wrapStrictTable(Constants, "Constants")
 
 TEST_CASE_FIXTURE(BuiltinsFixture, "generic_type_leak_to_module_interface_variadic")
 {
-    ScopedFastFlag sff{FFlag::LuauNewOverloadResolver2, true};
-
     fileResolver.source["game/A"] = R"(
 local wrapStrictTable
 
@@ -1437,10 +1431,7 @@ TEST_CASE_FIXTURE(Fixture, "unification_inferring_never_for_refined_param")
 
 TEST_CASE_FIXTURE(BuiltinsFixture, "assert_and_many_nested_typeof_contexts")
 {
-    ScopedFastFlag sffs[] = {
-        {FFlag::LuauSolverV2, true},
-        {FFlag::LuauAddRefinementToAssertions, true},
-    };
+    ScopedFastFlag sff{FFlag::LuauSolverV2, true};
 
     CheckResult result = check(R"(
         local foo: unknown = nil :: any
@@ -1512,7 +1503,5 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "unions_should_work_with_bidirectional_typech
     CHECK(get<TypeMismatch>(result.errors[0]));
     CHECK(get<TypeMismatch>(result.errors[1]));
 }
-
-
 
 TEST_SUITE_END();

--- a/tests/TypeInfer.refinements.test.cpp
+++ b/tests/TypeInfer.refinements.test.cpp
@@ -10,15 +10,9 @@
 
 LUAU_FASTFLAG(LuauSolverV2)
 LUAU_FASTFLAG(LuauFunctionCallsAreNotNilable)
-LUAU_FASTFLAG(LuauRefineNoRefineAlways2)
-LUAU_FASTFLAG(LuauRefineDistributesOverUnions)
 LUAU_FASTFLAG(LuauNumericUnaryOpsDontProduceNegationRefinements)
-LUAU_FASTFLAG(LuauAddRefinementToAssertions)
 LUAU_FASTFLAG(DebugLuauAssertOnForcedConstraint)
-LUAU_FASTFLAG(LuauNormalizationPreservesAny)
-LUAU_FASTFLAG(LuauRefineNoRefineAlways2)
 LUAU_FASTFLAG(LuauBetterTypeMismatchErrors)
-LUAU_FASTFLAG(LuauFixSubtypingOfNegations)
 
 using namespace Luau;
 
@@ -1717,8 +1711,6 @@ TEST_CASE_FIXTURE(RefinementExternTypeFixture, "asserting_non_existent_propertie
 
 TEST_CASE_FIXTURE(RefinementExternTypeFixture, "x_is_not_instance_or_else_not_part")
 {
-    ScopedFastFlag sff{FFlag::LuauRefineDistributesOverUnions, true};
-
     CheckResult result = check(R"(
         local function f(x: Part | Folder | string)
             if typeof(x) ~= "Instance" or not x:IsA("Part") then
@@ -2828,10 +2820,7 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "refine_by_no_refine_should_always_reduce")
     // how we report constraint solving incomplete errors revealed that this
     // test would always fail to solve all constraints, except under eager
     // generalization.
-    ScopedFastFlag sffs[] = {
-        {FFlag::LuauSolverV2, true},
-        {FFlag::LuauRefineNoRefineAlways2, true},
-    };
+    ScopedFastFlag _{FFlag::LuauSolverV2, true};
 
     CheckResult result = check(R"(
         function foo(t): boolean return true end
@@ -2901,7 +2890,6 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "refinements_from_and_should_not_refine_to_ne
 {
     ScopedFastFlag sffs[] = {
         {FFlag::LuauSolverV2, true},
-        {FFlag::LuauRefineDistributesOverUnions, true},
     };
 
     loadDefinition(R"(
@@ -3029,10 +3017,7 @@ TEST_CASE_FIXTURE(Fixture, "oss_1517_equality_doesnt_add_nil")
 
 TEST_CASE_FIXTURE(BuiltinsFixture, "typeof_refinement_context")
 {
-    ScopedFastFlag sffs[] = {
-        {FFlag::LuauSolverV2, true},
-        {FFlag::LuauAddRefinementToAssertions, true},
-    };
+    ScopedFastFlag sff{FFlag::LuauSolverV2, true};
 
     LUAU_REQUIRE_NO_ERRORS(check(R"(
         --!strict
@@ -3049,10 +3034,7 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "typeof_refinement_context")
 
 TEST_CASE_FIXTURE(BuiltinsFixture, "assert_and_typeof_refinement_context")
 {
-    ScopedFastFlag sffs[] = {
-        {FFlag::LuauSolverV2, true},
-        {FFlag::LuauAddRefinementToAssertions, true},
-    };
+    ScopedFastFlag sff{FFlag::LuauSolverV2, true};
 
     LUAU_REQUIRE_NO_ERRORS(check(R"(
         --!strict
@@ -3067,10 +3049,7 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "assert_and_typeof_refinement_context")
 
 TEST_CASE_FIXTURE(BuiltinsFixture, "foo_call_should_not_refine")
 {
-    ScopedFastFlag sffs[] = {
-        {FFlag::LuauSolverV2, true},
-        {FFlag::LuauAddRefinementToAssertions, true},
-    };
+    ScopedFastFlag sff{FFlag::LuauSolverV2, true};
 
     CheckResult result = check(R"(
         --!strict
@@ -3089,10 +3068,7 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "foo_call_should_not_refine")
 
 TEST_CASE_FIXTURE(BuiltinsFixture, "assert_call_should_not_refine_despite_typeof")
 {
-    ScopedFastFlag sffs[] = {
-        {FFlag::LuauSolverV2, true},
-        {FFlag::LuauAddRefinementToAssertions, true},
-    };
+    ScopedFastFlag sff{FFlag::LuauSolverV2, true};
 
     CheckResult result = check(R"(
         --!strict
@@ -3113,10 +3089,7 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "assert_call_should_not_refine_despite_typeof
 
 TEST_CASE_FIXTURE(BuiltinsFixture, "non_conditional_context_in_if_should_not_refine")
 {
-    ScopedFastFlag sffs[] = {
-        {FFlag::LuauSolverV2, true},
-        {FFlag::LuauAddRefinementToAssertions, true},
-    };
+    ScopedFastFlag sff{FFlag::LuauSolverV2, true};
 
     CheckResult result = check(R"(
         local function bing(_: any) end
@@ -3163,8 +3136,6 @@ TEST_CASE_FIXTURE(Fixture, "type_function_reduction_with_union_type_application"
 
 TEST_CASE_FIXTURE(BuiltinsFixture, "refine_any_and_unknown_should_still_be_any")
 {
-    ScopedFastFlag _{FFlag::LuauNormalizationPreservesAny, true};
-
     LUAU_REQUIRE_NO_ERRORS(check(R"(
         local REACT_FRAGMENT_TYPE = (nil :: any)
         local function typeOf(object: any)
@@ -3185,7 +3156,6 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "cli_181100_fast_track_refinement_against_unk
 {
     ScopedFastFlag sffs[] = {
         {FFlag::LuauSolverV2, true},
-        {FFlag::LuauRefineNoRefineAlways2, true},
         {FFlag::DebugLuauAssertOnForcedConstraint, true},
     };
 
@@ -3211,10 +3181,7 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "cli_181100_fast_track_refinement_against_unk
 
 TEST_CASE_FIXTURE(BuiltinsFixture, "cli_181549_refined_string_should_be_subtype_of_string")
 {
-    ScopedFastFlag sffs[] = {
-        {FFlag::LuauSolverV2, true},
-        {FFlag::LuauFixSubtypingOfNegations, true},
-    };
+    ScopedFastFlag _{FFlag::LuauSolverV2, true};
 
     LUAU_REQUIRE_NO_ERRORS(check(Mode::Nonstrict, R"(
       local hello : string = "world"

--- a/tests/TypeInfer.singletons.test.cpp
+++ b/tests/TypeInfer.singletons.test.cpp
@@ -8,8 +8,8 @@
 using namespace Luau;
 
 LUAU_FASTFLAG(LuauSolverV2)
-LUAU_FASTFLAG(LuauPushTypeConstraintIndexer)
 LUAU_FASTFLAG(LuauBetterTypeMismatchErrors)
+LUAU_FASTFLAG(LuauPushTypeUnifyConstantHandling)
 
 TEST_SUITE_BEGIN("TypeSingletons");
 
@@ -460,6 +460,10 @@ Table type 'a' not compatible with type 'Cat' because the former is missing fiel
 
 TEST_CASE_FIXTURE(Fixture, "error_detailed_tagged_union_mismatch_bool")
 {
+    ScopedFastFlag sffs[] = {
+        {FFlag::LuauBetterTypeMismatchErrors, true},
+        {FFlag::LuauPushTypeUnifyConstantHandling, true},
+    };
     CheckResult result = check(R"(
 type Good = { success: true, result: string }
 type Bad = { success: false, error: string }
@@ -471,22 +475,14 @@ local a: Result = { success = false, result = 'something' }
     LUAU_REQUIRE_ERROR_COUNT(1, result);
     if (FFlag::LuauSolverV2)
     {
-        if (FFlag::LuauBetterTypeMismatchErrors)
-            CHECK("Expected this to be 'Bad | Good', but got '{ result: string, success: boolean }'" == toString(result.errors[0]));
-        else
-            CHECK("Type '{ result: string, success: boolean }' could not be converted into 'Bad | Good'" == toString(result.errors[0]));
-    }
-    else if (FFlag::LuauBetterTypeMismatchErrors)
-    {
-        const std::string expected = R"(Expected this to be 'Bad | Good', but got 'a'
-caused by:
-  None of the union options are compatible. For example:
-Table type 'a' not compatible with type 'Bad' because the former is missing field 'error')";
-        CHECK_EQ(expected, toString(result.errors[0]));
+        CHECK_EQ(
+            "Table type '{ result: string, success: false }' not compatible with type 'Bad' because the former is missing field 'error'",
+            toString(result.errors[0])
+        );
     }
     else
     {
-        const std::string expected = R"(Type 'a' could not be converted into 'Bad | Good'
+        const std::string expected = R"(Expected this to be 'Bad | Good', but got 'a'
 caused by:
   None of the union options are compatible. For example:
 Table type 'a' not compatible with type 'Bad' because the former is missing field 'error')";
@@ -498,6 +494,8 @@ TEST_CASE_FIXTURE(Fixture, "parametric_tagged_union_alias")
 {
     ScopedFastFlag sff[] = {
         {FFlag::LuauSolverV2, true},
+        {FFlag::LuauBetterTypeMismatchErrors, true},
+        {FFlag::LuauPushTypeUnifyConstantHandling, true},
     };
     CheckResult result = check(R"(
         type Ok<T> = {success: true, result: T}
@@ -510,15 +508,10 @@ TEST_CASE_FIXTURE(Fixture, "parametric_tagged_union_alias")
 
     LUAU_REQUIRE_ERROR_COUNT(1, result);
 
-    const std::string expectedError = FFlag::LuauBetterTypeMismatchErrors ? "Expected this to be\n\t"
-                                                                            "'Err<number> | Ok<string>'"
-                                                                            "\nbut got\n\t"
-                                                                            "'{ result: string, success: boolean }'"
-                                                                          : "Type\n\t"
-                                                                            "'{ result: string, success: boolean }'"
-                                                                            "\ncould not be converted into\n\t"
-                                                                            "'Err<number> | Ok<string>'";
-    CHECK(toString(result.errors[0]) == expectedError);
+    CHECK_EQ(
+        "Table type '{ result: string, success: false }' not compatible with type 'Err<number>' because the former is missing field 'error'",
+        toString(result.errors[0])
+    );
 }
 
 TEST_CASE_FIXTURE(Fixture, "if_then_else_expression_singleton_options")
@@ -790,10 +783,7 @@ TEST_CASE_FIXTURE(Fixture, "oss_2010")
 
 TEST_CASE_FIXTURE(Fixture, "oss_1773")
 {
-    ScopedFastFlag sffs[] = {
-        {FFlag::LuauSolverV2, true},
-        {FFlag::LuauPushTypeConstraintIndexer, true},
-    };
+    ScopedFastFlag _{FFlag::LuauSolverV2, true};
 
     LUAU_REQUIRE_NO_ERRORS(check(R"(
         --!strict
@@ -820,10 +810,7 @@ TEST_CASE_FIXTURE(Fixture, "oss_1773")
 
 TEST_CASE_FIXTURE(Fixture, "bidirectionally_infer_indexers_errored")
 {
-    ScopedFastFlag sffs[] = {
-        {FFlag::LuauSolverV2, true},
-        {FFlag::LuauPushTypeConstraintIndexer, true},
-    };
+    ScopedFastFlag _{FFlag::LuauSolverV2, true};
 
     CheckResult result = check(R"(
         --!strict
@@ -847,6 +834,63 @@ TEST_CASE_FIXTURE(Fixture, "oss_2018")
 {
     LUAU_REQUIRE_NO_ERRORS(check(R"(
         local rule: { rule: "AppendTextComment" } | { rule: "Other" } = { rule = "AppendTextComment" }
+    )"));
+}
+
+TEST_CASE_FIXTURE(Fixture, "oss_2010_but_with_booleans")
+{
+    ScopedFastFlag sffs[] = {
+        {FFlag::LuauSolverV2, true},
+        {FFlag::LuauPushTypeUnifyConstantHandling, true},
+    };
+
+    CheckResult results = check(R"(
+        local function foo<T>(my_enum: true | T): T
+            return my_enum :: T
+        end
+
+        local function bar<T>(my_enum: true & T): T
+            return my_enum :: T
+        end
+
+        local var1 = foo(true)
+        local var2 = foo(false)
+
+        local var3 = bar(true)
+        local var4 = bar(false)
+    )");
+
+    LUAU_REQUIRE_ERROR_COUNT(1, results);
+    auto err = get<TypeMismatch>(results.errors[0]);
+    REQUIRE(err);
+    CHECK_EQ("true", toString(err->wantedType));
+    CHECK_EQ("false", toString(err->givenType));
+
+    // FIXME: That one seems arguably correct.
+    CHECK_EQ("unknown", toString(requireType("var1")));
+    CHECK_EQ("false", toString(requireType("var2")));
+    CHECK_EQ("true", toString(requireType("var3")));
+    CHECK_EQ("false", toString(requireType("var4")));
+}
+
+TEST_CASE_FIXTURE(Fixture, "cli_184125")
+{
+    ScopedFastFlag sffs[] = {
+        {FFlag::LuauSolverV2, true},
+        {FFlag::LuauPushTypeUnifyConstantHandling, true},
+    };
+
+    LUAU_REQUIRE_NO_ERRORS(check(R"(
+        type MyTypeA = {Value: true}
+        type MyTypeB = {Value: false}
+
+        local function Func(input: number) : (MyTypeA | MyTypeB)
+            if input == 1 then
+                return {Value = true}
+            else
+                return {Value = false}
+            end
+        end
     )"));
 }
 

--- a/tests/TypeInfer.tables.test.cpp
+++ b/tests/TypeInfer.tables.test.cpp
@@ -23,14 +23,8 @@ LUAU_FASTFLAG(LuauInstantiateInSubtyping)
 LUAU_FASTFLAG(LuauFixIndexerSubtypingOrdering)
 LUAU_FASTFLAG(DebugLuauAssertOnForcedConstraint)
 LUAU_FASTINT(LuauPrimitiveInferenceInTableLimit)
-LUAU_FASTFLAG(LuauNoScopeShallNotSubsumeAll)
 LUAU_FASTFLAG(LuauCacheDuplicateHasPropConstraints)
-LUAU_FASTFLAG(LuauPushTypeConstraintIntersection)
-LUAU_FASTFLAG(LuauPushTypeConstraintLambdas2)
-LUAU_FASTFLAG(LuauNewOverloadResolver2)
-LUAU_FASTFLAG(LuauGetmetatableError)
-LUAU_FASTFLAG(LuauSuppressIndexingIntoError)
-LUAU_FASTFLAG(LuauPushTypeConstriantAlwaysCompletes)
+LUAU_FASTFLAG(LuauPushTypeConstraintLambdas3)
 LUAU_FASTFLAG(LuauMarkUnscopedGenericsAsSolved)
 LUAU_FASTFLAG(LuauUseFastSubtypeForIndexerWithName)
 LUAU_FASTFLAG(LuauBetterTypeMismatchErrors)
@@ -323,7 +317,7 @@ TEST_CASE_FIXTURE(Fixture, "call_method")
     )");
     LUAU_REQUIRE_NO_ERRORS(result);
 
-    CHECK_EQ(*getBuiltins()->numberType, *requireType("a"));
+    CHECK("number" == toString(requireType("a")));
 }
 
 TEST_CASE_FIXTURE(Fixture, "call_method_with_explicit_self_argument")
@@ -663,8 +657,8 @@ TEST_CASE_FIXTURE(Fixture, "infer_array")
 
     REQUIRE(bool(ttv->indexer));
 
-    CHECK_EQ(*ttv->indexer->indexType, *getBuiltins()->numberType);
-    CHECK_EQ(*ttv->indexer->indexResultType, *getBuiltins()->stringType);
+    CHECK("number" == toString(ttv->indexer->indexType));
+    CHECK("string" == toString(ttv->indexer->indexResultType));
 }
 
 /* This is a bit weird.
@@ -761,7 +755,7 @@ TEST_CASE_FIXTURE(Fixture, "indexers_quantification_2")
 
     CHECK_EQ(argType->state, retType->state);
 
-    REQUIRE_EQ(*argVec[0], *retVec[0]);
+    CHECK(argVec[0] == retVec[0]);
 }
 
 TEST_CASE_FIXTURE(Fixture, "infer_indexer_from_array_like_table")
@@ -778,8 +772,8 @@ TEST_CASE_FIXTURE(Fixture, "infer_indexer_from_array_like_table")
     REQUIRE(bool(ttv->indexer));
     const TableIndexer& indexer = *ttv->indexer;
 
-    CHECK_EQ(*getBuiltins()->numberType, *indexer.indexType);
-    CHECK_EQ(*getBuiltins()->stringType, *indexer.indexResultType);
+    CHECK("number" == toString(indexer.indexType));
+    CHECK("string" == toString(indexer.indexResultType));
 }
 
 TEST_CASE_FIXTURE(Fixture, "infer_indexer_from_value_property_in_literal")
@@ -837,8 +831,8 @@ TEST_CASE_FIXTURE(Fixture, "infer_indexer_from_its_variable_type_and_unifiable")
     REQUIRE_MESSAGE(tTy != nullptr, "Expected a table but got " << toString(t2Ty));
 
     REQUIRE(tTy->indexer);
-    CHECK_EQ(*getBuiltins()->numberType, *tTy->indexer->indexType);
-    CHECK_EQ(*getBuiltins()->stringType, *tTy->indexer->indexResultType);
+    CHECK("number" == toString(tTy->indexer->indexType));
+    CHECK("string" == toString(tTy->indexer->indexResultType));
 }
 
 TEST_CASE_FIXTURE(Fixture, "indexer_mismatch")
@@ -860,7 +854,7 @@ TEST_CASE_FIXTURE(Fixture, "indexer_mismatch")
     CHECK(toString(tm->wantedType) == "{number}");
     CHECK(toString(tm->givenType) == "{ [string]: string }");
 
-    CHECK_NE(*t1, *t2);
+    CHECK(toString(t1) != toString(t2));
 }
 
 TEST_CASE_FIXTURE(Fixture, "infer_indexer_from_its_function_return_type")
@@ -962,7 +956,7 @@ TEST_CASE_FIXTURE(Fixture, "infer_type_when_indexing_from_a_table_indexer")
 
     LUAU_REQUIRE_NO_ERRORS(result);
 
-    CHECK_EQ(*getBuiltins()->stringType, *requireType("s"));
+    CHECK("string" == toString(requireType("s")));
 }
 
 TEST_CASE_FIXTURE(BuiltinsFixture, "indexing_from_a_table_should_prefer_properties_when_possible")
@@ -988,13 +982,13 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "indexing_from_a_table_should_prefer_properti
 
     LUAU_REQUIRE_ERROR_COUNT(1, result);
 
-    CHECK_EQ(*getBuiltins()->stringType, *requireType("a1"));
-    CHECK_EQ(*getBuiltins()->stringType, *requireType("a2"));
+    CHECK("string" == toString(requireType("a1")));
+    CHECK("string" == toString(requireType("a2")));
 
-    CHECK_EQ(*getBuiltins()->numberType, *requireType("b1"));
-    CHECK_EQ(*getBuiltins()->numberType, *requireType("b2"));
+    CHECK("number" == toString(requireType("b1")));
+    CHECK("number" == toString(requireType("b2")));
 
-    CHECK_EQ(*getBuiltins()->numberType, *requireType("c"));
+    CHECK("number" == toString(requireType("c")));
 
     CHECK_MESSAGE(nullptr != get<TypeMismatch>(result.errors[0]), "Expected a TypeMismatch but got " << result.errors[0]);
 }
@@ -1069,7 +1063,7 @@ TEST_CASE_FIXTURE(Fixture, "assigning_to_an_unsealed_table_with_string_literal_s
     REQUIRE(a.readTy);
     TypeId propertyA = *a.readTy;
     REQUIRE(propertyA != nullptr);
-    CHECK_EQ(*getBuiltins()->stringType, *propertyA);
+    CHECK("string" == toString(propertyA));
 }
 
 TEST_CASE_FIXTURE(BuiltinsFixture, "oop_indexer_works")
@@ -1092,7 +1086,7 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "oop_indexer_works")
 
     LUAU_REQUIRE_NO_ERRORS(result);
 
-    CHECK_EQ(*getBuiltins()->stringType, *requireType("words"));
+    CHECK("string" == toString(requireType("words")));
 }
 
 TEST_CASE_FIXTURE(BuiltinsFixture, "indexer_table")
@@ -1105,7 +1099,7 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "indexer_table")
 
     LUAU_REQUIRE_NO_ERRORS(result);
 
-    CHECK_EQ(*getBuiltins()->stringType, *requireType("b"));
+    CHECK("string" == toString(requireType("b")));
 }
 
 TEST_CASE_FIXTURE(BuiltinsFixture, "indexer_fn")
@@ -1116,7 +1110,7 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "indexer_fn")
     )");
     LUAU_REQUIRE_NO_ERRORS(result);
 
-    CHECK_EQ(*getBuiltins()->numberType, *requireType("b"));
+    CHECK("number" == toString(requireType("b")));
 }
 
 TEST_CASE_FIXTURE(BuiltinsFixture, "meta_add")
@@ -1150,7 +1144,7 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "meta_add_inferred")
 
     LUAU_REQUIRE_NO_ERRORS(result);
 
-    CHECK_EQ(*requireType("a"), *requireType("c"));
+    CHECK(follow(requireType("a")) == follow(requireType("c")));
 }
 
 TEST_CASE_FIXTURE(BuiltinsFixture, "meta_add_both_ways")
@@ -1167,8 +1161,8 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "meta_add_both_ways")
     LUAU_REQUIRE_NO_ERRORS(result);
 
     CHECK_EQ("Vector", toString(requireType("a")));
-    CHECK_EQ(*requireType("a"), *requireType("b"));
-    CHECK_EQ(*requireType("a"), *requireType("c"));
+    CHECK(follow(requireType("a")) == follow(requireType("b")));
+    CHECK(follow(requireType("a")) == follow(requireType("c")));
 }
 
 TEST_CASE_FIXTURE(BuiltinsFixture, "meta_add_both_ways_lti")
@@ -1191,8 +1185,8 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "meta_add_both_ways_lti")
     LUAU_REQUIRE_NO_ERRORS(result);
 
     CHECK_EQ("Vector", toString(requireType("a")));
-    CHECK_EQ(*requireType("a"), *requireType("b"));
-    CHECK_EQ(*requireType("a"), *requireType("c"));
+    CHECK(follow(requireType("a")) == follow(requireType("b")));
+    CHECK(follow(requireType("a")) == follow(requireType("c")));
 }
 
 // This test exposed a bug where we let go of the "seen" stack while unifying table types
@@ -1258,10 +1252,10 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "oop_polymorphic")
 
     LUAU_REQUIRE_NO_ERRORS(result);
 
-    CHECK_EQ(*getBuiltins()->booleanType, *requireType("alive"));
-    CHECK_EQ(*getBuiltins()->stringType, *requireType("movement"));
-    CHECK_EQ(*getBuiltins()->stringType, *requireType("name"));
-    CHECK_EQ(*getBuiltins()->numberType, *requireType("speed"));
+    CHECK("boolean" == toString(requireType("alive")));
+    CHECK("string" == toString(requireType("movement")));
+    CHECK("string" == toString(requireType("name")));
+    CHECK("number" == toString(requireType("speed")));
 }
 
 TEST_CASE_FIXTURE(Fixture, "user_defined_table_types_are_named")
@@ -1467,7 +1461,7 @@ TEST_CASE_FIXTURE(Fixture, "found_like_key_in_table_function_call")
     REQUIRE(error);
 
     TypeId t = requireType("t");
-    CHECK_EQ(*t, *error->table);
+    CHECK(toString(t) == toString(error->table));
     CHECK_EQ("fOo", error->key);
 
     auto candidates = error->candidates;
@@ -1492,7 +1486,7 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "found_like_key_in_table_property_access")
     REQUIRE(error);
 
     TypeId t = requireType("t");
-    CHECK_EQ(*t, *error->table);
+    CHECK(toString(t) == toString(error->table));
     CHECK_EQ("x", error->key);
 
     auto candidates = error->candidates;
@@ -1517,7 +1511,7 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "found_multiple_like_keys")
     REQUIRE(error);
 
     TypeId t = requireType("t");
-    CHECK_EQ(*t, *error->table);
+    CHECK(toString(t) == toString(error->table));
     CHECK_EQ("foo", error->key);
 
     auto candidates = error->candidates;
@@ -1547,7 +1541,7 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "dont_suggest_exact_match_keys")
     REQUIRE(error);
 
     TypeId t = requireType("t");
-    CHECK_EQ(*t, *error->table);
+    CHECK(follow(t) == follow(error->table));
     CHECK_EQ("Foo", error->key);
 
     auto candidates = error->candidates;
@@ -1568,7 +1562,7 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "getmetatable_returns_pointer_to_metatable")
         local returnedMT = getmetatable(t)
     )");
 
-    CHECK_EQ(*requireType("mt"), *requireType("returnedMT"));
+    CHECK(follow(requireType("mt")) == follow(requireType("returnedMT")));
 }
 
 TEST_CASE_FIXTURE(BuiltinsFixture, "metatable_mismatch_should_fail")
@@ -1592,8 +1586,8 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "metatable_mismatch_should_fail")
 
     TypeMismatch* tm = get<TypeMismatch>(result.errors[0]);
     REQUIRE(tm);
-    CHECK_EQ(*tm->wantedType, *requireType("t1"));
-    CHECK_EQ(*tm->givenType, *requireType("t2"));
+    CHECK(tm->wantedType == requireType("t1"));
+    CHECK(tm->givenType == requireType("t2"));
 }
 
 TEST_CASE_FIXTURE(BuiltinsFixture, "property_lookup_through_tabletypevar_metatable")
@@ -1634,7 +1628,7 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "missing_metatable_for_sealed_tables_do_not_g
 
     TypeId a = requireType("a");
     TypeId t = requireType("t");
-    CHECK_NE(*a, *t);
+    CHECK(toString(a) != toString(t));
 
     TypeError te = result.errors[0];
     TypeMismatch* tm = get<TypeMismatch>(te);
@@ -2377,7 +2371,7 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "table_insert_should_cope_with_optional_prope
 
 TEST_CASE_FIXTURE(BuiltinsFixture, "table_insert_should_cope_with_optional_properties_in_strict")
 {
-    ScopedFastFlag sffs[] = {{FFlag::LuauSolverV2, true}, {FFlag::LuauNoScopeShallNotSubsumeAll, true}};
+    ScopedFastFlag sffs[] = {{FFlag::LuauSolverV2, true}};
 
     CheckResult result = check(R"(
         --!strict
@@ -2893,10 +2887,6 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "give_up_after_one_metatable_index_look_up")
 
 TEST_CASE_FIXTURE(Fixture, "confusing_indexing")
 {
-    ScopedFastFlag sffs[] = {
-        {FFlag::LuauPushTypeConstraintIntersection, true},
-    };
-
     CheckResult result = check(R"(
         type T = {} & {p: number | string}
         local function f(t: T)
@@ -3016,7 +3006,7 @@ TEST_CASE_FIXTURE(Fixture, "table_length")
     LUAU_REQUIRE_NO_ERRORS(result);
 
     CHECK(nullptr != get<TableType>(requireType("t")));
-    CHECK_EQ(*getBuiltins()->numberType, *requireType("s"));
+    CHECK("number" == toString(requireType("s")));
 }
 
 TEST_CASE_FIXTURE(Fixture, "nil_assign_doesnt_hit_indexer")
@@ -3316,17 +3306,12 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "dont_crash_when_setmetatable_does_not_produc
 {
     CheckResult result = check("local x = setmetatable({})");
 
-    if (FFlag::LuauSolverV2 && FFlag::LuauNewOverloadResolver2)
+    if (FFlag::LuauSolverV2)
     {
         LUAU_REQUIRE_ERROR_COUNT(1, result);
         const CountMismatch* cm = get<CountMismatch>(result.errors.at(0));
         CHECK(cm->actual == 1);
         CHECK(cm->expected == 2);
-    }
-    else if (FFlag::LuauSolverV2)
-    {
-        // CLI-114665: Generic parameters should not also be optional.
-        LUAU_REQUIRE_NO_ERRORS(result);
     }
     else
     {
@@ -5167,61 +5152,31 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "subtyping_with_a_metatable_table_path")
         end
     )");
 
-    if (FFlag::LuauNewOverloadResolver2)
-    {
-        LUAU_REQUIRE_ERROR_COUNT(4, result);
+    LUAU_REQUIRE_ERROR_COUNT(4, result);
 
-        // We shouldn't allow `setmetatable()` to type check
-        CHECK(result.errors.at(0).location == Location{{2, 21}, {2, 43}});
-        CHECK("Type function instance setmetatable<nil, nil> is uninhabited" == toString(result.errors.at(0)));
+    // We shouldn't allow `setmetatable()` to type check
+    CHECK(result.errors.at(0).location == Location{{2, 21}, {2, 43}});
+    CHECK("Type function instance setmetatable<nil, nil> is uninhabited" == toString(result.errors.at(0)));
 
-        CHECK(result.errors.at(1).location == Location{{2, 28}, {2, 40}});
-        CHECK("Argument count mismatch. Function expects 2 arguments, but none are specified" == toString(result.errors.at(1)));
+    CHECK(result.errors.at(1).location == Location{{2, 28}, {2, 40}});
+    CHECK("Argument count mismatch. Function expects 2 arguments, but none are specified" == toString(result.errors.at(1)));
 
-        CHECK(result.errors.at(2).location == Location{{3, 8}, {5, 11}});
-        CHECK("Type function instance setmetatable<nil, nil> is uninhabited" == toString(result.errors.at(2)));
+    CHECK(result.errors.at(2).location == Location{{3, 8}, {5, 11}});
+    CHECK("Type function instance setmetatable<nil, nil> is uninhabited" == toString(result.errors.at(2)));
 
-        if (FFlag::LuauBetterTypeMismatchErrors)
-            CHECK(
-                "Expected this to be 'setmetatable<nil, nil>', but got '{ @metatable {  }, {  } & {  } }'; \n"
-                "the 1st entry in the type pack is `{ @metatable {  }, {  } & {  } }` and in the 1st entry in the type packreduces to "
-                "`never`, and `{ @metatable {  }, {  } & {  } }` is not a subtype of `never`" == toString(result.errors.at(3))
-            );
-        else
-            CHECK(
-                "Type pack '{ @metatable {  }, {  } & {  } }' could not be converted into 'setmetatable<nil, nil>'; \n"
-                "this is because the 1st entry in the type pack is `{ @metatable {  }, {  } & {  } }` and in the 1st entry in the type packreduces "
-                "to "
-                "`never`, and `{ @metatable {  }, {  } & {  } }` is not a subtype of `never`" == toString(result.errors.at(3))
-            );
-    }
+    if (FFlag::LuauBetterTypeMismatchErrors)
+        CHECK(
+            "Expected this to be 'setmetatable<nil, nil>', but got '{ @metatable {  }, {  } & {  } }'; \n"
+            "the 1st entry in the type pack is `{ @metatable {  }, {  } & {  } }` and in the 1st entry in the type packreduces to "
+            "`never`, and `{ @metatable {  }, {  } & {  } }` is not a subtype of `never`" == toString(result.errors.at(3))
+        );
     else
-    {
-        LUAU_REQUIRE_ERROR_COUNT(3, result);
-
-        // We shouldn't allow `setmetatable()` to type check
-        CHECK_EQ(result.errors[0].location, Location{{2, 21}, {2, 43}});
-        CHECK_EQ("Type function instance setmetatable<nil, nil> is uninhabited", toString(result.errors[0]));
-
-        CHECK_EQ(result.errors[1].location, Location{{3, 8}, {5, 11}});
-        CHECK_EQ("Type function instance setmetatable<nil, nil> is uninhabited", toString(result.errors[1]));
-
-        if (FFlag::LuauBetterTypeMismatchErrors)
-            CHECK_EQ(
-                "Expected this to be 'setmetatable<nil, nil>', but got '{ @metatable {  }, {  } & {  } }'; \n"
-                "the 1st entry in the type pack is `{ @metatable {  }, {  } & {  } }` and in the 1st entry in the type packreduces to "
-                "`never`, and `{ @metatable {  }, {  } & {  } }` is not a subtype of `never`",
-                toString(result.errors[2])
-            );
-        else
-            CHECK_EQ(
-                "Type pack '{ @metatable {  }, {  } & {  } }' could not be converted into 'setmetatable<nil, nil>'; \n"
-                "this is because the 1st entry in the type pack is `{ @metatable {  }, {  } & {  } }` and in the 1st entry in the type packreduces "
-                "to "
-                "`never`, and `{ @metatable {  }, {  } & {  } }` is not a subtype of `never`",
-                toString(result.errors[2])
-            );
-    }
+        CHECK(
+            "Type pack '{ @metatable {  }, {  } & {  } }' could not be converted into 'setmetatable<nil, nil>'; \n"
+            "this is because the 1st entry in the type pack is `{ @metatable {  }, {  } & {  } }` and in the 1st entry in the type packreduces "
+            "to "
+            "`never`, and `{ @metatable {  }, {  } & {  } }` is not a subtype of `never`" == toString(result.errors.at(3))
+        );
 }
 
 TEST_CASE_FIXTURE(BuiltinsFixture, "metatable_union_type")
@@ -6306,7 +6261,7 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "table_insert_array_of_any")
 
 TEST_CASE_FIXTURE(BuiltinsFixture, "bad_insert_type_mismatch")
 {
-    ScopedFastFlag sffs[] = {{FFlag::LuauSolverV2, true}, {FFlag::LuauNoScopeShallNotSubsumeAll, true}};
+    ScopedFastFlag sffs[] = {{FFlag::LuauSolverV2, true}};
 
     CheckResult result = check(R"(
         local function doInsert(t: { string })
@@ -6334,10 +6289,7 @@ TEST_CASE_FIXTURE(Fixture, "string_indexer_satisfies_read_only_property")
 
 TEST_CASE_FIXTURE(Fixture, "bidirectional_inference_works_through_intersections")
 {
-    ScopedFastFlag sffs[] = {
-        {FFlag::LuauSolverV2, true},
-        {FFlag::LuauPushTypeConstraintIntersection, true},
-    };
+    ScopedFastFlag _{FFlag::LuauSolverV2, true};
 
     LUAU_REQUIRE_NO_ERRORS(check(R"(
         type x = {} & ({ state: "1" } | { state: "2" })
@@ -6347,10 +6299,7 @@ TEST_CASE_FIXTURE(Fixture, "bidirectional_inference_works_through_intersections"
 
 TEST_CASE_FIXTURE(Fixture, "bidirectional_inference_intersection_other_intersection_example")
 {
-    ScopedFastFlag sffs[] = {
-        {FFlag::LuauSolverV2, true},
-        {FFlag::LuauPushTypeConstraintIntersection, true},
-    };
+    ScopedFastFlag _{FFlag::LuauSolverV2, true};
 
     LUAU_REQUIRE_NO_ERRORS(check(R"(
         type A = { foo: "a" }
@@ -6425,7 +6374,7 @@ TEST_CASE_FIXTURE(Fixture, "array_of_callbacks_bidirectionally_inferred")
 {
     ScopedFastFlag sffs[] = {
         {FFlag::LuauSolverV2, true},
-        {FFlag::LuauPushTypeConstraintLambdas2, true},
+        {FFlag::LuauPushTypeConstraintLambdas3, true},
         {FFlag::DebugLuauAssertOnForcedConstraint, true},
     };
 
@@ -6448,7 +6397,7 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "oss_1483")
 {
     ScopedFastFlag sffs[] = {
         {FFlag::LuauSolverV2, true},
-        {FFlag::LuauPushTypeConstraintLambdas2, true},
+        {FFlag::LuauPushTypeConstraintLambdas3, true},
         {FFlag::DebugLuauAssertOnForcedConstraint, true},
     };
 
@@ -6470,7 +6419,7 @@ TEST_CASE_FIXTURE(Fixture, "oss_1910")
 {
     ScopedFastFlag sffs[] = {
         {FFlag::LuauSolverV2, true},
-        {FFlag::LuauPushTypeConstraintLambdas2, true},
+        {FFlag::LuauPushTypeConstraintLambdas3, true},
         {FFlag::DebugLuauAssertOnForcedConstraint, true},
     };
 
@@ -6492,7 +6441,7 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "bidirectional_inference_variadic_type_pack")
 {
     ScopedFastFlag sffs[] = {
         {FFlag::LuauSolverV2, true},
-        {FFlag::LuauPushTypeConstraintLambdas2, true},
+        {FFlag::LuauPushTypeConstraintLambdas3, true},
         {FFlag::DebugLuauAssertOnForcedConstraint, true},
     };
 
@@ -6516,8 +6465,7 @@ TEST_CASE_FIXTURE(Fixture, "table_with_intersection_containing_lambda")
 {
     ScopedFastFlag sffs[] = {
         {FFlag::LuauSolverV2, true},
-        {FFlag::LuauPushTypeConstraintLambdas2, true},
-        {FFlag::LuauPushTypeConstraintIntersection, true},
+        {FFlag::LuauPushTypeConstraintLambdas3, true},
         {FFlag::DebugLuauAssertOnForcedConstraint, true},
     };
 
@@ -6542,8 +6490,6 @@ TEST_CASE_FIXTURE(Fixture, "table_with_intersection_containing_lambda")
 
 TEST_CASE_FIXTURE(BuiltinsFixture, "cli_174304_allow_getmetatable_error_and_table")
 {
-    ScopedFastFlag _{FFlag::LuauGetmetatableError, true};
-
     LUAU_REQUIRE_NO_ERRORS(check(R"(
         local function instanceof(tbl: any, class: any): boolean
             if typeof(tbl) ~= "table" then
@@ -6571,8 +6517,6 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "cli_174304_allow_getmetatable_error_and_tabl
 
 TEST_CASE_FIXTURE(BuiltinsFixture, "allow_indexing_into_error_or_not_nil")
 {
-    ScopedFastFlag _{FFlag::LuauSuppressIndexingIntoError, true};
-
     LUAU_REQUIRE_NO_ERRORS(check(R"(
         --!strict
         local function f(i: number, ...)
@@ -6590,10 +6534,7 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "allow_indexing_into_error_or_not_nil")
 
 TEST_CASE_FIXTURE(BuiltinsFixture, "show_not_a_table_error_when_indexing_into_non_table")
 {
-    ScopedFastFlag sffs[] = {
-        {FFlag::LuauSuppressIndexingIntoError, true},
-        {FFlag::LuauFixIndexingUnionWithNonTable, true},
-    };
+    ScopedFastFlag _{FFlag::LuauFixIndexingUnionWithNonTable, true};
 
     CheckResult result = check(R"(
         --!strict
@@ -6609,8 +6550,7 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "oss_1684")
 {
     ScopedFastFlag sffs[] = {
         {FFlag::LuauSolverV2, true},
-        {FFlag::LuauPushTypeConstraintLambdas2, true},
-        {FFlag::LuauPushTypeConstraintIntersection, true},
+        {FFlag::LuauPushTypeConstraintLambdas3, true},
         {FFlag::DebugLuauAssertOnForcedConstraint, true},
     };
 
@@ -6642,7 +6582,6 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "oss_2094_push_type_constraint_should_always_
 {
     ScopedFastFlag sffs[] = {
         {FFlag::LuauSolverV2, true},
-        {FFlag::LuauPushTypeConstriantAlwaysCompletes, true},
         {FFlag::LuauMarkUnscopedGenericsAsSolved, true},
         {FFlag::DebugLuauAssertOnForcedConstraint, true},
     };

--- a/tests/TypeInfer.test.cpp
+++ b/tests/TypeInfer.test.cpp
@@ -30,8 +30,6 @@ LUAU_FASTFLAG(LuauDfgAllowUpdatesInLoops)
 LUAU_FASTFLAG(DebugLuauMagicTypes)
 LUAU_FASTFLAG(LuauMissingFollowMappedGenericPacks)
 LUAU_FASTFLAG(LuauTryToOptimizeSetTypeUnification)
-LUAU_FASTFLAG(LuauMetatableAvoidSingletonUnion)
-LUAU_FASTFLAG(LuauUnknownGlobalFixSuggestion)
 LUAU_FASTFLAG(LuauBetterTypeMismatchErrors)
 LUAU_FASTFLAG(DebugLuauForbidInternalTypes)
 LUAU_FASTFLAG(LuauAvoidMintingMultipleBlockedTypesForGlobals)
@@ -211,8 +209,8 @@ TEST_CASE_FIXTURE(Fixture, "if_statement")
     }
     else
     {
-        CHECK_EQ(*getBuiltins()->stringType, *requireType("a"));
-        CHECK_EQ(*getBuiltins()->numberType, *requireType("b"));
+        CHECK("string" == toString(requireType("a")));
+        CHECK("number" == toString(requireType("b")));
     }
 }
 
@@ -1379,8 +1377,6 @@ end
 
 TEST_CASE_FIXTURE(BuiltinsFixture, "typechecking_in_type_guards")
 {
-    ScopedFastFlag unknownGlobalFixSuggestion{FFlag::LuauUnknownGlobalFixSuggestion, true};
-
     CheckResult result = check(R"(
 local a = type(foo) == 'nil'
 local b = typeof(foo) ~= 'nil'
@@ -1806,7 +1802,6 @@ TEST_CASE_FIXTURE(Fixture, "avoid_double_reference_to_free_type")
 TEST_CASE_FIXTURE(BuiltinsFixture, "infer_types_of_globals")
 {
     ScopedFastFlag sff_LuauSolverV2{FFlag::LuauSolverV2, true};
-    ScopedFastFlag unknownGlobalFixSuggestion{FFlag::LuauUnknownGlobalFixSuggestion, true};
 
     CheckResult result = check(R"(
         --!strict
@@ -2729,8 +2724,6 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "any_type_in_function_argument_should_not_err
 
 TEST_CASE_FIXTURE(BuiltinsFixture, "fuzz_avoid_singleton_union")
 {
-    ScopedFastFlag _{FFlag::LuauMetatableAvoidSingletonUnion, true};
-
     LUAU_REQUIRE_ERRORS(check(R"(
         _ = if true then _ else {},if (_) then _ elseif "" then {} elseif _ then {} elseif _ then _ else {}
         for l0,l2 in setmetatable(_,_),l0,_ do

--- a/tests/TypeInfer.tryUnify.test.cpp
+++ b/tests/TypeInfer.tryUnify.test.cpp
@@ -57,7 +57,7 @@ TEST_CASE_FIXTURE(TryUnifyFixture, "compatible_functions_are_unified")
 
     state.log.commit();
 
-    CHECK_EQ(functionOne, functionTwo);
+    CHECK(toString(functionOne) == toString(functionTwo));
 }
 
 TEST_CASE_FIXTURE(TryUnifyFixture, "incompatible_functions_are_preserved")
@@ -80,8 +80,8 @@ TEST_CASE_FIXTURE(TryUnifyFixture, "incompatible_functions_are_preserved")
     CHECK(state.failure);
     CHECK(!state.errors.empty());
 
-    CHECK_EQ(functionOne, functionOneSaved);
-    CHECK_EQ(functionTwo, functionTwoSaved);
+    CHECK(toString(functionOne) == toString(functionOneSaved));
+    CHECK(toString(functionTwo) == toString(functionTwoSaved));
 }
 
 TEST_CASE_FIXTURE(TryUnifyFixture, "tables_can_be_unified")
@@ -94,7 +94,7 @@ TEST_CASE_FIXTURE(TryUnifyFixture, "tables_can_be_unified")
         TableType{{{"foo", {arena.freshType(getBuiltins(), globalScope->level)}}}, std::nullopt, globalScope->level, TableState::Unsealed},
     }};
 
-    CHECK_NE(*getMutable<TableType>(&tableOne)->props["foo"].type_DEPRECATED(), *getMutable<TableType>(&tableTwo)->props["foo"].type_DEPRECATED());
+    CHECK(getMutable<TableType>(&tableOne)->props["foo"].type_DEPRECATED() != getMutable<TableType>(&tableTwo)->props["foo"].type_DEPRECATED());
 
     state.tryUnify(&tableTwo, &tableOne);
 
@@ -103,7 +103,7 @@ TEST_CASE_FIXTURE(TryUnifyFixture, "tables_can_be_unified")
 
     state.log.commit();
 
-    CHECK_EQ(*getMutable<TableType>(&tableOne)->props["foo"].type_DEPRECATED(), *getMutable<TableType>(&tableTwo)->props["foo"].type_DEPRECATED());
+    CHECK(follow(getMutable<TableType>(&tableOne)->props["foo"].type_DEPRECATED()) == follow(getMutable<TableType>(&tableTwo)->props["foo"].type_DEPRECATED()));
 }
 
 TEST_CASE_FIXTURE(TryUnifyFixture, "incompatible_tables_are_preserved")
@@ -126,14 +126,14 @@ TEST_CASE_FIXTURE(TryUnifyFixture, "incompatible_tables_are_preserved")
         },
     }};
 
-    CHECK_NE(*getMutable<TableType>(&tableOne)->props["foo"].type_DEPRECATED(), *getMutable<TableType>(&tableTwo)->props["foo"].type_DEPRECATED());
+    CHECK(getMutable<TableType>(&tableOne)->props["foo"].type_DEPRECATED() != getMutable<TableType>(&tableTwo)->props["foo"].type_DEPRECATED());
 
     state.tryUnify(&tableTwo, &tableOne);
 
     CHECK(state.failure);
     CHECK_EQ(1, state.errors.size());
 
-    CHECK_NE(*getMutable<TableType>(&tableOne)->props["foo"].type_DEPRECATED(), *getMutable<TableType>(&tableTwo)->props["foo"].type_DEPRECATED());
+    CHECK(follow(getMutable<TableType>(&tableOne)->props["foo"].type_DEPRECATED()) != follow(getMutable<TableType>(&tableTwo)->props["foo"].type_DEPRECATED()));
 }
 
 TEST_CASE_FIXTURE(Fixture, "uninhabited_intersection_sub_never")

--- a/tests/TypeInfer.typeInstantiations.test.cpp
+++ b/tests/TypeInfer.typeInstantiations.test.cpp
@@ -6,7 +6,8 @@
 using namespace Luau;
 
 LUAU_FASTFLAG(LuauSolverV2)
-LUAU_FASTFLAG(LuauExplicitTypeExpressionInstantiation)
+LUAU_FASTFLAG(LuauExplicitTypeInstantiationSyntax)
+LUAU_FASTFLAG(LuauExplicitTypeInstantiationSupport)
 LUAU_FASTFLAG(LuauBetterTypeMismatchErrors)
 
 TEST_SUITE_BEGIN("TypeInferExplicitTypeInstantiations");
@@ -20,7 +21,8 @@ TEST_CASE_FIXTURE(Fixture, "as_expression_correct")
 {
     SUBCASE_BOTH_SOLVERS()
     {
-        ScopedFastFlag sff{FFlag::LuauExplicitTypeExpressionInstantiation, true};
+        ScopedFastFlag syntax{FFlag::LuauExplicitTypeInstantiationSyntax, true};
+        ScopedFastFlag semantics{FFlag::LuauExplicitTypeInstantiationSupport, true};
 
         CheckResult result = check(R"(
         --!strict
@@ -39,7 +41,8 @@ TEST_CASE_FIXTURE(Fixture, "as_expression_incorrect")
 {
     SUBCASE_BOTH_SOLVERS()
     {
-        ScopedFastFlag sff{FFlag::LuauExplicitTypeExpressionInstantiation, true};
+        ScopedFastFlag syntax{FFlag::LuauExplicitTypeInstantiationSyntax, true};
+        ScopedFastFlag semantics{FFlag::LuauExplicitTypeInstantiationSupport, true};
 
         CheckResult result = check(R"(
         --!strict
@@ -74,7 +77,8 @@ TEST_CASE_FIXTURE(Fixture, "as_stmt_correct")
 {
     SUBCASE_BOTH_SOLVERS()
     {
-        ScopedFastFlag sff{FFlag::LuauExplicitTypeExpressionInstantiation, true};
+        ScopedFastFlag syntax{FFlag::LuauExplicitTypeInstantiationSyntax, true};
+        ScopedFastFlag semantics{FFlag::LuauExplicitTypeInstantiationSupport, true};
 
         CheckResult result = check(R"(
         --!strict
@@ -93,7 +97,8 @@ TEST_CASE_FIXTURE(Fixture, "as_stmt_incorrect")
 {
     SUBCASE_BOTH_SOLVERS()
     {
-        ScopedFastFlag sff{FFlag::LuauExplicitTypeExpressionInstantiation, true};
+        ScopedFastFlag syntax{FFlag::LuauExplicitTypeInstantiationSyntax, true};
+        ScopedFastFlag semantics{FFlag::LuauExplicitTypeInstantiationSupport, true};
 
         CheckResult result = check(R"(
         --!strict
@@ -130,7 +135,8 @@ TEST_CASE_FIXTURE(Fixture, "multiple_calls")
 {
     SUBCASE_BOTH_SOLVERS()
     {
-        ScopedFastFlag sff{FFlag::LuauExplicitTypeExpressionInstantiation, true};
+        ScopedFastFlag syntax{FFlag::LuauExplicitTypeInstantiationSyntax, true};
+        ScopedFastFlag semantics{FFlag::LuauExplicitTypeInstantiationSupport, true};
 
         CheckResult result = check(R"(
         --!strict
@@ -150,7 +156,8 @@ TEST_CASE_FIXTURE(Fixture, "anonymous_type_inferred")
 {
     SUBCASE_BOTH_SOLVERS()
     {
-        ScopedFastFlag sff{FFlag::LuauExplicitTypeExpressionInstantiation, true};
+        ScopedFastFlag syntax{FFlag::LuauExplicitTypeInstantiationSyntax, true};
+        ScopedFastFlag semantics{FFlag::LuauExplicitTypeInstantiationSupport, true};
 
         CheckResult result = check(R"(
         --!strict
@@ -171,7 +178,8 @@ TEST_CASE_FIXTURE(Fixture, "anonymous_type_inferred")
 
 TEST_CASE_FIXTURE(Fixture, "type_packs")
 {
-    ScopedFastFlag sff{FFlag::LuauExplicitTypeExpressionInstantiation, true};
+        ScopedFastFlag syntax{FFlag::LuauExplicitTypeInstantiationSyntax, true};
+        ScopedFastFlag semantics{FFlag::LuauExplicitTypeInstantiationSupport, true};
 
     // FIXME: This triggers a GenericTypePackCountMismatch error, and it's not obvious if the
     // code for explicit types is broken, or if subtyping is broken.
@@ -189,7 +197,8 @@ TEST_CASE_FIXTURE(Fixture, "type_packs")
 
 TEST_CASE_FIXTURE(Fixture, "type_packs_method")
 {
-    ScopedFastFlag sff{FFlag::LuauExplicitTypeExpressionInstantiation, true};
+    ScopedFastFlag syntax{FFlag::LuauExplicitTypeInstantiationSyntax, true};
+    ScopedFastFlag semantics{FFlag::LuauExplicitTypeInstantiationSupport, true};
 
     // FIXME: This triggers a GenericTypePackCountMismatch error, and it's not obvious if the
     // code for explicit types is broken, or if subtyping is broken.
@@ -209,7 +218,8 @@ TEST_CASE_FIXTURE(Fixture, "type_packs_method")
 
 TEST_CASE_FIXTURE(Fixture, "type_packs_incorrect")
 {
-    ScopedFastFlag sff{FFlag::LuauExplicitTypeExpressionInstantiation, true};
+    ScopedFastFlag syntax{FFlag::LuauExplicitTypeInstantiationSyntax, true};
+    ScopedFastFlag semantics{FFlag::LuauExplicitTypeInstantiationSupport, true};
 
     // FIXME: This triggers a GenericTypePackCountMismatch error, and it's not obvious if the
     // code for explicit types is broken, or if subtyping is broken.
@@ -227,7 +237,8 @@ TEST_CASE_FIXTURE(Fixture, "type_packs_incorrect")
 
 TEST_CASE_FIXTURE(Fixture, "type_packs_incorrect_method")
 {
-    ScopedFastFlag sff{FFlag::LuauExplicitTypeExpressionInstantiation, true};
+    ScopedFastFlag syntax{FFlag::LuauExplicitTypeInstantiationSyntax, true};
+    ScopedFastFlag semantics{FFlag::LuauExplicitTypeInstantiationSupport, true};
 
     // FIXME: This triggers a GenericTypePackCountMismatch error, and it's not obvious if the
     // code for explicit types is broken, or if subtyping is broken.
@@ -249,7 +260,8 @@ TEST_CASE_FIXTURE(Fixture, "dot_index_call")
 {
     SUBCASE_BOTH_SOLVERS()
     {
-        ScopedFastFlag sff{FFlag::LuauExplicitTypeExpressionInstantiation, true};
+        ScopedFastFlag syntax{FFlag::LuauExplicitTypeInstantiationSyntax, true};
+        ScopedFastFlag semantics{FFlag::LuauExplicitTypeInstantiationSupport, true};
 
         CheckResult result = check(R"(
         --!strict
@@ -272,7 +284,8 @@ TEST_CASE_FIXTURE(Fixture, "method_index_call")
 {
     SUBCASE_BOTH_SOLVERS()
     {
-        ScopedFastFlag sff{FFlag::LuauExplicitTypeExpressionInstantiation, true};
+        ScopedFastFlag syntax{FFlag::LuauExplicitTypeInstantiationSyntax, true};
+        ScopedFastFlag semantics{FFlag::LuauExplicitTypeInstantiationSupport, true};
 
         CheckResult result = check(R"(
         --!strict
@@ -296,7 +309,8 @@ TEST_CASE_FIXTURE(Fixture, "stored_as_variable")
 {
     SUBCASE_BOTH_SOLVERS()
     {
-        ScopedFastFlag sff{FFlag::LuauExplicitTypeExpressionInstantiation, true};
+        ScopedFastFlag syntax{FFlag::LuauExplicitTypeInstantiationSyntax, true};
+        ScopedFastFlag semantics{FFlag::LuauExplicitTypeInstantiationSupport, true};
 
         CheckResult result = check(R"(
         --!strict
@@ -320,7 +334,8 @@ TEST_CASE_FIXTURE(Fixture, "not_a_function")
 {
     SUBCASE_BOTH_SOLVERS()
     {
-        ScopedFastFlag sff{FFlag::LuauExplicitTypeExpressionInstantiation, true};
+        ScopedFastFlag syntax{FFlag::LuauExplicitTypeInstantiationSyntax, true};
+        ScopedFastFlag semantics{FFlag::LuauExplicitTypeInstantiationSupport, true};
 
         CheckResult result = check(R"(
         --!strict
@@ -339,7 +354,8 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "metatable_call")
 {
     SUBCASE_BOTH_SOLVERS()
     {
-        ScopedFastFlag sff{FFlag::LuauExplicitTypeExpressionInstantiation, true};
+        ScopedFastFlag syntax{FFlag::LuauExplicitTypeInstantiationSyntax, true};
+        ScopedFastFlag semantics{FFlag::LuauExplicitTypeInstantiationSupport, true};
 
         CheckResult result = check(R"(
         --!strict
@@ -363,7 +379,8 @@ TEST_CASE_FIXTURE(Fixture, "method_call_incomplete")
 {
     SUBCASE_BOTH_SOLVERS()
     {
-        ScopedFastFlag sff{FFlag::LuauExplicitTypeExpressionInstantiation, true};
+        ScopedFastFlag syntax{FFlag::LuauExplicitTypeInstantiationSyntax, true};
+        ScopedFastFlag semantics{FFlag::LuauExplicitTypeInstantiationSupport, true};
 
         CheckResult result = check(R"(
         --!strict
@@ -387,7 +404,8 @@ TEST_CASE_FIXTURE(Fixture, "too_many_provided")
 {
     SUBCASE_BOTH_SOLVERS()
     {
-        ScopedFastFlag sff{FFlag::LuauExplicitTypeExpressionInstantiation, true};
+        ScopedFastFlag syntax{FFlag::LuauExplicitTypeInstantiationSyntax, true};
+        ScopedFastFlag semantics{FFlag::LuauExplicitTypeInstantiationSupport, true};
 
         CheckResult result = check(R"(
         --!strict
@@ -420,7 +438,8 @@ TEST_CASE_FIXTURE(Fixture, "too_many_provided_type_packs")
 {
     SUBCASE_BOTH_SOLVERS()
     {
-        ScopedFastFlag sff{FFlag::LuauExplicitTypeExpressionInstantiation, true};
+        ScopedFastFlag syntax{FFlag::LuauExplicitTypeInstantiationSyntax, true};
+        ScopedFastFlag semantics{FFlag::LuauExplicitTypeInstantiationSupport, true};
 
         CheckResult result = check(R"(
         --!strict
@@ -453,7 +472,8 @@ TEST_CASE_FIXTURE(Fixture, "too_many_provided_method")
 {
     SUBCASE_BOTH_SOLVERS()
     {
-        ScopedFastFlag sff{FFlag::LuauExplicitTypeExpressionInstantiation, true};
+        ScopedFastFlag syntax{FFlag::LuauExplicitTypeInstantiationSyntax, true};
+        ScopedFastFlag semantics{FFlag::LuauExplicitTypeInstantiationSupport, true};
 
         CheckResult result = check(R"(
         --!strict
@@ -489,7 +509,8 @@ TEST_CASE_FIXTURE(Fixture, "too_many_type_packs_provided_method")
 {
     SUBCASE_BOTH_SOLVERS()
     {
-        ScopedFastFlag sff{FFlag::LuauExplicitTypeExpressionInstantiation, true};
+        ScopedFastFlag syntax{FFlag::LuauExplicitTypeInstantiationSyntax, true};
+        ScopedFastFlag semantics{FFlag::LuauExplicitTypeInstantiationSupport, true};
 
         CheckResult result = check(R"(
         --!strict
@@ -525,7 +546,8 @@ TEST_CASE_FIXTURE(Fixture, "function_intersections")
 {
     SUBCASE_BOTH_SOLVERS()
     {
-        ScopedFastFlag sff{FFlag::LuauExplicitTypeExpressionInstantiation, true};
+        ScopedFastFlag syntax{FFlag::LuauExplicitTypeInstantiationSyntax, true};
+        ScopedFastFlag semantics{FFlag::LuauExplicitTypeInstantiationSupport, true};
 
         CheckResult result = check(R"(
         --!strict
@@ -544,12 +566,13 @@ TEST_CASE_FIXTURE(Fixture, "incomplete_type_packs")
 {
     SUBCASE_BOTH_SOLVERS()
     {
-        ScopedFastFlag sff{FFlag::LuauExplicitTypeExpressionInstantiation, true};
+        ScopedFastFlag syntax{FFlag::LuauExplicitTypeInstantiationSyntax, true};
+        ScopedFastFlag semantics{FFlag::LuauExplicitTypeInstantiationSupport, true};
 
         CheckResult result = check(R"(
-        local f: <A, T...>() -> (A, T...) = nil :: any
-        local correct: string, b: number, c: boolean = f<<string>>()
-        local incorrect: number, b: number, c: boolean = f<<string>>()
+            local f: <A, T...>() -> (A, T...) = nil :: any
+            local correct: string, b: number, c: boolean = f<<string>>()
+            local incorrect: number, b: number, c: boolean = f<<string>>()
         )");
 
         LUAU_REQUIRE_ERROR_COUNT(1, result);

--- a/tests/TypeInfer.typestates.test.cpp
+++ b/tests/TypeInfer.typestates.test.cpp
@@ -4,7 +4,6 @@
 #include "doctest.h"
 
 LUAU_FASTFLAG(LuauSolverV2)
-LUAU_FASTFLAG(LuauRefineDistributesOverUnions)
 LUAU_FASTFLAG(LuauBetterTypeMismatchErrors)
 
 using namespace Luau;
@@ -366,7 +365,6 @@ TEST_CASE_FIXTURE(TypeStateFixture, "captured_locals_do_not_mutate_upvalue_type_
 {
     ScopedFastFlag sffs[] = {
         {FFlag::LuauSolverV2, true},
-        {FFlag::LuauRefineDistributesOverUnions, true},
     };
 
     CheckResult result = check(R"(

--- a/tests/TypeVar.test.cpp
+++ b/tests/TypeVar.test.cpp
@@ -14,43 +14,6 @@ using namespace Luau;
 
 TEST_SUITE_BEGIN("TypeTests");
 
-TEST_CASE_FIXTURE(Fixture, "primitives_are_equal")
-{
-    REQUIRE_EQ(getBuiltins()->booleanType, getBuiltins()->booleanType);
-}
-
-TEST_CASE_FIXTURE(Fixture, "bound_type_is_equal_to_that_which_it_is_bound")
-{
-    Type bound(BoundType(getBuiltins()->booleanType));
-    REQUIRE_EQ(bound, *getBuiltins()->booleanType);
-}
-
-TEST_CASE_FIXTURE(Fixture, "equivalent_cyclic_tables_are_equal")
-{
-    Type cycleOne{TypeVariant(TableType())};
-    TableType* tableOne = getMutable<TableType>(&cycleOne);
-    tableOne->props["self"] = {&cycleOne};
-
-    Type cycleTwo{TypeVariant(TableType())};
-    TableType* tableTwo = getMutable<TableType>(&cycleTwo);
-    tableTwo->props["self"] = {&cycleTwo};
-
-    CHECK_EQ(cycleOne, cycleTwo);
-}
-
-TEST_CASE_FIXTURE(Fixture, "different_cyclic_tables_are_not_equal")
-{
-    Type cycleOne{TypeVariant(TableType())};
-    TableType* tableOne = getMutable<TableType>(&cycleOne);
-    tableOne->props["self"] = {&cycleOne};
-
-    Type cycleTwo{TypeVariant(TableType())};
-    TableType* tableTwo = getMutable<TableType>(&cycleTwo);
-    tableTwo->props["this"] = {&cycleTwo};
-
-    CHECK_NE(cycleOne, cycleTwo);
-}
-
 TEST_CASE_FIXTURE(Fixture, "return_type_of_function_is_not_parenthesized_if_just_one_value")
 {
     auto emptyArgumentPack = TypePackVar{TypePack{}};

--- a/tests/conformance/buffers.luau
+++ b/tests/conformance/buffers.luau
@@ -463,6 +463,22 @@ end
 
 boundchecksempty()
 
+local function boundchecksrangemerge1(buf: buffer, a: number)
+  assert(ecall(function(buf: buffer, a: number)
+    return buffer.readi32(buf, a + 8) + buffer.readi32(buf, a + 4) + buffer.readi32(buf, a + 0)
+  end, buf, a) == "buffer access out of bounds")
+end
+
+boundchecksrangemerge1(buffer.create(4), 0)
+
+local function boundchecksrangemerge2(buf: buffer, a: number)
+  assert(ecall(function(buf: buffer, a: number)
+    return buffer.readi32(buf, a) + buffer.readi32(buf, a - 8)
+  end, buf, a) == "buffer access out of bounds")
+end
+
+boundchecksrangemerge2(buffer.create(16), 4)
+
 local function intuint()
   local b = buffer.create(32)
 

--- a/tests/conformance/native.luau
+++ b/tests/conformance/native.luau
@@ -520,6 +520,15 @@ end
 
 bufferbounds(0)
 
+local function bufferboundsmerge1(b12: buffer, a: number, ...)
+  local r1 = buffer.readi32(b12, a + 8) + buffer.readi32(b12, a + 4) + buffer.readi32(b12, a + 0)
+  assert(r1 == 0)
+
+  assert(is_native())
+end
+
+bufferboundsmerge1(buffer.create(12), 0)
+
 function deadStoreChecks1()
   local a = 1.0
   local b = 0.0

--- a/tests/conformance/native_integer_spills.luau
+++ b/tests/conformance/native_integer_spills.luau
@@ -391,7 +391,7 @@ FUNC_LIST[2] = function(hashtable: buffer, entries: buffer, px: buffer, py: buff
             buffer.readf32(px, (i+7) * 4)
 
         local y0, y1, y2, y3, y4, y5, y6, y7 = 
-            buffer.readf32(py, (i)) * 4, 
+            buffer.readf32(py, (i) * 4), 
             buffer.readf32(py, (i+1) * 4),
             buffer.readf32(py, (i+2) * 4), 
             buffer.readf32(py, (i+3) * 4),


### PR DESCRIPTION
Hello everyone and a happy New Year!
The first sync of 2026 is already here with improvements to new type solver and native code generation.

# Analysis

* Explicit type instantiation is now ready for production use (Fixes #2114, Fixes #2144, Fixes #2113, and Fixes #2119)
* When subtyping extern types and tables, we now check indexers as well as properties, which fixes a soundness bug where tables without properties but clearly incompatible indexers were considered super types of extern types:
```luau
local function f(c: Color3): { Color3 }
    return c -- This used to not error and now does
end

```
* Using bound generics as type annotations on nested functions or lambdas now no longer leak into the quantified generics of said lambda / inner function:
```luau
local function makeApplier<A..., R...>(f: (A...) -> (R...))
    return function (... : A...): R...
        f(...)
    end
end
local function add(x: number, y: number): number return x + y end
-- Prior, `f` would have the (incorrect) type of `<A..., R...>(A...) -> (R...)`, as it
-- erroneously picked up the generics from `makeApplier`. Now it will have 
-- the correct type of `(number, number) -> number`
local f = makeApplier(add)
```
* Lambda bidirectional inference is now slightly less sensitive to generics; prior _any_ generic in the lambda type would prevent "pushing in" the type, but now this is restricted to potentially unbound generics that are from the function type we are pushing in, as in:
```luau
type testsuite = { case: (self: testsuite, <T>(T) -> T) -> () }
local test1: { suite: (string, (testsuite) -> ()) -> () } = nil :: any
-- Prior we would error on the _entire_ lambda ...
test1.suite("LuteTestCommand", function(suite)
    -- but now we only error here
    suite:case(42)
end)
```
* Generic polarity inference has been reworked to be significantly faster, especially for large mutually recursive type aliases
* Generic type packs now more consistently infer the correct type for function calls, most importantly for `pcall` and its siblings. (Fixes #2109. Fixes #2143)
```luau
local function makestr(n: number): string
	return tostring(n)
end

-- `s` now has type `string` and not `unknown`
local success, s = pcall(makestr, 42)
```
* Bidirectional inference of constants (especially booleans) should be more consistent, such as in:
```luau
type Good = { success: true, result: string }
type Bad = { success: false, error: string }
type Result = Good | Bad
-- This errors before and after, but we now recognize that you 
-- meant this to be `Bad` and will note the lack of the `error` member
local a: Result = { success = false, result = 'something' }
```
* The mechanism for generating "Recursive type being used with different parameters" has been reworked. This should mean less false positives, and we will now consistently highlight the erroneous type alias instance, but we now adhere closer to the [very strict RFC](https://rfcs.luau.org/recursive-type-restriction.html).
```luau
-- Not only did this line error, but it errored even in nonstrict mode
type A = { B<any> }
type B<T> = { method: (B<T>) -> () }

-- This used to _not_ error under the new solver but now does, despite being fairly benign
type B<T = number> = { B<number> }
```

# Native Codegen

* `vector` library operations are now performed with 32-bit floating-point precision, matching the results of the interpreter and improving performance by skipping unnecessary 32-bit to 64-bit conversions
* 2-argument `vector.create` constructor will now use native lowering instead of calling out to a slower C++ fastcall function
* Added native support for vector flooring division operator `//` instead of calling out to a slower C++ VM utility function
* Identical calls to the math library (`math.cos`, `math.sin` and many others) are now eliminated
* A larger set of identical operations on vector values are now eliminated
* Buffer length checks are now merged together when possible
```luau
-- only one range check
return buffer.readf64(b, i) * buffer.readf64(b, i + 8) * buffer.readf64(b, i + 16)

-- when stride multiplier is used, it still produces only a single range check
return buffer.readf64(b, i * 8) * buffer.readf64(b, (i + 1) * 8) * buffer.readf64(b, (i + 2) * 8)
```
* Fixed missing constant fold of `TRUNCATE_UINT` which could cause a lowering failure under 'LuauCodegenNumIntFolds2' flag

# Autocomplete

* Fixed a crash when indexing write-only properties

# Internal Contributors

Co-authored-by: Andy Friesen <afriesen@roblox.com>
Co-authored-by: Annie Tang <annietang@roblox.com>
Co-authored-by: Ariel Weiss <arielweiss@roblox.com>
Co-authored-by: Hunter Goldstein <hgoldstein@roblox.com>
Co-authored-by: Varun Saini <vsaini@roblox.com>
Co-authored-by: Vighnesh Vijay <vvijay@roblox.com>
Co-authored-by: Vyacheslav Egorov <vegorov@roblox.com>
