### PR TITLE
pass a state parameter to useratom

### DIFF
--- a/VM/include/lua.h
+++ b/VM/include/lua.h
@@ -455,7 +455,7 @@ struct lua_Callbacks
     void (*panic)(lua_State* L, int errcode); // gets called when an unprotected error is raised (if longjmp is used)
 
     void (*userthread)(lua_State* LP, lua_State* L); // gets called when L is created (LP == parent) or destroyed (LP == NULL)
-    int16_t (*useratom)(const char* s, size_t l);    // gets called when a string is created; returned atom can be retrieved via tostringatom
+    int16_t (*useratom)(lua_State* L, const char* s, size_t l);    // gets called when a string is created; returned atom can be retrieved via tostringatom
 
     void (*debugbreak)(lua_State* L, lua_Debug* ar);     // gets called when BREAK instruction is encountered
     void (*debugstep)(lua_State* L, lua_Debug* ar);      // gets called after each instruction in single step mode

--- a/VM/src/lapi.cpp
+++ b/VM/src/lapi.cpp
@@ -61,7 +61,7 @@ const char* luau_ident = "$Luau: Copyright (C) 2019-2024 Roblox Corporation $\n"
 #define updateatom(L, ts) \
     { \
         if (ts->atom == ATOM_UNDEF) \
-            ts->atom = L->global->cb.useratom ? L->global->cb.useratom(ts->data, ts->len) : -1; \
+            ts->atom = L->global->cb.useratom ? L->global->cb.useratom(L, ts->data, ts->len) : -1; \
     }
 
 static LuaTable* getcurrenv(lua_State* L)

--- a/tests/Conformance.test.cpp
+++ b/tests/Conformance.test.cpp
@@ -2366,7 +2366,7 @@ TEST_CASE("ApiAtoms")
     StateRef globalState(luaL_newstate(), lua_close);
     lua_State* L = globalState.get();
 
-    lua_callbacks(L)->useratom = [](const char* s, size_t l) -> int16_t
+    lua_callbacks(L)->useratom = [](lua_State* L, const char* s, size_t l) -> int16_t
     {
         if (strcmp(s, "string") == 0)
             return 0;


### PR DESCRIPTION
Closes #2083.

This PR adds a state parameter to the `useratom` callback. While this is a breaking change, it requires very minimal updates to embedder code.

The reasons for this change are in #2083, but again, all other callbacks have state, and in useratom's current form, I must use a global mutable static variable to effectively use it. Which is not ideal.