### PR TITLE
Fix false LocalShadow warning triggered by type function references

### DIFF
--- a/Analysis/src/Linter.cpp
+++ b/Analysis/src/Linter.cpp
@@ -934,6 +934,11 @@ private:
         return true;
     }
 
+    bool visit(AstStatTypeFunction* node) override
+    {
+        return false;
+    }
+
     bool visit(AstExprFunction* node) override
     {
         if (node->self)

--- a/tests/Linter.test.cpp
+++ b/tests/Linter.test.cpp
@@ -365,6 +365,22 @@ return bar()
     CHECK_EQ(result.warnings[0].text, "Variable 'a' shadows previous declaration at line 2");
 }
 
+TEST_CASE_FIXTURE(Fixture, "LocalShadowTypeFunction")
+{
+    LintResult result = lint(R"(
+type num = number
+
+type function GetNum()
+    return num
+end
+
+local num = 10
+return num
+)");
+
+    REQUIRE(0 == result.warnings.size());
+}
+
 TEST_CASE_FIXTURE(Fixture, "LocalUnused")
 {
     LintResult result = lint(R"(


### PR DESCRIPTION
Fixes #2087

The LocalShadow lint walker traverses into AstStatTypeFunction bodies, where type references like num appear as AstExprGlobal nodes. When a local variable with the same name is declared later, the linter incorrectly reports a shadow warning.

This skips traversal into AstStatTypeFunction nodes in LintLocalHygiene, matching how the compiler's FunctionVisitor already handles them.