### PR TITLE
Fix singleton type annotations emitting incorrect bytecode type

### DIFF
--- a/Compiler/src/Types.cpp
+++ b/Compiler/src/Types.cpp
@@ -129,6 +129,14 @@ static LuauBytecodeType getType(
     {
         return LBC_TYPE_NIL;
     }
+    else if (const AstTypeSingletonBool* singletonBool = ty->as<AstTypeSingletonBool>())
+    {
+        return LBC_TYPE_BOOLEAN;
+    }
+    else if (const AstTypeSingletonString* singletonString = ty->as<AstTypeSingletonString>())
+    {
+        return LBC_TYPE_STRING;
+    }
 
     return LBC_TYPE_ANY;
 }

--- a/tests/Compiler.test.cpp
+++ b/tests/Compiler.test.cpp
@@ -9902,6 +9902,35 @@ end
     );
 }
 
+TEST_CASE("TypeSingleton")
+{
+    CHECK_EQ(
+        "\n" + compileTypeTable(R"(
+function myfunc(test: true, foo: false)
+end
+
+function myfunc2(test: "hello")
+end
+
+function myfunc3(test: true | false)
+end
+
+function myfunc4(test: true | nil)
+end
+
+function myfunc5(test: "hello" | "world")
+end
+)"),
+        R"(
+0: function(boolean, boolean)
+1: function(string)
+2: function(boolean)
+3: function(boolean?)
+4: function(string)
+)"
+    );
+}
+
 TEST_CASE("BuiltinFoldMathK")
 {
     // we can fold math.pi at optimization level 2


### PR DESCRIPTION
## Summary

- Singleton boolean types (`true`, `false`) and singleton string types (e.g., `"hello"`) in function parameter annotations were emitting `LBC_TYPE_ANY` in bytecode type info instead of `LBC_TYPE_BOOLEAN` / `LBC_TYPE_STRING`
- Added handling for `AstTypeSingletonBool` and `AstTypeSingletonString` in `Compiler/src/Types.cpp`'s `getType` function
- Added test case `TypeSingleton` covering singleton booleans, singleton strings, and their union combinations (`true | false`, `true | nil`, `"hello" | "world"`)

## Details

The `getType` function in `Compiler/src/Types.cpp` maps AST type annotations to `LuauBytecodeType` values. It had handlers for `AstTypeReference`, `AstTypeTable`, `AstTypeFunction`, `AstTypeUnion`, `AstTypeIntersection`, `AstTypeGroup`, and `AstTypeOptional`, but was missing handlers for `AstTypeSingletonBool` and `AstTypeSingletonString`. This caused singleton type annotations to fall through to the default `return LBC_TYPE_ANY`.

The fix adds two `else if` branches before the final fallback:
- `AstTypeSingletonBool` → `LBC_TYPE_BOOLEAN`
- `AstTypeSingletonString` → `LBC_TYPE_STRING`

This also correctly propagates through union types (e.g., `true | false` → `boolean`, `true | nil` → `boolean?`).

Fixes #2244

## Test plan

- [x] New `TypeSingleton` test case validates correct bytecode type emission for singleton boolean and string annotations
- [x] Existing tests should continue to pass (no behavioral change for non-singleton types)
- [x] CI runs across all platforms (Linux, macOS, Windows) and configurations