### PR TITLE
Avoid undefined behavior with invalid UTF-8 strings in utf8_decode

### DIFF
--- a/VM/src/lutf8lib.cpp
+++ b/VM/src/lutf8lib.cpp
@@ -42,8 +42,10 @@ static const char* utf8_decode(const char* o, int* val)
             res = (res << 6) | (cc & 0x3F); // add lower 6 bits from cont. byte
             c <<= 1;                        // to test next bit
         }
+        if (count > 3)
+            return NULL; // invalid byte sequence
         res |= ((c & 0x7F) << (count * 5)); // add first byte
-        if (count > 3 || res > MAXUNICODE || res <= limits[count])
+        if (res > MAXUNICODE || res <= limits[count])
             return NULL; // invalid byte sequence
         if (unsigned(res - 0xD800) < 0x800)
             return NULL; // surrogate


### PR DESCRIPTION
Example:
```lua
utf8.len"\xFF\x80\x80\x80\x80\x80\x80\x80"
```
This currently causes undefined behavior.

See also: https://groups.google.com/g/lua-l/c/5TqwqKe1MF8/m/9uVjr8VBAQAJ