### PR TITLE
Wrap LUAI_FUNC and LUAI_DATA in #ifndef guard

### DIFF
--- a/VM/include/luaconf.h
+++ b/VM/include/luaconf.h
@@ -53,12 +53,19 @@
 #define LUALIB_API LUA_API
 
 // Can be used to reconfigure visibility for internal APIs
+#ifndef LUAI_FUNC
 #if defined(__GNUC__)
 #define LUAI_FUNC __attribute__((visibility("hidden"))) extern
-#define LUAI_DATA LUAI_FUNC
 #else
 #define LUAI_FUNC extern
+#endif
+#endif
+#ifndef LUAI_DATA
+#if defined(__GNUC__)
+#define LUAI_DATA LUAI_FUNC
+#else
 #define LUAI_DATA extern
+#endif
 #endif
 
 // Can be used to reconfigure internal error handling to use longjmp instead of C++ EH


### PR DESCRIPTION
Currently `LUAI_FUNC` and `LUAI_DATA` are unconditionally defined. When compiling Luau as a shared library, some of the internal functions can still be useful to have available for more advanced operations. There's currently no way to redefine the `LUAI_*` pair as `__declspec(dllexport)` in MSVC or strip the hidden visibility on GCC without making source changes to Luau itself.

This change wraps their definitions in `#ifndef` to allow redefinition by the compiler.