### PR TITLE
Fix index assertion for global configuration

### DIFF
--- a/Config/src/LuauConfig.cpp
+++ b/Config/src/LuauConfig.cpp
@@ -241,7 +241,7 @@ static std::optional<std::string> createLuauConfigFromLuauTable(
                 if (!global)
                     return "configuration value in \"globals\" table must be a string";
 
-                LUAU_ASSERT(0 <= index - 1 && index - 1 < globalsTable->size());
+                LUAU_ASSERT(index >= 1 && index <= globalsTable->size());
                 globals[index - 1] = *global;
             }
 


### PR DESCRIPTION
this type of problem is fixed by either avoiding unsigned subtraction in relational comparisons or by casting to a signed type that can represent negative values, or by relying on already-validated bounds instead of rechecking with problematic arithmetic.

Here, the assertion is trying to state that `index - 1` is a valid index into `globals` / `globalsTable`. We already enforce `1 <= index <= globalsTable->size()` just above. Therefore, within this block we know `index - 1` is in range `[0, globalsTable->size() - 1]`. The cleanest fix without changing functionality is to rewrite the assertion so it no longer uses unsigned subtraction on the left-hand side and instead asserts the well-formed condition that we already know: `1 <= index && index <= globalsTable->size()`. Alternatively, we could express the bounds directly on `index - 1` but only from the upper side: `index - 1 < globalsTable->size()` is already sufficient given the earlier guard; checking `0 <= index - 1` is redundant and meaningless. To keep the assertion closely aligned with the guard, the best fix is to replace the assertion with `LUAU_ASSERT(index >= 1 && index <= globalsTable->size());`, which avoids the problematic subtraction while preserving the intended bounds-check semantics.

Concretely, in `Config/src/LuauConfig.cpp`, locate line 244 inside the `"globals"` handling loop and replace the `LUAU_ASSERT` expression with an assertion formulated directly on `index` (no subtraction). No new methods, imports, or definitions are required.
