### PR TITLE
change the local var name for table loop because "i" is already used

### DIFF
--- a/VM/src/lvmload.cpp
+++ b/VM/src/lvmload.cpp
@@ -492,7 +492,7 @@ static int loadsafe(
             {
                 int keys = readVarInt(data, size, offset);
                 LuaTable* h = luaH_new(L, 0, keys);
-                for (int i = 0; i < keys; ++i)
+                for (int ii = 0; ii < keys; ++ii)
                 {
                     int key = readVarInt(data, size, offset);
                     TValue* val = luaH_set(L, h, &p->k[key]);


### PR DESCRIPTION
the keys loop thing uses ``i``, but ``i`` is already being used and so is ``j``, all the other loops don't use ``int i`` they use ``int j``, so how come this one uses ``i`` again?

It does compile, though idk if there is ever a compiler that would complain about it. C# would.