### PR TITLE
Sync to upstream/release/710

### DIFF
--- a/Analysis/include/Luau/Normalize.h
+++ b/Analysis/include/Luau/Normalize.h
@@ -142,6 +142,12 @@ struct NormalizedExternType
      */
     std::unordered_map<TypeId, TypeIds> externTypes;
 
+    /*
+     * We track an overall collection of shapes that extend this extern type.
+     * This should be interpreted as a big intersection of the given types.
+     */
+    TypeIds shapeExtensions;
+
     /**
      * In order to maintain a consistent insertion order, we use this vector to
      * keep track of it. An ordered std::map will sort by pointer identity,
@@ -402,6 +408,7 @@ private:
     TypeId intersectionOfBools(TypeId here, TypeId there);
     void intersectExternTypes(NormalizedExternType& heres, const NormalizedExternType& theres);
     void intersectExternTypesWithExternType(NormalizedExternType& heres, TypeId there);
+    void intersectExternTypesWithShape(NormalizedExternType& heres, TypeId there);
     void intersectStrings(NormalizedStringType& here, const NormalizedStringType& there);
     std::optional<TypeId> intersectionOfTables(TypeId here, TypeId there, SeenTablePropPairs& seenTablePropPairs, Set<TypeId>& seenSet);
     void intersectTablesWithTable(TypeIds& heres, TypeId there, SeenTablePropPairs& seenTablePropPairs, Set<TypeId>& seenSetTypes);

--- a/Analysis/src/Frontend.cpp
+++ b/Analysis/src/Frontend.cpp
@@ -41,7 +41,6 @@ LUAU_FASTFLAGVARIABLE(DebugLuauForbidInternalTypes)
 LUAU_FASTFLAGVARIABLE(DebugLuauForceStrictMode)
 LUAU_FASTFLAGVARIABLE(DebugLuauForceNonStrictMode)
 LUAU_FASTFLAGVARIABLE(DebugLuauAlwaysShowConstraintSolvingIncomplete)
-LUAU_FASTFLAG(LuauStandaloneParseType)
 
 namespace Luau
 {

--- a/Ast/src/Ast.cpp
+++ b/Ast/src/Ast.cpp
@@ -3,7 +3,6 @@
 
 #include "Luau/Common.h"
 
-LUAU_FASTFLAGVARIABLE(LuauStandaloneParseType)
 
 LUAU_FASTFLAG(LuauExplicitTypeInstantiationSyntax)
 

--- a/Ast/src/Parser.cpp
+++ b/Ast/src/Parser.cpp
@@ -20,7 +20,6 @@ LUAU_FASTINTVARIABLE(LuauParseErrorLimit, 100)
 LUAU_FASTFLAGVARIABLE(LuauSolverV2)
 LUAU_DYNAMIC_FASTFLAGVARIABLE(DebugLuauReportReturnTypeVariadicWithTypeSuffix, false)
 LUAU_FASTFLAGVARIABLE(LuauExplicitTypeInstantiationSyntax)
-LUAU_FASTFLAG(LuauStandaloneParseType)
 LUAU_FASTFLAGVARIABLE(LuauCstStatDoWithStatsStart)
 LUAU_FASTFLAGVARIABLE(DesugaredArrayTypeReferenceIsEmpty)
 
@@ -244,14 +243,11 @@ ParseNodeResult<Node> Parser::runParse(const char* buffer, size_t bufferSize, As
         Node* expr = f(p);
         size_t lines = p.lexer.current().location.end.line + (bufferSize > 0 && buffer[bufferSize - 1] != '\n');
 
-        if (FFlag::LuauStandaloneParseType)
+        Lexeme eof = p.lexer.next();
+        if (eof.type != Lexeme::Eof)
         {
-            Lexeme eof = p.lexer.next();
-            if (eof.type != Lexeme::Eof)
-            {
-                expr = nullptr;
-                p.parseErrors.emplace_back(eof.location, "Expected end of file");
-            }
+            expr = nullptr;
+            p.parseErrors.emplace_back(eof.location, "Expected end of file");
         }
 
         return ParseNodeResult<Node>{

--- a/CLI/include/Luau/Counters.h
+++ b/CLI/include/Luau/Counters.h
@@ -1,0 +1,10 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+#pragma once
+
+struct lua_State;
+
+void countersInit(lua_State* L);
+bool countersActive();
+
+void countersTrack(lua_State* L, int funcindex);
+void countersDump(const char* path);

--- a/CLI/include/Luau/ReplRequirer.h
+++ b/CLI/include/Luau/ReplRequirer.h
@@ -18,12 +18,21 @@ struct ReplRequirer
     using BoolCheck = bool (*)();
     using Coverage = void (*)(lua_State*, int);
 
-    ReplRequirer(CompileOptions copts, BoolCheck coverageActive, BoolCheck codegenEnabled, Coverage coverageTrack);
+    ReplRequirer(
+        CompileOptions copts,
+        BoolCheck coverageActive,
+        BoolCheck codegenEnabled,
+        Coverage coverageTrack,
+        BoolCheck countersActive,
+        Coverage countersTrack
+    );
 
     CompileOptions copts;
     BoolCheck coverageActive;
     BoolCheck codegenEnabled;
     Coverage coverageTrack;
+    BoolCheck countersActive;
+    Coverage countersTrack;
 
     VfsNavigator vfs;
 };

--- a/CLI/src/Counters.cpp
+++ b/CLI/src/Counters.cpp
@@ -1,0 +1,153 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+#include "Luau/Counters.h"
+#include "Luau/CodeGenOptions.h"
+#include "Luau/DenseHash.h"
+
+#include "lua.h"
+
+#include <algorithm>
+#include <string>
+#include <vector>
+
+struct LineCounters
+{
+    uint64_t regularExecuted = 0;
+    uint64_t fallbackExecuted = 0;
+    uint64_t vmExitTaken = 0;
+};
+
+struct FunctionCounters
+{
+    std::string name;
+    Luau::DenseHashMap<int, LineCounters> counters{-1};
+};
+
+struct ModuleCounters
+{
+    std::string name;
+    std::vector<FunctionCounters> functions;
+};
+
+struct Counters
+{
+    lua_State* L = nullptr;
+    std::vector<int> moduleRefs;
+
+    std::vector<ModuleCounters> moduleCounters;
+
+} gCounters;
+
+void countersInit(lua_State* L)
+{
+    gCounters.L = lua_mainthread(L);
+}
+
+bool countersActive()
+{
+    return gCounters.L != nullptr;
+}
+
+void countersTrack(lua_State* L, int funcindex)
+{
+    int ref = lua_ref(L, funcindex);
+    gCounters.moduleRefs.push_back(ref);
+}
+
+static void countersFunctionCallback(void* context, const char* function, int lineDefined)
+{
+    ModuleCounters& counters = *(ModuleCounters*)context;
+
+    std::string name;
+
+    if (function == nullptr && lineDefined == 1)
+        name = "<main>";
+    else if (function)
+        name = std::string(function) + ":" + std::to_string(lineDefined);
+    else
+        name = "<anonymous>:" + std::to_string(lineDefined);
+
+    counters.functions.emplace_back();
+    counters.functions.back().name = name;
+}
+
+static void countersValueCallback(void* context, int kind, int line, uint64_t hits)
+{
+    ModuleCounters& counters = *(ModuleCounters*)context;
+    FunctionCounters& function = counters.functions.back();
+
+    Luau::CodeGen::CodeGenCounter counterKind = Luau::CodeGen::CodeGenCounter(kind);
+
+    if (counterKind == Luau::CodeGen::CodeGenCounter::RegularBlockExecuted)
+        function.counters[line].regularExecuted += hits;
+    else if (counterKind == Luau::CodeGen::CodeGenCounter::FallbackBlockExecuted)
+        function.counters[line].fallbackExecuted += hits;
+    else if (counterKind == Luau::CodeGen::CodeGenCounter::VmExitTaken)
+        function.counters[line].vmExitTaken += hits;
+}
+
+void countersDump(const char* path)
+{
+    lua_State* L = gCounters.L;
+
+    for (int fref : gCounters.moduleRefs)
+    {
+        lua_getref(L, fref);
+
+        lua_Debug ar = {};
+        lua_getinfo(L, -1, "s", &ar);
+
+        gCounters.moduleCounters.emplace_back();
+        ModuleCounters& moduleCounters = gCounters.moduleCounters.back();
+
+        moduleCounters.name = std::string(ar.short_src);
+        lua_getcounters(L, -1, &moduleCounters, countersFunctionCallback, countersValueCallback);
+
+        lua_pop(L, 1);
+    }
+
+    FILE* f = fopen(path, "wb");
+    if (!f)
+    {
+        fprintf(stderr, "Error opening counters file (callgrind) %s\n", path);
+        return;
+    }
+
+    fprintf(f, "version: 1\n");
+    fprintf(f, "creator: Luau REPL\n");
+    fprintf(f, "events: Regular Fallback VmExit\n");
+
+    for (const ModuleCounters& moduleCounter : gCounters.moduleCounters)
+    {
+        fprintf(f, "fl=%s\n", moduleCounter.name.c_str());
+
+        for (const FunctionCounters& functionCounter : moduleCounter.functions)
+        {
+            fprintf(f, "fn=%s\n", functionCounter.name.c_str());
+
+            // For presentation and stability, we need line counter data sorted by line
+            std::vector<std::pair<int, LineCounters>> sortedCounters;
+
+            for (const auto& [line, counters] : functionCounter.counters)
+                sortedCounters.emplace_back(line, counters);
+
+            std::sort(
+                sortedCounters.begin(),
+                sortedCounters.end(),
+                [](auto&& a, auto&& b)
+                {
+                    return a.first < b.first;
+                }
+            );
+
+            for (const auto& [line, counters] : sortedCounters)
+            {
+                if (counters.regularExecuted != 0 || counters.fallbackExecuted != 0 || counters.vmExitTaken != 0)
+                    fprintf(f, "%d %lld %lld %lld\n", line, (long long)counters.regularExecuted, (long long)counters.fallbackExecuted, (long long)counters.vmExitTaken);
+            }
+        }
+    }
+
+    fclose(f);
+
+    printf("Counters data written to %s (%d modules)\n", path, int(gCounters.moduleCounters.size()));
+}

--- a/CLI/src/Coverage.cpp
+++ b/CLI/src/Coverage.cpp
@@ -59,7 +59,7 @@ void coverageDump(const char* path)
 {
     lua_State* L = gCoverage.L;
 
-    FILE* f = fopen(path, "w");
+    FILE* f = fopen(path, "wb");
     if (!f)
     {
         fprintf(stderr, "Error opening coverage %s\n", path);

--- a/CLI/src/ReplRequirer.cpp
+++ b/CLI/src/ReplRequirer.cpp
@@ -168,11 +168,18 @@ static int load(lua_State* L, void* ctx, const char* path, const char* chunkname
         if (req->codegenEnabled())
         {
             Luau::CodeGen::CompilationOptions nativeOptions;
+
+            if (req->countersActive())
+                nativeOptions.recordCounters = true;
+
             Luau::CodeGen::compile(ML, -1, nativeOptions);
         }
 
         if (req->coverageActive())
             req->coverageTrack(ML, -1);
+
+        if (req->countersActive())
+            req->countersTrack(ML, -1);
 
         int status = lua_resume(ML, L, 0);
 
@@ -224,10 +231,19 @@ void requireConfigInit(luarequire_Configuration* config)
     config->load = load;
 }
 
-ReplRequirer::ReplRequirer(CompileOptions copts, BoolCheck coverageActive, BoolCheck codegenEnabled, Coverage coverageTrack)
+ReplRequirer::ReplRequirer(
+    CompileOptions copts,
+    BoolCheck coverageActive,
+    BoolCheck codegenEnabled,
+    Coverage coverageTrack,
+    BoolCheck countersActive,
+    Coverage countersTrack
+)
     : copts(copts)
     , coverageActive(coverageActive)
     , codegenEnabled(codegenEnabled)
     , coverageTrack(coverageTrack)
+    , countersActive(countersActive)
+    , countersTrack(countersTrack)
 {
 }

--- a/CodeGen/include/Luau/CodeGenOptions.h
+++ b/CodeGen/include/Luau/CodeGenOptions.h
@@ -19,6 +19,13 @@ enum CodeGenFlags
     CodeGen_ColdFunctions = 1 << 1,
 };
 
+enum class CodeGenCounter : unsigned
+{
+    RegularBlockExecuted = 1,
+    FallbackBlockExecuted = 2,
+    VmExitTaken = 3,
+};
+
 using AllocationCallback = void(void* context, void* oldPointer, size_t oldSize, void* newPointer, size_t newSize);
 
 struct IrBuilder;
@@ -119,8 +126,9 @@ struct CompilationOptions
 
     // null-terminated array of userdata types names that might have custom lowering
     const char* const* userdataTypes = nullptr;
-};
 
+    bool recordCounters = false;
+};
 
 using AnnotatorFn = void (*)(void* context, std::string& result, int fid, int instpos);
 

--- a/CodeGen/include/Luau/ConditionX64.h
+++ b/CodeGen/include/Luau/ConditionX64.h
@@ -120,7 +120,7 @@ inline ConditionX64 getInverseCondition(ConditionX64 cond)
     case ConditionX64::BelowEqual:
         return ConditionX64::AboveEqual;
     case ConditionX64::Above:
-        return ConditionX64::Above;
+        return ConditionX64::Below;
     case ConditionX64::AboveEqual:
         return ConditionX64::BelowEqual;
     case ConditionX64::Equal:

--- a/CodeGen/include/Luau/IrBuilder.h
+++ b/CodeGen/include/Luau/IrBuilder.h
@@ -62,6 +62,7 @@ struct IrBuilder
 
     IrOp block(IrBlockKind kind); // Requested kind can be ignored if we are in an outlined sequence
     IrOp blockAtInst(uint32_t index);
+    IrOp fallbackBlock(uint32_t pcpos);
 
     IrOp vmReg(uint8_t index);
     IrOp vmConst(uint32_t index);

--- a/CodeGen/include/Luau/IrData.h
+++ b/CodeGen/include/Luau/IrData.h
@@ -2,6 +2,7 @@
 #pragma once
 
 #include "Luau/Bytecode.h"
+#include "Luau/DenseHash.h"
 #include "Luau/IrAnalysis.h"
 #include "Luau/Label.h"
 #include "Luau/RegisterX64.h"
@@ -1202,6 +1203,7 @@ struct IrBlock
     uint32_t chainkey = 0;
     uint32_t expectedNextBlock = ~0u;
 
+    // Bytecode PC position at which the block was generated
     uint32_t startpc = kBlockNoStartPc;
 
     Label label;
@@ -1268,6 +1270,8 @@ struct IrFunction
     uint32_t entryLocation = 0;
     uint32_t endLocation = 0;
 
+    std::vector<uint32_t> extraNativeData;
+
     // For each instruction, an operand that can be used to recompute the value
     std::vector<ValueRestoreLocation> valueRestoreOps;
     std::vector<uint32_t> validRestoreOpBlocks;
@@ -1281,6 +1285,8 @@ struct IrFunction
     CfgInfo cfg;
 
     LoweringStats* stats = nullptr;
+
+    bool recordCounters = false; // Taken from CompilationOptions for easy access
 
     IrBlock& blockOp(IrOp op)
     {

--- a/CodeGen/include/Luau/IrUtils.h
+++ b/CodeGen/include/Luau/IrUtils.h
@@ -5,8 +5,6 @@
 #include "Luau/Common.h"
 #include "Luau/IrData.h"
 
-LUAU_FASTFLAG(LuauCodegenUpvalueLoadProp2)
-
 namespace Luau
 {
 namespace CodeGen
@@ -184,9 +182,8 @@ inline bool hasResult(IrCmd cmd)
     case IrCmd::BUFFER_READI32:
     case IrCmd::BUFFER_READF32:
     case IrCmd::BUFFER_READF64:
-        return true;
     case IrCmd::GET_UPVALUE:
-        return FFlag::LuauCodegenUpvalueLoadProp2;
+        return true;
     default:
         break;
     }

--- a/CodeGen/include/Luau/IrVisitUseDef.h
+++ b/CodeGen/include/Luau/IrVisitUseDef.h
@@ -4,8 +4,6 @@
 #include "Luau/Common.h"
 #include "Luau/IrData.h"
 
-LUAU_FASTFLAG(LuauCodegenUpvalueLoadProp2)
-
 namespace Luau
 {
 namespace CodeGen
@@ -82,12 +80,8 @@ static void visitVmRegDefsUses(T& visitor, IrFunction& function, IrInst& inst)
         visitor.defRange(vmRegOp(OP_A(inst)), function.uintOp(OP_B(inst)));
         break;
     case IrCmd::GET_UPVALUE:
-        if (!FFlag::LuauCodegenUpvalueLoadProp2)
-            visitor.def(OP_A(inst));
         break;
     case IrCmd::SET_UPVALUE:
-        if (!FFlag::LuauCodegenUpvalueLoadProp2)
-            visitor.use(OP_B(inst));
         break;
     case IrCmd::INTERRUPT:
         break;

--- a/CodeGen/include/Luau/NativeProtoExecData.h
+++ b/CodeGen/include/Luau/NativeProtoExecData.h
@@ -32,6 +32,9 @@ struct NativeProtoExecDataHeader
     // elements in the instruction offsets array following this header.
     uint32_t bytecodeInstructionCount = 0;
 
+    // The number of extra uin32_t elements of custom data after the bytecode offsets
+    uint32_t extraDataCount = 0;
+
     // The size of the native code for this NativeProto, in bytes.
     size_t nativeCodeSize = 0;
 };
@@ -47,7 +50,7 @@ struct NativeProtoExecDataDeleter
 
 using NativeProtoExecDataPtr = std::unique_ptr<uint32_t[], NativeProtoExecDataDeleter>;
 
-[[nodiscard]] NativeProtoExecDataPtr createNativeProtoExecData(uint32_t bytecodeInstructionCount);
+[[nodiscard]] NativeProtoExecDataPtr createNativeProtoExecData(uint32_t bytecodeInstructionCount, uint32_t extraDataCount);
 void destroyNativeProtoExecData(const uint32_t* instructionOffsets) noexcept;
 
 [[nodiscard]] NativeProtoExecDataHeader& getNativeProtoExecDataHeader(uint32_t* instructionOffsets) noexcept;

--- a/CodeGen/src/CodeGenAssembly.cpp
+++ b/CodeGen/src/CodeGenAssembly.cpp
@@ -11,8 +11,6 @@
 
 #include "lapi.h"
 
-LUAU_FASTFLAG(LuauCodegenLocationEndFix)
-
 namespace Luau
 {
 namespace CodeGen
@@ -228,7 +226,7 @@ static std::string getAssemblyImpl(AssemblyBuilder& build, const TValue* func, A
             functionStat.line = p->linedefined;
             functionStat.bcodeCount = getInstructionCount(p->code, p->sizecode);
             functionStat.irCount = unsigned(ir.function.instructions.size());
-            functionStat.asmSize = FFlag::LuauCodegenLocationEndFix ? asmSize * sizeof(build.code[0]) : asmSize;
+            functionStat.asmSize = asmSize * sizeof(build.code[0]);
             functionStat.asmCount = asmCount;
             if (stats->functionStatsFlags & FunctionStats_BytecodeSummary)
             {

--- a/CodeGen/src/CodeGenLower.h
+++ b/CodeGen/src/CodeGenLower.h
@@ -27,6 +27,7 @@ LUAU_FASTINT(CodegenHeuristicsInstructionLimit)
 LUAU_FASTINT(CodegenHeuristicsBlockLimit)
 LUAU_FASTINT(CodegenHeuristicsBlockInstructionLimit)
 LUAU_FASTFLAG(LuauCodegenBlockSafeEnv)
+LUAU_FASTFLAG(LuauCodegenCounterSupport)
 
 namespace Luau
 {
@@ -152,6 +153,9 @@ inline bool lowerImpl(
         {
             function.entryLocation = build.getLabelOffset(block.label);
         }
+
+        if (FFlag::LuauCodegenCounterSupport)
+            lowering.startBlock(block);
 
         IrBlock& nextBlock = getNextBlock(function, sortedBlocks, dummy, i);
 
@@ -316,6 +320,9 @@ inline bool lowerFunction(
 )
 {
     ir.function.stats = stats;
+
+    if (FFlag::LuauCodegenCounterSupport)
+        ir.function.recordCounters = options.compilationOptions.recordCounters;
 
     killUnusedBlocks(ir.function);
 

--- a/CodeGen/src/IrLoweringA64.h
+++ b/CodeGen/src/IrLoweringA64.h
@@ -2,6 +2,7 @@
 #pragma once
 
 #include "Luau/AssemblyBuilderA64.h"
+#include "Luau/CodeGenOptions.h"
 #include "Luau/DenseHash.h"
 #include "Luau/IrData.h"
 
@@ -18,6 +19,7 @@ namespace CodeGen
 struct ModuleHelpers;
 struct AssemblyOptions;
 struct LoweringStats;
+enum class CodeGenCounter : unsigned;
 
 namespace A64
 {
@@ -27,6 +29,7 @@ struct IrLoweringA64
     IrLoweringA64(AssemblyBuilderA64& build, ModuleHelpers& helpers, IrFunction& function, LoweringStats* stats);
 
     void lowerInst(IrInst& inst, uint32_t index, const IrBlock& next);
+    void startBlock(const IrBlock& curr);
     void finishBlock(const IrBlock& curr, const IrBlock& next);
     void finishFunction();
 
@@ -39,6 +42,10 @@ struct IrLoweringA64
     void finalizeTargetLabel(IrOp op, Label& fresh);
 
     void checkSafeEnv(IrOp target, const IrBlock& next);
+
+    void allocAndIncrementCounterAt(CodeGenCounter kind, uint32_t pcpos);
+    void incrementCounterAt(size_t offset);
+
     void checkObjectBarrierConditions(RegisterA64 object, RegisterA64 temp, RegisterA64 ra, IrOp raOp, int ratag, Label& skip);
 
     // Operand data build helpers

--- a/CodeGen/src/IrLoweringX64.h
+++ b/CodeGen/src/IrLoweringX64.h
@@ -20,6 +20,7 @@ namespace CodeGen
 struct ModuleHelpers;
 struct AssemblyOptions;
 struct LoweringStats;
+enum class CodeGenCounter : unsigned;
 
 namespace X64
 {
@@ -29,6 +30,7 @@ struct IrLoweringX64
     IrLoweringX64(AssemblyBuilderX64& build, ModuleHelpers& helpers, IrFunction& function, LoweringStats* stats);
 
     void lowerInst(IrInst& inst, uint32_t index, const IrBlock& next);
+    void startBlock(const IrBlock& curr);
     void finishBlock(const IrBlock& curr, const IrBlock& next);
     void finishFunction();
 
@@ -46,6 +48,9 @@ struct IrLoweringX64
     void storeFloat(OperandX64 dst, IrOp src);
     void storeDoubleAsFloat(OperandX64 dst, IrOp src);
     void checkSafeEnv(IrOp target, const IrBlock& next);
+
+    void allocAndIncrementCounterAt(CodeGenCounter kind, uint32_t pcpos);
+    void incrementCounterAt(size_t offset);
 
     // Operand data lookup helpers
     OperandX64 memRegDoubleOp(IrOp op);

--- a/CodeGen/src/IrUtils.cpp
+++ b/CodeGen/src/IrUtils.cpp
@@ -16,7 +16,6 @@
 #include <limits.h>
 #include <math.h>
 
-LUAU_FASTFLAG(LuauCodegenUpvalueLoadProp2)
 LUAU_FASTFLAG(LuauCodegenBufferRangeMerge3)
 LUAU_FASTFLAGVARIABLE(LuauCodegenBufferBaseFold)
 
@@ -287,7 +286,7 @@ IrValueKind getCmdValueKind(IrCmd cmd)
     case IrCmd::CONCAT:
         return IrValueKind::None;
     case IrCmd::GET_UPVALUE:
-        return FFlag::LuauCodegenUpvalueLoadProp2 ? IrValueKind::Tvalue : IrValueKind::None;
+        return IrValueKind::Tvalue;
     case IrCmd::SET_UPVALUE:
     case IrCmd::CHECK_TAG:
     case IrCmd::CHECK_TRUTHY:

--- a/CodeGen/src/IrValueLocationTracking.cpp
+++ b/CodeGen/src/IrValueLocationTracking.cpp
@@ -3,8 +3,6 @@
 
 #include "Luau/IrUtils.h"
 
-LUAU_FASTFLAG(LuauCodegenUpvalueLoadProp2)
-
 namespace Luau
 {
 namespace CodeGen
@@ -82,8 +80,6 @@ void IrValueLocationTracking::beforeInstLowering(IrInst& inst)
         invalidateRestoreVmRegs(vmRegOp(OP_A(inst)), function.uintOp(OP_B(inst)));
         break;
     case IrCmd::GET_UPVALUE:
-        if (!FFlag::LuauCodegenUpvalueLoadProp2)
-            invalidateRestoreOp(OP_A(inst), /*skipValueInvalidation*/ false);
         break;
     case IrCmd::CALL:
         // Even if result count is limited, all registers starting from function (ra) might be modified

--- a/CodeGen/src/OptimizeDeadStore.cpp
+++ b/CodeGen/src/OptimizeDeadStore.cpp
@@ -14,6 +14,7 @@ LUAU_FASTFLAG(LuauCodegenBufferRangeMerge3)
 LUAU_FASTFLAGVARIABLE(LuauCodegenDsoPairTrackFix)
 LUAU_FASTFLAGVARIABLE(LuauCodegenDsoTagOverlayFix)
 LUAU_FASTFLAG(LuauCodegenOpReadOnly)
+LUAU_FASTFLAG(LuauCodegenSafeEnvPreserve)
 
 // TODO: optimization can be improved by knowing which registers are live in at each VM exit
 
@@ -992,6 +993,13 @@ static void markDeadStoresInInst(RemoveDeadStoreState& state, IrBuilder& build, 
 static void markDeadStoresInBlock(IrBuilder& build, IrBlock& block, RemoveDeadStoreState& state)
 {
     IrFunction& function = build.function;
+
+    if (FFlag::LuauCodegenSafeEnvPreserve)
+    {
+        // Block might establish a safe environment right at the start and might take a VM exit
+        if ((block.flags & kBlockFlagSafeEnvCheck) != 0)
+            state.readAllRegs();
+    }
 
     for (uint32_t index = block.start; index <= block.finish; index++)
     {

--- a/Compiler/src/BuiltinFolding.cpp
+++ b/Compiler/src/BuiltinFolding.cpp
@@ -7,8 +7,6 @@
 #include <array>
 #include <math.h>
 
-LUAU_FASTFLAGVARIABLE(LuauCompileStringCharSubFold)
-
 namespace Luau
 {
 namespace Compile
@@ -471,7 +469,7 @@ Constant foldBuiltin(AstNameTable& stringTable, int bfid, const Constant* args, 
         break;
 
     case LBF_STRING_CHAR:
-        if (FFlag::LuauCompileStringCharSubFold && count < kStringCharFoldLimit)
+        if (count < kStringCharFoldLimit)
         {
             std::array<char, kStringCharFoldLimit> buf{};
 
@@ -507,7 +505,7 @@ Constant foldBuiltin(AstNameTable& stringTable, int bfid, const Constant* args, 
         break;
 
     case LBF_STRING_SUB:
-        if (FFlag::LuauCompileStringCharSubFold && count >= 2 && args[0].type == Constant::Type_String && args[1].type == Constant::Type_Number)
+        if (count >= 2 && args[0].type == Constant::Type_String && args[1].type == Constant::Type_Number)
         {
             if (count >= 3 && args[2].type != Constant::Type_Number)
                 return cvar();

--- a/Compiler/src/BytecodeBuilder.cpp
+++ b/Compiler/src/BytecodeBuilder.cpp
@@ -7,8 +7,6 @@
 #include <algorithm>
 #include <string.h>
 
-LUAU_FASTFLAG(LuauCompileStringCharSubFold)
-LUAU_FASTFLAG(LuauCompileCallCostModel)
 LUAU_FASTFLAGVARIABLE(LuauCompileCorrectLocalPc)
 
 namespace Luau
@@ -492,7 +490,6 @@ void BytecodeBuilder::emitAux(uint32_t aux)
 
 void BytecodeBuilder::undoEmit(LuauOpcode op)
 {
-    LUAU_ASSERT(FFlag::LuauCompileCallCostModel);
     LUAU_ASSERT(!insns.empty());
     LUAU_ASSERT((insns.back() & 0xff) == op);
 
@@ -1859,7 +1856,7 @@ void BytecodeBuilder::dumpConstant(std::string& result, int k) const
             else
                 formatAppend(result, "'%.*s'...", 32, str.data);
         }
-        else if (FFlag::LuauCompileStringCharSubFold)
+        else
         {
             formatAppend(result, "'");
 

--- a/Makefile
+++ b/Makefile
@@ -46,11 +46,11 @@ ISOCLINE_SOURCES=extern/isocline/src/isocline.c
 ISOCLINE_OBJECTS=$(ISOCLINE_SOURCES:%=$(BUILD)/%.o)
 ISOCLINE_TARGET=$(BUILD)/libisocline.a
 
-TESTS_SOURCES=$(wildcard tests/*.cpp) CLI/src/FileUtils.cpp CLI/src/Flags.cpp CLI/src/Profiler.cpp CLI/src/Coverage.cpp CLI/src/Repl.cpp CLI/src/ReplRequirer.cpp CLI/src/VfsNavigator.cpp
+TESTS_SOURCES=$(wildcard tests/*.cpp) CLI/src/FileUtils.cpp CLI/src/Flags.cpp CLI/src/Profiler.cpp CLI/src/Coverage.cpp CLI/src/Counters.cpp CLI/src/Repl.cpp CLI/src/ReplRequirer.cpp CLI/src/VfsNavigator.cpp
 TESTS_OBJECTS=$(TESTS_SOURCES:%=$(BUILD)/%.o)
 TESTS_TARGET=$(BUILD)/luau-tests
 
-REPL_CLI_SOURCES=CLI/src/FileUtils.cpp CLI/src/Flags.cpp CLI/src/Profiler.cpp CLI/src/Coverage.cpp CLI/src/Repl.cpp CLI/src/ReplEntry.cpp CLI/src/ReplRequirer.cpp CLI/src/VfsNavigator.cpp
+REPL_CLI_SOURCES=CLI/src/FileUtils.cpp CLI/src/Flags.cpp CLI/src/Profiler.cpp CLI/src/Coverage.cpp CLI/src/Counters.cpp CLI/src/Repl.cpp CLI/src/ReplEntry.cpp CLI/src/ReplRequirer.cpp CLI/src/VfsNavigator.cpp
 REPL_CLI_OBJECTS=$(REPL_CLI_SOURCES:%=$(BUILD)/%.o)
 REPL_CLI_TARGET=$(BUILD)/luau
 

--- a/Sources.cmake
+++ b/Sources.cmake
@@ -418,10 +418,12 @@ target_sources(Luau.CLI.lib PRIVATE
 if(TARGET Luau.Repl.CLI)
     # Luau.Repl.CLI Sources
     target_sources(Luau.Repl.CLI PRIVATE
+        CLI/include/Luau/Counters.h
         CLI/include/Luau/Coverage.h
         CLI/include/Luau/Profiler.h
         CLI/include/Luau/ReplRequirer.h
 
+        CLI/src/Counters.cpp
         CLI/src/Coverage.cpp
         CLI/src/Profiler.cpp
         CLI/src/Repl.cpp
@@ -562,10 +564,12 @@ endif()
 if(TARGET Luau.CLI.Test)
     # Luau.CLI.Test Sources
     target_sources(Luau.CLI.Test PRIVATE
+        CLI/include/Luau/Counters.h
         CLI/include/Luau/Coverage.h
         CLI/include/Luau/Profiler.h
         CLI/include/Luau/ReplRequirer.h
 
+        CLI/src/Counters.cpp
         CLI/src/Coverage.cpp
         CLI/src/Profiler.cpp
         CLI/src/Repl.cpp

--- a/VM/include/lua.h
+++ b/VM/include/lua.h
@@ -421,6 +421,14 @@ typedef void (*lua_Coverage)(void* context, const char* function, int linedefine
 
 LUA_API void lua_getcoverage(lua_State* L, int funcindex, void* context, lua_Coverage callback);
 
+typedef void (*lua_CounterFunction)(void* context, const char* function, int linedefined);
+typedef void (*lua_CounterValue)(void* context, int kind, int line, uint64_t hits);
+
+// Unlike 'lua_getcoverage', counters are customizable in ways which prevent merging them together
+// 'lua_getcounters' will visit the specified function and all nested functions
+// 'functionvisit' is called first to establish a function, then multiple calls of 'countervisit' are made for each counter in that function
+LUA_API void lua_getcounters(lua_State* L, int funcindex, void* context, lua_CounterFunction functionvisit, lua_CounterValue countervisit);
+
 // Warning: this function is not thread-safe since it stores the result in a shared global array! Only use for debugging.
 LUA_API const char* lua_debugtrace(lua_State* L);
 

--- a/VM/src/lstate.h
+++ b/VM/src/lstate.h
@@ -155,6 +155,11 @@ struct lua_ExecutionCallbacks
     void (*disable)(lua_State* L, Proto* proto); // called when function has to be switched from native to bytecode in the debugger
     size_t (*getmemorysize)(lua_State* L, Proto* proto); // called to request the size of memory associated with native part of the Proto
     uint8_t (*gettypemapping)(lua_State* L, const char* str, size_t len); // called to get the userdata type index
+    char* (*getcounterdata)(
+        lua_State* L,
+        Proto* proto,
+        size_t* count
+    ); // called to get the execution counter data and count {uint32_t, uint32_t, uint64_t}
 };
 
 /*

--- a/tests/AssemblyBuilderA64.test.cpp
+++ b/tests/AssemblyBuilderA64.test.cpp
@@ -7,8 +7,6 @@
 
 #include <string.h>
 
-LUAU_FASTFLAG(LuauCodegenUpvalueLoadProp2)
-LUAU_FASTFLAG(LuauCodegenUintToFloat)
 
 using namespace Luau::CodeGen;
 using namespace Luau::CodeGen::A64;
@@ -384,8 +382,6 @@ TEST_CASE_FIXTURE(AssemblyBuilderA64Fixture, "AddressOfLabel")
 
 TEST_CASE_FIXTURE(AssemblyBuilderA64Fixture, "FPBasic")
 {
-    ScopedFastFlag luauCodegenUpvalueLoadProp{FFlag::LuauCodegenUpvalueLoadProp2, true};
-
     SINGLE_COMPARE(fmov(d0, d1), 0x1E604020);
     SINGLE_COMPARE(fmov(d0, x1), 0x9E670020);
     SINGLE_COMPARE(fmov(x3, d2), 0x9E660043);
@@ -393,8 +389,6 @@ TEST_CASE_FIXTURE(AssemblyBuilderA64Fixture, "FPBasic")
 
 TEST_CASE_FIXTURE(AssemblyBuilderA64Fixture, "FPMath")
 {
-    ScopedFastFlag luauCodegenUintToFloat{FFlag::LuauCodegenUintToFloat, true};
-
     SINGLE_COMPARE(fabs(d1, d2), 0x1E60C041);
     SINGLE_COMPARE(fabs(s1, s2), 0x1E20C041);
     SINGLE_COMPARE(fabs(q1, q2), 0x4EA0F841);

--- a/tests/FragmentAutocomplete.test.cpp
+++ b/tests/FragmentAutocomplete.test.cpp
@@ -24,7 +24,7 @@ LUAU_FASTINT(LuauParseErrorLimit)
 
 LUAU_FASTFLAG(LuauBetterReverseDependencyTracking)
 LUAU_FASTFLAG(LuauFragmentRequiresCanBeResolvedToAModule)
-LUAU_FASTFLAG(LuauAutocompleteFunctionCallArgTails)
+LUAU_FASTFLAG(LuauAutocompleteFunctionCallArgTails2)
 
 static std::optional<AutocompleteEntryMap> nullCallback(std::string tag, std::optional<const ExternType*> ptr, std::optional<std::string> contents)
 {
@@ -4734,7 +4734,7 @@ TEST_CASE_FIXTURE(FragmentAutocompleteFixture, "fragment_autocomplete_using_inde
 
 TEST_CASE_FIXTURE(FragmentAutocompleteFixture, "fragment_autocomplete_using_function_call_with_variadic_args")
 {
-    ScopedFastFlag sff{FFlag::LuauAutocompleteFunctionCallArgTails, true};
+    ScopedFastFlag sff{FFlag::LuauAutocompleteFunctionCallArgTails2, true};
 
     std::string source = R"(
         local function foo(...: "Val1" | "Val2") end
@@ -4752,8 +4752,8 @@ TEST_CASE_FIXTURE(FragmentAutocompleteFixture, "fragment_autocomplete_using_func
         [](FragmentAutocompleteStatusResult& frag)
         {
             REQUIRE(frag.result);
-            CHECK(frag.result->acResults.entryMap.count("Val1") == 0);
-            CHECK(frag.result->acResults.entryMap.count("Val2") == 0);
+            CHECK(frag.result->acResults.entryMap.count("\"Val1\"") == 1);
+            CHECK(frag.result->acResults.entryMap.count("\"Val2\"") == 1);
         }
     );
 }

--- a/tests/Frontend.test.cpp
+++ b/tests/Frontend.test.cpp
@@ -16,7 +16,6 @@
 using namespace Luau;
 
 LUAU_FASTFLAG(LuauSolverV2);
-LUAU_FASTFLAG(LuauStandaloneParseType)
 LUAU_FASTFLAG(DebugLuauFreezeArena)
 LUAU_FASTFLAG(DebugLuauMagicTypes)
 LUAU_FASTFLAG(LuauBetterTypeMismatchErrors)
@@ -1864,8 +1863,6 @@ TEST_CASE_FIXTURE(FrontendFixture, "parse_just_a_type")
 
 TEST_CASE_FIXTURE(FrontendFixture, "parse_types")
 {
-    ScopedFastFlag sff{FFlag::LuauStandaloneParseType, true};
-
     const TypeId ty1 = parseType("(number, boolean?) -> string");
     CHECK("(number, boolean?) -> string" == toString(ty1));
 

--- a/tests/IrBuilder.test.cpp
+++ b/tests/IrBuilder.test.cpp
@@ -18,8 +18,9 @@ LUAU_FASTFLAG(LuauCodegenDsoPairTrackFix)
 LUAU_FASTFLAG(LuauCodegenBufferRangeMerge3)
 LUAU_FASTFLAG(LuauCodegenBufferBaseFold)
 LUAU_FASTFLAG(LuauCodegenTableLoadProp2)
-LUAU_FASTFLAG(LuauCodegenUpvalueLoadProp2)
 LUAU_FASTFLAG(LuauCodegenDsoTagOverlayFix)
+LUAU_FASTFLAG(LuauCodegenCounterSupport)
+LUAU_FASTFLAG(LuauCodegenExtraBlockers)
 
 using namespace Luau::CodeGen;
 
@@ -131,8 +132,10 @@ TEST_SUITE_BEGIN("Optimization");
 
 TEST_CASE_FIXTURE(IrBuilderFixture, "FinalX64OptCheckTag")
 {
+    ScopedFastFlag luauCodegenCounterSupport{FFlag::LuauCodegenCounterSupport, true};
+
     IrOp block = build.block(IrBlockKind::Internal);
-    IrOp fallback = build.block(IrBlockKind::Fallback);
+    IrOp fallback = build.fallbackBlock(0u);
 
     build.beginBlock(block);
     IrOp tag1 = build.inst(IrCmd::LOAD_TAG, build.vmReg(2));
@@ -1033,8 +1036,10 @@ bb_0:
 
 TEST_CASE_FIXTURE(IrBuilderFixture, "SkipCheckTag")
 {
+    ScopedFastFlag luauCodegenCounterSupport{FFlag::LuauCodegenCounterSupport, true};
+
     IrOp block = build.block(IrBlockKind::Internal);
-    IrOp fallback = build.block(IrBlockKind::Fallback);
+    IrOp fallback = build.fallbackBlock(0u);
 
     build.beginBlock(block);
 
@@ -1088,8 +1093,10 @@ bb_0:
 
 TEST_CASE_FIXTURE(IrBuilderFixture, "RememberTableState")
 {
+    ScopedFastFlag luauCodegenCounterSupport{FFlag::LuauCodegenCounterSupport, true};
+
     IrOp block = build.block(IrBlockKind::Internal);
-    IrOp fallback = build.block(IrBlockKind::Fallback);
+    IrOp fallback = build.fallbackBlock(0u);
 
     build.beginBlock(block);
 
@@ -1132,8 +1139,10 @@ bb_fallback_1:
 
 TEST_CASE_FIXTURE(IrBuilderFixture, "RememberNewTableState")
 {
+    ScopedFastFlag luauCodegenCounterSupport{FFlag::LuauCodegenCounterSupport, true};
+
     IrOp block = build.block(IrBlockKind::Internal);
-    IrOp fallback = build.block(IrBlockKind::Fallback);
+    IrOp fallback = build.fallbackBlock(0u);
 
     build.beginBlock(block);
 
@@ -1244,8 +1253,10 @@ bb_0:
 
 TEST_CASE_FIXTURE(IrBuilderFixture, "BuiltinFastcallsMayInvalidateMemory")
 {
+    ScopedFastFlag luauCodegenCounterSupport{FFlag::LuauCodegenCounterSupport, true};
+
     IrOp block = build.block(IrBlockKind::Internal);
-    IrOp fallback = build.block(IrBlockKind::Fallback);
+    IrOp fallback = build.fallbackBlock(0u);
 
     build.beginBlock(block);
 
@@ -1325,8 +1336,10 @@ bb_0:
 
 TEST_CASE_FIXTURE(IrBuilderFixture, "TagCheckPropagation")
 {
+    ScopedFastFlag luauCodegenCounterSupport{FFlag::LuauCodegenCounterSupport, true};
+
     IrOp block = build.block(IrBlockKind::Internal);
-    IrOp fallback = build.block(IrBlockKind::Fallback);
+    IrOp fallback = build.fallbackBlock(0u);
 
     build.beginBlock(block);
 
@@ -1357,8 +1370,10 @@ bb_fallback_1:
 
 TEST_CASE_FIXTURE(IrBuilderFixture, "TagCheckPropagationConflicting")
 {
+    ScopedFastFlag luauCodegenCounterSupport{FFlag::LuauCodegenCounterSupport, true};
+
     IrOp block = build.block(IrBlockKind::Internal);
-    IrOp fallback = build.block(IrBlockKind::Fallback);
+    IrOp fallback = build.fallbackBlock(0u);
 
     build.beginBlock(block);
 
@@ -1389,10 +1404,12 @@ bb_fallback_1:
 
 TEST_CASE_FIXTURE(IrBuilderFixture, "TruthyTestRemoval")
 {
+    ScopedFastFlag luauCodegenCounterSupport{FFlag::LuauCodegenCounterSupport, true};
+
     IrOp block = build.block(IrBlockKind::Internal);
     IrOp trueBlock = build.block(IrBlockKind::Internal);
     IrOp falseBlock = build.block(IrBlockKind::Internal);
-    IrOp fallback = build.block(IrBlockKind::Fallback);
+    IrOp fallback = build.fallbackBlock(0u);
 
     build.beginBlock(block);
     IrOp unknown = build.inst(IrCmd::LOAD_TAG, build.vmReg(1));
@@ -1429,10 +1446,12 @@ bb_fallback_3:
 
 TEST_CASE_FIXTURE(IrBuilderFixture, "FalsyTestRemoval")
 {
+    ScopedFastFlag luauCodegenCounterSupport{FFlag::LuauCodegenCounterSupport, true};
+
     IrOp block = build.block(IrBlockKind::Internal);
     IrOp trueBlock = build.block(IrBlockKind::Internal);
     IrOp falseBlock = build.block(IrBlockKind::Internal);
-    IrOp fallback = build.block(IrBlockKind::Fallback);
+    IrOp fallback = build.fallbackBlock(0u);
 
     build.beginBlock(block);
     IrOp unknown = build.inst(IrCmd::LOAD_TAG, build.vmReg(1));
@@ -1821,8 +1840,10 @@ bb_0:
 
 TEST_CASE_FIXTURE(IrBuilderFixture, "InvalidateReglinkVersion")
 {
+    ScopedFastFlag luauCodegenCounterSupport{FFlag::LuauCodegenCounterSupport, true};
+
     IrOp block = build.block(IrBlockKind::Internal);
-    IrOp fallback = build.block(IrBlockKind::Fallback);
+    IrOp fallback = build.fallbackBlock(0u);
 
     build.beginBlock(block);
 
@@ -2030,10 +2051,12 @@ TEST_SUITE_BEGIN("LinearExecutionFlowExtraction");
 
 TEST_CASE_FIXTURE(IrBuilderFixture, "SimplePathExtraction")
 {
+    ScopedFastFlag luauCodegenCounterSupport{FFlag::LuauCodegenCounterSupport, true};
+
     IrOp block1 = build.block(IrBlockKind::Internal);
-    IrOp fallback1 = build.block(IrBlockKind::Fallback);
+    IrOp fallback1 = build.fallbackBlock(0u);
     IrOp block2 = build.block(IrBlockKind::Internal);
-    IrOp fallback2 = build.block(IrBlockKind::Fallback);
+    IrOp fallback2 = build.fallbackBlock(0u);
     IrOp block3 = build.block(IrBlockKind::Internal);
     IrOp block4 = build.block(IrBlockKind::Internal);
 
@@ -2101,10 +2124,12 @@ bb_linear_6:
 
 TEST_CASE_FIXTURE(IrBuilderFixture, "NoPathExtractionForBlocksWithLiveOutValues")
 {
+    ScopedFastFlag luauCodegenCounterSupport{FFlag::LuauCodegenCounterSupport, true};
+
     IrOp block1 = build.block(IrBlockKind::Internal);
-    IrOp fallback1 = build.block(IrBlockKind::Fallback);
+    IrOp fallback1 = build.fallbackBlock(0u);
     IrOp block2 = build.block(IrBlockKind::Internal);
-    IrOp fallback2 = build.block(IrBlockKind::Fallback);
+    IrOp fallback2 = build.fallbackBlock(0u);
     IrOp block3 = build.block(IrBlockKind::Internal);
     IrOp block4a = build.block(IrBlockKind::Internal);
     IrOp block4b = build.block(IrBlockKind::Internal);
@@ -2293,11 +2318,12 @@ bb_0:
 
 TEST_CASE_FIXTURE(IrBuilderFixture, "DuplicateHashSlotChecks")
 {
-    ScopedFastFlag luauCodegenUpvalueLoadProp{FFlag::LuauCodegenUpvalueLoadProp2, true};
     ScopedFastFlag luauCodegenTableLoadProp{FFlag::LuauCodegenTableLoadProp2, true};
+    ScopedFastFlag luauCodegenCounterSupport{FFlag::LuauCodegenCounterSupport, true};
+
 
     IrOp block = build.block(IrBlockKind::Internal);
-    IrOp fallback = build.block(IrBlockKind::Fallback);
+    IrOp fallback = build.fallbackBlock(0u);
 
     build.beginBlock(block);
 
@@ -2347,8 +2373,10 @@ bb_fallback_1:
 
 TEST_CASE_FIXTURE(IrBuilderFixture, "DuplicateHashSlotChecksAvoidNil")
 {
+    ScopedFastFlag luauCodegenCounterSupport{FFlag::LuauCodegenCounterSupport, true};
+
     IrOp block = build.block(IrBlockKind::Internal);
-    IrOp fallback = build.block(IrBlockKind::Fallback);
+    IrOp fallback = build.fallbackBlock(0u);
 
     build.beginBlock(block);
 
@@ -2416,8 +2444,10 @@ bb_fallback_1:
 
 TEST_CASE_FIXTURE(IrBuilderFixture, "DuplicateHashSlotChecksInvalidation")
 {
+    ScopedFastFlag luauCodegenCounterSupport{FFlag::LuauCodegenCounterSupport, true};
+
     IrOp block = build.block(IrBlockKind::Internal);
-    IrOp fallback = build.block(IrBlockKind::Fallback);
+    IrOp fallback = build.fallbackBlock(0u);
 
     build.beginBlock(block);
 
@@ -2476,11 +2506,11 @@ bb_fallback_1:
 
 TEST_CASE_FIXTURE(IrBuilderFixture, "DuplicateArrayElemChecksSameIndex")
 {
-    ScopedFastFlag luauCodegenUpvalueLoadProp{FFlag::LuauCodegenUpvalueLoadProp2, true};
     ScopedFastFlag luauCodegenTableLoadProp{FFlag::LuauCodegenTableLoadProp2, true};
+    ScopedFastFlag luauCodegenCounterSupport{FFlag::LuauCodegenCounterSupport, true};
 
     IrOp block = build.block(IrBlockKind::Internal);
-    IrOp fallback = build.block(IrBlockKind::Fallback);
+    IrOp fallback = build.fallbackBlock(0u);
 
     build.beginBlock(block);
 
@@ -2530,11 +2560,11 @@ bb_fallback_1:
 
 TEST_CASE_FIXTURE(IrBuilderFixture, "DuplicateArrayElemChecksSameValue")
 {
-    ScopedFastFlag luauCodegenUpvalueLoadProp{FFlag::LuauCodegenUpvalueLoadProp2, true};
     ScopedFastFlag luauCodegenTableLoadProp{FFlag::LuauCodegenTableLoadProp2, true};
+    ScopedFastFlag luauCodegenCounterSupport{FFlag::LuauCodegenCounterSupport, true};
 
     IrOp block = build.block(IrBlockKind::Internal);
-    IrOp fallback = build.block(IrBlockKind::Fallback);
+    IrOp fallback = build.fallbackBlock(0u);
 
     build.beginBlock(block);
 
@@ -2592,8 +2622,10 @@ bb_fallback_1:
 
 TEST_CASE_FIXTURE(IrBuilderFixture, "DuplicateArrayElemChecksLowerIndex")
 {
+    ScopedFastFlag luauCodegenCounterSupport{FFlag::LuauCodegenCounterSupport, true};
+
     IrOp block = build.block(IrBlockKind::Internal);
-    IrOp fallback = build.block(IrBlockKind::Fallback);
+    IrOp fallback = build.fallbackBlock(0u);
 
     build.beginBlock(block);
 
@@ -2646,8 +2678,10 @@ bb_fallback_1:
 
 TEST_CASE_FIXTURE(IrBuilderFixture, "DuplicateArrayElemChecksInvalidations")
 {
+    ScopedFastFlag luauCodegenCounterSupport{FFlag::LuauCodegenCounterSupport, true};
+
     IrOp block = build.block(IrBlockKind::Internal);
-    IrOp fallback = build.block(IrBlockKind::Fallback);
+    IrOp fallback = build.fallbackBlock(0u);
 
     build.beginBlock(block);
 
@@ -2704,8 +2738,10 @@ bb_fallback_1:
 
 TEST_CASE_FIXTURE(IrBuilderFixture, "ArrayElemChecksNegativeIndex")
 {
+    ScopedFastFlag luauCodegenCounterSupport{FFlag::LuauCodegenCounterSupport, true};
+
     IrOp block = build.block(IrBlockKind::Internal);
-    IrOp fallback = build.block(IrBlockKind::Fallback);
+    IrOp fallback = build.fallbackBlock(0u);
 
     build.beginBlock(block);
 
@@ -2752,9 +2788,10 @@ bb_fallback_1:
 TEST_CASE_FIXTURE(IrBuilderFixture, "DuplicateBufferLengthChecks")
 {
     ScopedFastFlag luauCodegenBufferRangeMerge{FFlag::LuauCodegenBufferRangeMerge3, true};
+    ScopedFastFlag luauCodegenCounterSupport{FFlag::LuauCodegenCounterSupport, true};
 
     IrOp block = build.block(IrBlockKind::Internal);
-    IrOp fallback = build.block(IrBlockKind::Fallback);
+    IrOp fallback = build.fallbackBlock(0u);
 
     build.beginBlock(block);
 
@@ -2821,9 +2858,10 @@ bb_fallback_1:
 TEST_CASE_FIXTURE(IrBuilderFixture, "BufferLengthChecksNegativeIndex")
 {
     ScopedFastFlag luauCodegenBufferRangeMerge{FFlag::LuauCodegenBufferRangeMerge3, true};
+    ScopedFastFlag luauCodegenCounterSupport{FFlag::LuauCodegenCounterSupport, true};
 
     IrOp block = build.block(IrBlockKind::Internal);
-    IrOp fallback = build.block(IrBlockKind::Fallback);
+    IrOp fallback = build.fallbackBlock(0u);
 
     build.beginBlock(block);
 
@@ -2856,9 +2894,10 @@ bb_fallback_1:
 TEST_CASE_FIXTURE(IrBuilderFixture, "BufferLengthChecksIntegerMatch")
 {
     ScopedFastFlag luauCodegenBufferRangeMerge{FFlag::LuauCodegenBufferRangeMerge3, true};
+    ScopedFastFlag luauCodegenCounterSupport{FFlag::LuauCodegenCounterSupport, true};
 
     IrOp block = build.block(IrBlockKind::Internal);
-    IrOp fallback = build.block(IrBlockKind::Fallback);
+    IrOp fallback = build.fallbackBlock(0u);
 
     build.beginBlock(block);
 
@@ -2895,9 +2934,10 @@ TEST_CASE_FIXTURE(IrBuilderFixture, "BufferLengthChecksIntegerMatch2")
 {
     ScopedFastFlag luauCodegenBufferRangeMerge{FFlag::LuauCodegenBufferRangeMerge3, true};
     ScopedFastFlag luauCodegenBufferBaseFold{FFlag::LuauCodegenBufferBaseFold, true};
+    ScopedFastFlag luauCodegenCounterSupport{FFlag::LuauCodegenCounterSupport, true};
 
     IrOp block = build.block(IrBlockKind::Internal);
-    IrOp fallback = build.block(IrBlockKind::Fallback);
+    IrOp fallback = build.fallbackBlock(0u);
 
     build.beginBlock(block);
     IrOp buffer = build.inst(IrCmd::LOAD_POINTER, build.vmReg(0));
@@ -3343,8 +3383,10 @@ bb_1:
 
 TEST_CASE_FIXTURE(IrBuilderFixture, "FallbackDoesNotFlowUp")
 {
+    ScopedFastFlag luauCodegenCounterSupport{FFlag::LuauCodegenCounterSupport, true};
+
     IrOp entry = build.block(IrBlockKind::Internal);
-    IrOp fallback = build.block(IrBlockKind::Fallback);
+    IrOp fallback = build.fallbackBlock(0u);
     IrOp exit = build.block(IrBlockKind::Internal);
 
     build.beginBlock(entry);
@@ -3647,8 +3689,10 @@ bb_0:
 
 TEST_CASE_FIXTURE(IrBuilderFixture, "LateTableStateLink")
 {
+    ScopedFastFlag luauCodegenCounterSupport{FFlag::LuauCodegenCounterSupport, true};
+
     IrOp block = build.block(IrBlockKind::Internal);
-    IrOp fallback = build.block(IrBlockKind::Fallback);
+    IrOp fallback = build.fallbackBlock(0u);
 
     build.beginBlock(block);
 
@@ -3861,8 +3905,10 @@ bb_0:
 
 TEST_CASE_FIXTURE(IrBuilderFixture, "TValueLoadToSplitStore")
 {
+    ScopedFastFlag luauCodegenCounterSupport{FFlag::LuauCodegenCounterSupport, true};
+
     IrOp entry = build.block(IrBlockKind::Internal);
-    IrOp fallback = build.block(IrBlockKind::Fallback);
+    IrOp fallback = build.fallbackBlock(0u);
 
     build.beginBlock(entry);
     IrOp op1 = build.inst(IrCmd::LOAD_DOUBLE, build.vmReg(0));
@@ -4046,8 +4092,6 @@ bb_0:
 
 TEST_CASE_FIXTURE(IrBuilderFixture, "IndirectFloatLoadExtractionMustRespectVersion")
 {
-    ScopedFastFlag luauCodegenUpvalueLoadProp{FFlag::LuauCodegenUpvalueLoadProp2, true};
-
     IrOp entry = build.block(IrBlockKind::Internal);
 
     build.beginBlock(entry);
@@ -4348,6 +4392,8 @@ bb_0:
 
 TEST_CASE_FIXTURE(IrBuilderFixture, "HiddenPointerUse5")
 {
+    ScopedFastFlag luauCodegenExtraBlockers{FFlag::LuauCodegenExtraBlockers, true};
+
     IrOp entry = build.block(IrBlockKind::Internal);
 
     build.beginBlock(entry);
@@ -4374,7 +4420,8 @@ bb_0:
    STORE_POINTER R1, %0
    STORE_TAG R1, ttable
    DO_LEN R3, R2
-   STORE_POINTER R2, %0
+   %4 = LOAD_POINTER R1
+   STORE_POINTER R2, %4
    STORE_TAG R2, ttable
    RETURN R2, 2i
 
@@ -4634,9 +4681,10 @@ bb_0:
 TEST_CASE_FIXTURE(IrBuilderFixture, "StoreCannotBeReplacedWithCheck")
 {
     ScopedFastFlag debugLuauAbortingChecks{FFlag::DebugLuauAbortingChecks, true};
+    ScopedFastFlag luauCodegenCounterSupport{FFlag::LuauCodegenCounterSupport, true};
 
     IrOp block = build.block(IrBlockKind::Internal);
-    IrOp fallback = build.block(IrBlockKind::Fallback);
+    IrOp fallback = build.fallbackBlock(0u);
     IrOp last = build.block(IrBlockKind::Internal);
 
     build.beginBlock(block);
@@ -4701,8 +4749,10 @@ bb_2:
 
 TEST_CASE_FIXTURE(IrBuilderFixture, "FullStoreHasToBeObservableFromFallbacks")
 {
+    ScopedFastFlag luauCodegenCounterSupport{FFlag::LuauCodegenCounterSupport, true};
+
     IrOp entry = build.block(IrBlockKind::Internal);
-    IrOp fallback = build.block(IrBlockKind::Fallback);
+    IrOp fallback = build.fallbackBlock(0u);
     IrOp last = build.block(IrBlockKind::Internal);
 
     build.beginBlock(entry);
@@ -4757,8 +4807,10 @@ bb_2:
 
 TEST_CASE_FIXTURE(IrBuilderFixture, "FullStoreHasToBeObservableFromFallbacks2")
 {
+    ScopedFastFlag luauCodegenCounterSupport{FFlag::LuauCodegenCounterSupport, true};
+
     IrOp entry = build.block(IrBlockKind::Internal);
-    IrOp fallback = build.block(IrBlockKind::Fallback);
+    IrOp fallback = build.fallbackBlock(0u);
     IrOp last = build.block(IrBlockKind::Internal);
 
     build.beginBlock(entry);
@@ -4811,8 +4863,10 @@ bb_2:
 
 TEST_CASE_FIXTURE(IrBuilderFixture, "FullStoreHasToBeObservableFromFallbacks3")
 {
+    ScopedFastFlag luauCodegenCounterSupport{FFlag::LuauCodegenCounterSupport, true};
+
     IrOp entry = build.block(IrBlockKind::Internal);
-    IrOp fallback = build.block(IrBlockKind::Fallback);
+    IrOp fallback = build.fallbackBlock(0u);
     IrOp last = build.block(IrBlockKind::Internal);
 
     build.beginBlock(entry);
@@ -4868,8 +4922,10 @@ bb_2:
 
 TEST_CASE_FIXTURE(IrBuilderFixture, "SafePartialValueStoresWithPreservedTag")
 {
+    ScopedFastFlag luauCodegenCounterSupport{FFlag::LuauCodegenCounterSupport, true};
+
     IrOp entry = build.block(IrBlockKind::Internal);
-    IrOp fallback = build.block(IrBlockKind::Fallback);
+    IrOp fallback = build.fallbackBlock(0u);
     IrOp last = build.block(IrBlockKind::Internal);
 
     build.beginBlock(entry);
@@ -4921,8 +4977,10 @@ bb_2:
 
 TEST_CASE_FIXTURE(IrBuilderFixture, "SafePartialValueStoresWithPreservedTag2")
 {
+    ScopedFastFlag luauCodegenCounterSupport{FFlag::LuauCodegenCounterSupport, true};
+
     IrOp entry = build.block(IrBlockKind::Internal);
-    IrOp fallback = build.block(IrBlockKind::Fallback);
+    IrOp fallback = build.fallbackBlock(0u);
     IrOp last = build.block(IrBlockKind::Internal);
 
     build.beginBlock(entry);

--- a/tests/SharedCodeAllocator.test.cpp
+++ b/tests/SharedCodeAllocator.test.cpp
@@ -255,7 +255,7 @@ TEST_CASE("NativeProtoRefcounting")
 
     std::vector<NativeProtoExecDataPtr> nativeProtos;
     nativeProtos.reserve(1);
-    NativeProtoExecDataPtr nativeProto = createNativeProtoExecData(0);
+    NativeProtoExecDataPtr nativeProto = createNativeProtoExecData(0, 0);
     getNativeProtoExecDataHeader(nativeProto.get()).bytecodeId = 0x01;
     nativeProtos.push_back(std::move(nativeProto));
 
@@ -311,7 +311,7 @@ TEST_CASE("NativeProtoState")
     nativeProtos.reserve(2);
 
     {
-        NativeProtoExecDataPtr nativeProto = createNativeProtoExecData(2);
+        NativeProtoExecDataPtr nativeProto = createNativeProtoExecData(2, 0);
         getNativeProtoExecDataHeader(nativeProto.get()).bytecodeId = 1;
         getNativeProtoExecDataHeader(nativeProto.get()).entryOffsetOrAddress = reinterpret_cast<const uint8_t*>(0x00);
         nativeProto[0] = 0;
@@ -321,7 +321,7 @@ TEST_CASE("NativeProtoState")
     }
 
     {
-        NativeProtoExecDataPtr nativeProto = createNativeProtoExecData(2);
+        NativeProtoExecDataPtr nativeProto = createNativeProtoExecData(2, 0);
         getNativeProtoExecDataHeader(nativeProto.get()).bytecodeId = 3;
         getNativeProtoExecDataHeader(nativeProto.get()).entryOffsetOrAddress = reinterpret_cast<const uint8_t*>(0x08);
         nativeProto[0] = 8;
@@ -370,7 +370,7 @@ TEST_CASE("AnonymousModuleLifetime")
     nativeProtos.reserve(1);
 
     {
-        NativeProtoExecDataPtr nativeProto = createNativeProtoExecData(2);
+        NativeProtoExecDataPtr nativeProto = createNativeProtoExecData(2, 0);
         getNativeProtoExecDataHeader(nativeProto.get()).bytecodeId = 1;
         getNativeProtoExecDataHeader(nativeProto.get()).entryOffsetOrAddress = reinterpret_cast<const uint8_t*>(0x00);
         nativeProto[0] = 0;

--- a/tests/TypeInfer.refinements.test.cpp
+++ b/tests/TypeInfer.refinements.test.cpp
@@ -14,6 +14,7 @@ LUAU_FASTFLAG(DebugLuauAssertOnForcedConstraint)
 LUAU_FASTFLAG(LuauBetterTypeMismatchErrors)
 LUAU_FASTFLAG(LuauTypeCheckerUdtfRenameClassToExtern)
 LUAU_FASTFLAG(LuauUnionOfTablesPreservesReadWrite)
+LUAU_FASTFLAG(LuauExternTypesNormalizeWithShapes)
 
 using namespace Luau;
 
@@ -1684,7 +1685,10 @@ TEST_CASE_FIXTURE(RefinementExternTypeFixture, "asserting_optional_properties_sh
 
     LUAU_REQUIRE_NO_ERRORS(result);
 
-    CHECK_EQ("WeldConstraint", toString(requireTypeAtPosition({3, 15})));
+    if (FFlag::LuauSolverV2 && FFlag::LuauExternTypesNormalizeWithShapes)
+        CHECK_EQ("WeldConstraint & { read Part1: ~(false?) }", toString(requireTypeAtPosition({3, 15})));
+    else
+        CHECK_EQ("WeldConstraint", toString(requireTypeAtPosition({3, 15})));
     CHECK_EQ("Vector3", toString(requireTypeAtPosition({6, 29})));
 }
 
@@ -2914,7 +2918,11 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "refinements_from_and_should_not_refine_to_ne
     )");
 
     LUAU_REQUIRE_NO_ERRORS(results);
-    CHECK_EQ("Config", toString(requireTypeAtPosition({6, 24})));
+
+    if (FFlag::LuauExternTypesNormalizeWithShapes)
+        CHECK_EQ("(Config & { read KeyboardEnabled: false? }) | (Config & { read MouseEnabled: false? })", toString(requireTypeAtPosition({6, 24})));
+    else
+        CHECK_EQ("Config", toString(requireTypeAtPosition({6, 24})));
 }
 
 TEST_CASE_FIXTURE(Fixture, "force_simplify_constraint_doesnt_drop_blocked_type")


### PR DESCRIPTION
Hello! Another week with updates to type analysis and fixes in compiler and native code generation.

### Analysis
* Table types are treated as shape types when normalizing against an extern type. This allows intersections against extern types to provide information on additional properties not declared in an extern type, but present for that particular value:
```luau
function take(thing: Instance & { Brushes: Instance })
    print(thing)
    print(thing.Brushes.Name)
end
```
* Fixed another crash which could happen when auto-complete visits a table with write-only properties

### Require library
* During path resolution, we now reset to the requirer's context _before_ `to_alias_override` is called, enabling embedders to implement context-sensitive alias overrides

### Compiler
* In a fast-call fallback sequence, `GETGLOBAL`/`GETUPVAL` will never use extra registers (Fixes #2248)

### Native Code Generation
* A counter system has been added which is used by native execution to report regular/fallback block execution and VM side exit statistics. When using `--codegen` together with `--counters` in Luau REPL, `callgrind.out` file is written containing the counter data to view in callgrind/cachegrind tools.
* Fixed an issue where `setfenv` change could have been ignored, executing fast-paths for longer than is allowed
* Stability improvements

---

Co-authored-by: Andy Friesen <afriesen@roblox.com>
Co-authored-by: Ariel Weiss <arielweiss@roblox.com>
Co-authored-by: Sora Kanosue <skanosue@roblox.com>
Co-authored-by: Varun Saini <vsaini@roblox.com>
Co-authored-by: Vighnesh Vijay <vvijay@roblox.com>
Co-authored-by: Vyacheslav Egorov <vegorov@roblox.com>
