### PR TITLE
Fix: restrict constant local elision to debugLevel 0.

### DIFF
--- a/Compiler/src/Compiler.cpp
+++ b/Compiler/src/Compiler.cpp
@@ -3192,7 +3192,7 @@ struct Compiler
     void compileStatLocal(AstStatLocal* stat)
     {
         // Optimization: we don't need to allocate and assign const locals, since their uses will be constant-folded
-        if (options.optimizationLevel >= 1 && options.debugLevel <= 1 && areLocalsRedundant(stat))
+        if (options.optimizationLevel >= 1 && options.debugLevel == 0 && areLocalsRedundant(stat))
             return;
 
         // Optimization: for 1-1 local assignments, we can reuse the register *if* neither local is mutated


### PR DESCRIPTION
When `LuauStringConstFolding2` was removed, folding became unconditional. That means `local _ = "a" .. "b"` now always folds to a constant, so `compileStatLocal` skips giving it a register - even at debugLevel == 1.  This shifts the register layout and breaks stack inspection tools reading from `ci->base`. 

The fix is to only skip register allocation at `debugLevel == 0`.
If someone has debug info enabled at all, the local should stay on the stack.