### PR TITLE
Sync to upstream/release/714

### DIFF
--- a/Analysis/include/Luau/ConstraintGenerator.h
+++ b/Analysis/include/Luau/ConstraintGenerator.h
@@ -13,6 +13,7 @@
 #include "Luau/NotNull.h"
 #include "Luau/Polarity.h"
 #include "Luau/Refinement.h"
+#include "Luau/Set.h"
 #include "Luau/Symbol.h"
 #include "Luau/TypeFwd.h"
 #include "Luau/TypeIds.h"
@@ -177,6 +178,8 @@ private:
     std::vector<InteriorFreeTypes> interiorFreeTypes;
 
     std::vector<TypeId> unionsToSimplify;
+
+    Set<TypeId> uninitializedGlobals{nullptr};
 
     Polarity polarity = Polarity::None;
 

--- a/Analysis/src/BuiltinTypeFunctions.cpp
+++ b/Analysis/src/BuiltinTypeFunctions.cpp
@@ -22,6 +22,7 @@ LUAU_DYNAMIC_FASTINTVARIABLE(LuauStepRefineRecursionLimit, 64)
 
 LUAU_FASTFLAG(LuauOverloadGetsInstantiated)
 LUAU_FASTFLAGVARIABLE(LuauTypeFunctionsCaptureNestedInstances)
+LUAU_FASTFLAGVARIABLE(LuauTypeFunctionsAddFreeTypePackWithPositivePolarity)
 
 namespace Luau
 {
@@ -145,7 +146,9 @@ static std::optional<TypePackId> solveFunctionCall(NotNull<TypeFunctionContext> 
     if (!selected.overload.has_value())
         return std::nullopt;
 
-    TypePackId retPack = ctx->arena->freshTypePack(ctx->scope);
+    TypePackId retPack = FFlag::LuauTypeFunctionsAddFreeTypePackWithPositivePolarity
+        ? ctx->arena->freshTypePack(ctx->scope, Polarity::Positive)
+        : ctx->arena->freshTypePack(ctx->scope);
     TypeId prospectiveFunction = ctx->arena->addType(FunctionType{argsPack, retPack});
 
     // FIXME: It's too bad that we have to bust out the Unifier here.  We should

--- a/Analysis/src/ConstraintGenerator.cpp
+++ b/Analysis/src/ConstraintGenerator.cpp
@@ -37,7 +37,6 @@ LUAU_FASTINT(LuauCheckRecursionLimit)
 LUAU_FASTFLAG(DebugLuauLogSolverToJson)
 LUAU_FASTFLAG(DebugLuauMagicTypes)
 LUAU_FASTINTVARIABLE(LuauPrimitiveInferenceInTableLimit, 500)
-LUAU_FASTFLAG(LuauExplicitTypeInstantiationSyntax)
 LUAU_FASTFLAG(LuauExplicitTypeInstantiationSupport)
 LUAU_FASTFLAGVARIABLE(LuauPropagateTypeAnnotationsInForInLoops)
 LUAU_FASTFLAGVARIABLE(LuauDontIncludeVarargWithAnnotation)
@@ -45,6 +44,7 @@ LUAU_FASTFLAGVARIABLE(LuauDisallowRedefiningBuiltinTypes)
 LUAU_FASTFLAGVARIABLE(LuauUnpackRespectsAnnotations)
 LUAU_FASTFLAG(LuauCaptureRecursiveCallsForTablesAndGlobals2)
 LUAU_FASTFLAGVARIABLE(LuauForwardPolarityForFunctionTypes)
+LUAU_FASTFLAGVARIABLE(LuauKeepExplicitMapForGlobalTypes)
 LUAU_FASTFLAGVARIABLE(LuauRefinementTypeVector)
 
 namespace Luau
@@ -1608,10 +1608,24 @@ ControlFlow ConstraintGenerator::visit(const ScopePtr& scope, AstStatFunction* f
         if (!existingFunctionTy)
             ice->ice("prepopulateGlobalScope did not populate a global name", globalName->location);
 
-        // Sketchy: We're specifically looking for BlockedTypes that were
-        // initially created by ConstraintGenerator::prepopulateGlobalScope.
-        if (auto bt = get<BlockedType>(*existingFunctionTy); bt && nullptr == bt->getOwner())
-            emplaceType<BoundType>(asMutable(*existingFunctionTy), generalizedType);
+        if (FFlag::LuauKeepExplicitMapForGlobalTypes)
+        {
+            if (auto bt = get<BlockedType>(*existingFunctionTy);
+                bt && uninitializedGlobals.contains(*existingFunctionTy))
+            {
+                LUAU_ASSERT(bt->getOwner() == nullptr);
+                uninitializedGlobals.erase(*existingFunctionTy);
+                emplaceType<BoundType>(asMutable(*existingFunctionTy), generalizedType);
+            }
+        }
+        else
+        {
+            // Sketchy: We're specifically looking for BlockedTypes that were
+            // initially created by ConstraintGenerator::prepopulateGlobalScope.
+            if (auto bt = get<BlockedType>(*existingFunctionTy); bt && nullptr == bt->getOwner())
+                emplaceType<BoundType>(asMutable(*existingFunctionTy), generalizedType);
+        }
+
 
         scope->bindings[globalName->name] = Binding{sig.signature, globalName->location};
         scope->lvalueTypes[def] = sig.signature;
@@ -2636,10 +2650,7 @@ Inference ConstraintGenerator::check(const ScopePtr& scope, AstExpr* expr, std::
     else if (auto interpString = expr->as<AstExprInterpString>())
         result = check(scope, interpString);
     else if (auto explicitTypeInstantiation = expr->as<AstExprInstantiate>())
-    {
-        LUAU_ASSERT(FFlag::LuauExplicitTypeInstantiationSyntax);
         result = check(scope, explicitTypeInstantiation);
-    }
     else if (auto err = expr->as<AstExprError>())
     {
         // Open question: Should we traverse into this?
@@ -3346,10 +3357,23 @@ void ConstraintGenerator::visitLValue(const ScopePtr& scope, AstExprGlobal* glob
         if (annotatedTy == follow(rhsType))
             return;
 
-        // Sketchy: We're specifically looking for BlockedTypes that were
-        // initially created by ConstraintGenerator::prepopulateGlobalScope.
-        if (auto bt = get<BlockedType>(follow(*annotatedTy)); bt && !bt->getOwner())
-            emplaceType<BoundType>(asMutable(*annotatedTy), rhsType);
+        if (FFlag::LuauKeepExplicitMapForGlobalTypes)
+        {
+            auto followedAnnotation = follow(*annotatedTy);
+            if (auto bt = get<BlockedType>(followedAnnotation); bt && uninitializedGlobals.contains(followedAnnotation))
+            {
+                LUAU_ASSERT(bt->getOwner() == nullptr);
+                emplaceType<BoundType>(asMutable(followedAnnotation), rhsType);
+            }
+        }
+        else
+        {
+            // Sketchy: We're specifically looking for BlockedTypes that were
+            // initially created by ConstraintGenerator::prepopulateGlobalScope.
+            if (auto bt = get<BlockedType>(follow(*annotatedTy)); bt && !bt->getOwner())
+                emplaceType<BoundType>(asMutable(*annotatedTy), rhsType);
+        }
+
 
         addConstraint(scope, global->location, SubtypeConstraint{rhsType, *annotatedTy});
     }
@@ -4401,6 +4425,7 @@ struct GlobalPrepopulator : AstVisitor
     const NotNull<Scope> globalScope;
     const NotNull<TypeArena> arena;
     const NotNull<const DataFlowGraph> dfg;
+    TypeIds globalStubTypes;
 
     GlobalPrepopulator(NotNull<Scope> globalScope, NotNull<TypeArena> arena, NotNull<const DataFlowGraph> dfg)
         : globalScope(globalScope)
@@ -4432,6 +4457,8 @@ struct GlobalPrepopulator : AstVisitor
                 if (globalScope->bindings.find(g->name) == globalScope->bindings.end())
                 {
                     TypeId bt = arena->addType(BlockedType{});
+                    if (FFlag::LuauKeepExplicitMapForGlobalTypes)
+                        globalStubTypes.insert(bt);
                     globalScope->bindings[g->name] = Binding{bt, g->location};
                 }
             }
@@ -4445,6 +4472,8 @@ struct GlobalPrepopulator : AstVisitor
         if (AstExprGlobal* g = function->name->as<AstExprGlobal>())
         {
             TypeId bt = arena->addType(BlockedType{});
+            if (FFlag::LuauKeepExplicitMapForGlobalTypes)
+                globalStubTypes.insert(bt);
             globalScope->bindings[g->name] = Binding{bt};
         }
 
@@ -4467,6 +4496,12 @@ void ConstraintGenerator::prepopulateGlobalScopeForFragmentTypecheck(const Scope
     // Handle type function globals as well, without preparing a module scope since they have a separate environment
     GlobalPrepopulator tfgp{NotNull{typeFunctionRuntime->rootScope.get()}, arena, dfg};
     program->visit(&tfgp);
+
+    if (FFlag::LuauKeepExplicitMapForGlobalTypes)
+    {
+        for (TypeId ty : tfgp.globalStubTypes)
+            uninitializedGlobals.insert(ty);
+    }
 }
 
 void ConstraintGenerator::prepopulateGlobalScope(const ScopePtr& globalScope, AstStatBlock* program)
@@ -4478,9 +4513,21 @@ void ConstraintGenerator::prepopulateGlobalScope(const ScopePtr& globalScope, As
 
     program->visit(&gp);
 
+    if (FFlag::LuauKeepExplicitMapForGlobalTypes)
+    {
+        for (TypeId ty : gp.globalStubTypes)
+            uninitializedGlobals.insert(ty);
+    }
+
     // Handle type function globals as well, without preparing a module scope since they have a separate environment
     GlobalPrepopulator tfgp{NotNull{typeFunctionRuntime->rootScope.get()}, arena, dfg};
     program->visit(&tfgp);
+
+    if (FFlag::LuauKeepExplicitMapForGlobalTypes)
+    {
+        for (TypeId ty : tfgp.globalStubTypes)
+            uninitializedGlobals.insert(ty);
+    }
 }
 
 bool ConstraintGenerator::recordPropertyAssignment(TypeId ty)

--- a/Analysis/src/ConstraintSolver.cpp
+++ b/Analysis/src/ConstraintSolver.cpp
@@ -49,6 +49,7 @@ LUAU_FASTFLAG(LuauRelateHandlesCoincidentTables)
 LUAU_FASTFLAG(LuauUnpackRespectsAnnotations)
 LUAU_FASTFLAG(LuauReplacerRespectsReboundGenerics)
 LUAU_FASTFLAGVARIABLE(LuauOverloadGetsInstantiated)
+LUAU_FASTFLAGVARIABLE(LuauFollowInExplicitInstantiation)
 
 namespace Luau
 {
@@ -2923,11 +2924,14 @@ TypeId ConstraintSolver::instantiateFunctionType(
     const Location& location
 )
 {
+    if (FFlag::LuauFollowInExplicitInstantiation)
+        functionTypeId = follow(functionTypeId);
+
     // no work to be done if we're not instantiating with anything
     if (typeArguments.empty() && typePackArguments.empty())
         return functionTypeId;
 
-    const FunctionType* ft = get<FunctionType>(follow(functionTypeId));
+    const FunctionType* ft = get<FunctionType>(FFlag::LuauFollowInExplicitInstantiation ? functionTypeId : follow(functionTypeId));
     if (!ft)
     {
         return functionTypeId;

--- a/Analysis/src/DataFlowGraph.cpp
+++ b/Analysis/src/DataFlowGraph.cpp
@@ -13,7 +13,6 @@
 
 LUAU_FASTFLAG(DebugLuauFreezeArena)
 LUAU_FASTFLAG(LuauSolverV2)
-LUAU_FASTFLAG(LuauExplicitTypeInstantiationSyntax)
 LUAU_FASTFLAG(LuauExplicitTypeInstantiationSupport)
 LUAU_FASTFLAGVARIABLE(LuauCaptureRecursiveCallsForTablesAndGlobals2)
 
@@ -916,10 +915,7 @@ DataFlowResult DataFlowGraphBuilder::visitExpr(AstExpr* e)
         else if (auto i = e->as<AstExprInterpString>())
             return visitExpr(i);
         else if (auto i = e->as<AstExprInstantiate>())
-        {
-            LUAU_ASSERT(FFlag::LuauExplicitTypeInstantiationSyntax);
             return visitExpr(i);
-        }
         else if (auto error = e->as<AstExprError>())
             return visitExpr(error);
         else

--- a/Analysis/src/Linter.cpp
+++ b/Analysis/src/Linter.cpp
@@ -13,8 +13,6 @@
 #include <climits>
 
 LUAU_FASTINTVARIABLE(LuauSuggestionDistance, 4)
-
-LUAU_FASTFLAG(LuauExplicitTypeInstantiationSyntax)
 LUAU_FASTFLAGVARIABLE(LuauLinterVectorPrimitive)
 
 namespace Luau
@@ -191,7 +189,6 @@ static bool similar(AstExpr* lhs, AstExpr* rhs)
     }
     CASE(AstExprInstantiate)
     {
-        LUAU_ASSERT(FFlag::LuauExplicitTypeInstantiationSyntax);
         return similar(le->expr, re->expr);
     }
     else

--- a/Analysis/src/Module.cpp
+++ b/Analysis/src/Module.cpp
@@ -114,18 +114,8 @@ struct ClonePublicInterface : Substitution
 {
     NotNull<BuiltinTypes> builtinTypes;
     NotNull<Module> module;
-    // NOTE: This can be made non-optional after
-    // LuauUseWorkspacePropToChooseSolver is clipped.
-    std::optional<SolverMode> solverMode{std::nullopt};
+    SolverMode solverMode;
     bool internalTypeEscaped = false;
-
-    ClonePublicInterface(const TxnLog* log, NotNull<BuiltinTypes> builtinTypes, Module* module)
-        : Substitution(log, &module->interfaceTypes)
-        , builtinTypes(builtinTypes)
-        , module(module)
-    {
-        LUAU_ASSERT(module);
-    }
 
     ClonePublicInterface(const TxnLog* log, NotNull<BuiltinTypes> builtinTypes, Module* module, SolverMode solverMode)
         : Substitution(log, &module->interfaceTypes)

--- a/Analysis/src/Subtyping.cpp
+++ b/Analysis/src/Subtyping.cpp
@@ -29,6 +29,7 @@ LUAU_FASTFLAG(LuauUnifyWithSubtyping2)
 LUAU_FASTINTVARIABLE(LuauSubtypingIterationLimit, 20000)
 LUAU_FASTFLAGVARIABLE(LuauSubtypingReplaceBounds)
 LUAU_FASTFLAG(LuauOverloadGetsInstantiated)
+LUAU_FASTFLAGVARIABLE(LuauFollowGenericBeforeCheckingIfMapped)
 
 namespace Luau
 {
@@ -146,7 +147,6 @@ bool MappedGenericEnvironment::bindGeneric(TypePackId genericTp, TypePackId bind
     }
     else
     {
-        LUAU_ASSERT(!"bindGeneric called on a non-bindable generic type pack");
         return false;
     }
 }
@@ -534,6 +534,8 @@ struct ApplyMappedGenerics : Substitution
         {
             for (TypeId g : f->generics)
             {
+                if (FFlag::LuauFollowGenericBeforeCheckingIfMapped)
+                    g = follow(g);
                 if (const std::vector<SubtypingEnvironment::GenericBounds>* bounds = env->mappedGenerics.find(g); bounds && !bounds->empty())
                     // We don't want to mutate the generics of a function that's being subtyped
                     return true;

--- a/Analysis/src/TypeChecker2.cpp
+++ b/Analysis/src/TypeChecker2.cpp
@@ -34,7 +34,6 @@
 
 LUAU_FASTFLAG(DebugLuauMagicTypes)
 
-LUAU_FASTFLAG(LuauExplicitTypeInstantiationSyntax)
 LUAU_FASTFLAG(LuauExplicitTypeInstantiationSupport)
 
 LUAU_FASTFLAG(LuauMorePreciseErrorSuppression)
@@ -1406,10 +1405,7 @@ void TypeChecker2::visit(AstExpr* expr, ValueContext context)
     else if (auto e = expr->as<AstExprIfElse>())
         return visit(e);
     else if (auto e = expr->as<AstExprInstantiate>())
-    {
-        LUAU_ASSERT(FFlag::LuauExplicitTypeInstantiationSyntax);
         return visit(e);
-    }
     else if (auto e = expr->as<AstExprInterpString>())
         return visit(e);
     else if (auto e = expr->as<AstExprError>())
@@ -2693,7 +2689,6 @@ void TypeChecker2::visit(AstExprIfElse* expr)
 
 void TypeChecker2::visit(AstExprInstantiate* explicitTypeInstantiation)
 {
-    LUAU_ASSERT(FFlag::LuauExplicitTypeInstantiationSyntax);
     visit(explicitTypeInstantiation->expr, ValueContext::RValue);
     if (FFlag::LuauExplicitTypeInstantiationSupport)
         checkTypeInstantiation(

--- a/Analysis/src/TypeInfer.cpp
+++ b/Analysis/src/TypeInfer.cpp
@@ -29,7 +29,6 @@ LUAU_FASTINTVARIABLE(LuauTypeInferTypePackLoopLimit, 5000)
 LUAU_FASTINTVARIABLE(LuauCheckRecursionLimit, 300)
 LUAU_FASTINTVARIABLE(LuauVisitRecursionLimit, 500)
 LUAU_FASTFLAG(LuauKnowsTheDataModel3)
-LUAU_FASTFLAG(LuauExplicitTypeInstantiationSyntax)
 LUAU_FASTFLAGVARIABLE(LuauExplicitTypeInstantiationSupport)
 LUAU_FASTFLAGVARIABLE(DebugLuauFreezeDuringUnification)
 LUAU_FASTFLAG(LuauInstantiateInSubtyping)
@@ -1924,10 +1923,7 @@ WithPredicate<TypeId> TypeChecker::checkExpr(const ScopePtr& scope, const AstExp
     else if (auto a = expr.as<AstExprInterpString>())
         result = checkExpr(scope, *a);
     else if (auto a = expr.as<AstExprInstantiate>())
-    {
-        LUAU_ASSERT(FFlag::LuauExplicitTypeInstantiationSyntax);
         result = checkExpr(scope, *a);
-    }
     else
         ice("Unhandled AstExpr?");
 

--- a/Ast/include/Luau/Cst.h
+++ b/Ast/include/Luau/Cst.h
@@ -224,17 +224,6 @@ public:
     Position endPosition;
 };
 
-// Clip with FFlag::LuauCstStatBlock
-class CstStatDo_DEPRECATED : public CstNode
-{
-public:
-    LUAU_CST_RTTI(CstStatDo_DEPRECATED)
-
-    explicit CstStatDo_DEPRECATED(Position endPosition);
-
-    Position endPosition;
-};
-
 class CstStatRepeat : public CstNode
 {
 public:

--- a/Ast/src/Ast.cpp
+++ b/Ast/src/Ast.cpp
@@ -4,8 +4,6 @@
 #include "Luau/Common.h"
 
 
-LUAU_FASTFLAG(LuauExplicitTypeInstantiationSyntax)
-
 namespace Luau
 {
 
@@ -36,8 +34,6 @@ static void visitTypeList(AstVisitor* visitor, const AstTypeList& list)
 
 static void visitTypeOrPackArray(AstVisitor* visitor, const AstArray<AstTypeOrPack>& arrayOfTypeOrPack)
 {
-    LUAU_ASSERT(FFlag::LuauExplicitTypeInstantiationSyntax);
-
     for (const AstTypeOrPack& param : arrayOfTypeOrPack)
     {
         if (param.type)
@@ -240,7 +236,6 @@ AstExprCall::AstExprCall(
     , self(self)
     , argLocation(argLocation)
 {
-    LUAU_ASSERT(FFlag::LuauExplicitTypeInstantiationSyntax || explicitTypes.size == 0);
 }
 
 void AstExprCall::visit(AstVisitor* visitor)
@@ -551,13 +546,10 @@ AstExprInstantiate::AstExprInstantiate(const Location& location, AstExpr* expr, 
     , expr(expr)
     , typeArguments(types)
 {
-    LUAU_ASSERT(FFlag::LuauExplicitTypeInstantiationSyntax);
 }
 
 void AstExprInstantiate::visit(AstVisitor* visitor)
 {
-    LUAU_ASSERT(FFlag::LuauExplicitTypeInstantiationSyntax);
-
     if (visitor->visit(this))
     {
         expr->visit(visitor);
@@ -1100,20 +1092,7 @@ void AstTypeReference::visit(AstVisitor* visitor)
 {
     if (visitor->visit(this))
     {
-        if (FFlag::LuauExplicitTypeInstantiationSyntax)
-        {
-            visitTypeOrPackArray(visitor, parameters);
-        }
-        else
-        {
-            for (const AstTypeOrPack& param : parameters)
-            {
-                if (param.type)
-                    param.type->visit(visitor);
-                else
-                    param.typePack->visit(visitor);
-            }
-        }
+        visitTypeOrPackArray(visitor, parameters);
     }
 }
 

--- a/Ast/src/Cst.cpp
+++ b/Ast/src/Cst.cpp
@@ -3,8 +3,6 @@
 #include "Luau/Cst.h"
 #include "Luau/Common.h"
 
-LUAU_FASTFLAG(LuauCstStatDoWithStatsStart)
-
 namespace Luau
 {
 
@@ -89,14 +87,6 @@ CstStatDo::CstStatDo(Position statsStartPosition, Position endPosition)
     , statsStartPosition(statsStartPosition)
     , endPosition(endPosition)
 {
-    LUAU_ASSERT(FFlag::LuauCstStatDoWithStatsStart);
-}
-
-CstStatDo_DEPRECATED::CstStatDo_DEPRECATED(Position endPosition)
-    : CstNode(CstClassIndex())
-    , endPosition(endPosition)
-{
-    LUAU_ASSERT(!FFlag::LuauCstStatDoWithStatsStart);
 }
 
 CstStatRepeat::CstStatRepeat(Position untilPosition)

--- a/Ast/src/Parser.cpp
+++ b/Ast/src/Parser.cpp
@@ -19,8 +19,6 @@ LUAU_FASTINTVARIABLE(LuauParseErrorLimit, 100)
 // See docs/SyntaxChanges.md for an explanation.
 LUAU_FASTFLAGVARIABLE(LuauSolverV2)
 LUAU_DYNAMIC_FASTFLAGVARIABLE(DebugLuauReportReturnTypeVariadicWithTypeSuffix, false)
-LUAU_FASTFLAGVARIABLE(LuauExplicitTypeInstantiationSyntax)
-LUAU_FASTFLAGVARIABLE(LuauCstStatDoWithStatsStart)
 LUAU_FASTFLAGVARIABLE(DesugaredArrayTypeReferenceIsEmpty)
 LUAU_FASTFLAGVARIABLE(LuauConst2)
 LUAU_FASTFLAGVARIABLE(DebugLuauNoInline)
@@ -637,43 +635,24 @@ AstStat* Parser::parseDo()
     Lexeme matchDo = lexer.current();
     nextLexeme(); // do
 
-    if (FFlag::LuauCstStatDoWithStatsStart)
+    std::optional<Location> statsStart = options.storeCstData ? std::optional{lexer.current().location} : std::nullopt;
+
+    AstStatBlock* body = parseBlock();
+
+    body->location.begin = start.begin;
+
+    Location endLocation = lexer.current().location;
+    body->hasEnd = expectMatchEndAndConsume(Lexeme::ReservedEnd, matchDo);
+    if (body->hasEnd)
+        body->location.end = endLocation.end;
+
+    if (options.storeCstData)
     {
-        std::optional<Location> statsStart = options.storeCstData ? std::optional{lexer.current().location} : std::nullopt;
-
-        AstStatBlock* body = parseBlock();
-
-        body->location.begin = start.begin;
-
-        Location endLocation = lexer.current().location;
-        body->hasEnd = expectMatchEndAndConsume(Lexeme::ReservedEnd, matchDo);
-        if (body->hasEnd)
-            body->location.end = endLocation.end;
-
-        if (options.storeCstData)
-        {
-            LUAU_ASSERT(statsStart);
-            cstNodeMap[body] = allocator.alloc<CstStatDo>(statsStart->begin, endLocation.begin);
-        }
-
-        return body;
+        LUAU_ASSERT(statsStart);
+        cstNodeMap[body] = allocator.alloc<CstStatDo>(statsStart->begin, endLocation.begin);
     }
-    else
-    {
-        AstStatBlock* body = parseBlock();
 
-        body->location.begin = start.begin;
-
-        Location endLocation = lexer.current().location;
-        body->hasEnd = expectMatchEndAndConsume(Lexeme::ReservedEnd, matchDo);
-        if (body->hasEnd)
-            body->location.end = endLocation.end;
-
-        if (options.storeCstData)
-            cstNodeMap[body] = allocator.alloc<CstStatDo_DEPRECATED>(endLocation.begin);
-
-        return body;
-    }
+    return body;
 }
 
 // break
@@ -3253,7 +3232,7 @@ AstExpr* Parser::parsePrimaryExpr(bool asStatement)
         {
             expr = parseFunctionArgs(expr, false);
         }
-        else if (FFlag::LuauExplicitTypeInstantiationSyntax && lexer.current().type == '<' && lexer.lookahead().type == '<')
+        else if (lexer.current().type == '<' && lexer.lookahead().type == '<')
         {
             expr = parseExplicitTypeInstantiationExpr(start, *expr);
         }
@@ -3279,37 +3258,30 @@ AstExpr* Parser::parseMethodCall(Position start, AstExpr* expr)
     Name index = parseIndexName("method name", opPosition);
     AstExpr* func = allocator.alloc<AstExprIndexName>(Location(start, index.location.end), expr, index.name, index.location, opPosition, ':');
 
-    if (FFlag::LuauExplicitTypeInstantiationSyntax)
+    AstArray<AstTypeOrPack> typeArguments;
+    CstTypeInstantiation* cstTypeArguments = options.storeCstData ? allocator.alloc<CstTypeInstantiation>() : nullptr;
+
+    if (lexer.current().type == '<' && lexer.lookahead().type == '<')
     {
-        AstArray<AstTypeOrPack> typeArguments;
-        CstTypeInstantiation* cstTypeArguments = options.storeCstData ? allocator.alloc<CstTypeInstantiation>() : nullptr;
-
-        if (lexer.current().type == '<' && lexer.lookahead().type == '<')
-        {
-            typeArguments = parseTypeInstantiationExpr(cstTypeArguments);
-        }
-
-        expr = parseFunctionArgs(func, true);
-
-        if (options.storeCstData)
-        {
-            CstNode** cstNode = cstNodeMap.find(expr);
-            if (cstNode)
-            {
-                CstExprCall* exprCall = (*cstNode)->as<CstExprCall>();
-                LUAU_ASSERT(exprCall);
-                exprCall->explicitTypes = cstTypeArguments;
-            }
-        }
-
-        // If we have an AstExprCall, fill in the type arguments
-        if (auto call = expr->as<AstExprCall>(); call && typeArguments.size > 0)
-            call->typeArguments = typeArguments;
+        typeArguments = parseTypeInstantiationExpr(cstTypeArguments);
     }
-    else
+
+    expr = parseFunctionArgs(func, true);
+
+    if (options.storeCstData)
     {
-        expr = parseFunctionArgs(func, true);
+        CstNode** cstNode = cstNodeMap.find(expr);
+        if (cstNode)
+        {
+            CstExprCall* exprCall = (*cstNode)->as<CstExprCall>();
+            LUAU_ASSERT(exprCall);
+            exprCall->explicitTypes = cstTypeArguments;
+        }
     }
+
+    // If we have an AstExprCall, fill in the type arguments
+    if (auto call = expr->as<AstExprCall>(); call && typeArguments.size > 0)
+        call->typeArguments = typeArguments;
 
     return expr;
 }
@@ -4258,8 +4230,6 @@ LUAU_NOINLINE AstExpr* Parser::parseExplicitTypeInstantiationExpr(Position start
 
 AstArray<AstTypeOrPack> Parser::parseTypeInstantiationExpr(CstTypeInstantiation* cstNodeOut, Location* endLocationOut)
 {
-    LUAU_ASSERT(FFlag::LuauExplicitTypeInstantiationSyntax);
-
     LUAU_ASSERT(lexer.current().type == '<' && lexer.lookahead().type == '<');
 
     if (cstNodeOut)

--- a/Ast/src/PrettyPrinter.cpp
+++ b/Ast/src/PrettyPrinter.cpp
@@ -10,8 +10,6 @@
 #include <math.h>
 
 LUAU_FASTFLAG(DebugLuauNoInline)
-LUAU_FASTFLAG(LuauExplicitTypeInstantiationSyntax)
-LUAU_FASTFLAG(LuauCstStatDoWithStatsStart)
 
 namespace
 {
@@ -542,12 +540,9 @@ struct Printer
 
             const auto cstNode = lookupCstNode<CstExprCall>(a);
 
-            if (FFlag::LuauExplicitTypeInstantiationSyntax)
+            if (writeTypes && (a->typeArguments.size > 0 || (cstNode && cstNode->explicitTypes)))
             {
-                if (writeTypes && (a->typeArguments.size > 0 || (cstNode && cstNode->explicitTypes)))
-                {
-                    visualizeExplicitTypeInstantiation(a->typeArguments, cstNode && cstNode->explicitTypes ? cstNode->explicitTypes : nullptr);
-                }
+                visualizeExplicitTypeInstantiation(a->typeArguments, cstNode && cstNode->explicitTypes ? cstNode->explicitTypes : nullptr);
             }
 
             if (cstNode)
@@ -832,8 +827,6 @@ struct Printer
         }
         else if (const auto& a = expr.as<AstExprInstantiate>())
         {
-            LUAU_ASSERT(FFlag::LuauExplicitTypeInstantiationSyntax);
-
             visualize(*a->expr);
 
             if (writeTypes)
@@ -877,44 +870,25 @@ struct Printer
 
         if (const auto& block = program.as<AstStatBlock>())
         {
-            if (FFlag::LuauCstStatDoWithStatsStart)
+            if (const auto cstNode = lookupCstNode<CstStatDo>(block))
             {
-                if (const auto cstNode = lookupCstNode<CstStatDo>(block))
-                {
-                    writer.keyword("do");
+                writer.keyword("do");
 
-                    advance(cstNode->statsStartPosition);
+                advance(cstNode->statsStartPosition);
 
-                    for (const auto& s : block->body)
-                        visualize(*s);
+                for (const auto& s : block->body)
+                    visualize(*s);
 
-                    advance(cstNode->endPosition);
-                    writer.keyword("end");
-                }
-                else
-                {
-                    for (const auto& s : block->body)
-                        visualize(*s);
-
-                    writer.advance(block->location.end);
-                    writeEnd(program.location);
-                }
+                advance(cstNode->endPosition);
+                writer.keyword("end");
             }
             else
             {
-                writer.keyword("do");
                 for (const auto& s : block->body)
                     visualize(*s);
-                if (const auto cstNode = lookupCstNode<CstStatDo_DEPRECATED>(block))
-                {
-                    advance(cstNode->endPosition);
-                    writer.keyword("end");
-                }
-                else
-                {
-                    writer.advance(block->location.end);
-                    writeEnd(program.location);
-                }
+
+                writer.advance(block->location.end);
+                writeEnd(program.location);
             }
         }
         else if (const auto& a = program.as<AstStatIf>())
@@ -1900,8 +1874,6 @@ struct Printer
 
     void visualizeExplicitTypeInstantiation(const AstArray<AstTypeOrPack>& typeArguments, const CstTypeInstantiation* cstNode)
     {
-        LUAU_ASSERT(FFlag::LuauExplicitTypeInstantiationSyntax);
-
         if (cstNode)
         {
             advance(cstNode->leftArrow1Position);

--- a/CLI/src/Compile.cpp
+++ b/CLI/src/Compile.cpp
@@ -293,7 +293,13 @@ static double recordDeltaTime(double& timer)
     return delta;
 }
 
-static bool compileFile(const char* name, CompileFormat format, Luau::CodeGen::AssemblyOptions::Target assemblyTarget, CompileStats& stats)
+static bool compileFile(
+    const char* name,
+    CompileFormat format,
+    Luau::CodeGen::AssemblyOptions::Target assemblyTarget,
+    CompileStats& stats,
+    bool dumpConstants
+)
 {
     double currts = Luau::TimeTrace::getClock();
 
@@ -330,10 +336,11 @@ static bool compileFile(const char* name, CompileFormat format, Luau::CodeGen::A
 
         if (format == CompileFormat::Text)
         {
-            bcb.setDumpFlags(
-                Luau::BytecodeBuilder::Dump_Code | Luau::BytecodeBuilder::Dump_Source | Luau::BytecodeBuilder::Dump_Locals |
-                Luau::BytecodeBuilder::Dump_Remarks | Luau::BytecodeBuilder::Dump_Types
-            );
+            uint32_t flags = Luau::BytecodeBuilder::Dump_Code | Luau::BytecodeBuilder::Dump_Source | Luau::BytecodeBuilder::Dump_Locals |
+                             Luau::BytecodeBuilder::Dump_Remarks | Luau::BytecodeBuilder::Dump_Types;
+            if (dumpConstants)
+                flags |= Luau::BytecodeBuilder::Dump_Constants;
+            bcb.setDumpFlags(flags);
             bcb.setDumpSource(*source);
         }
         else if (format == CompileFormat::Remarks)
@@ -423,6 +430,7 @@ static void displayHelp(const char* argv0)
     printf("  --timetrace: record compiler time tracing information into trace.json\n");
     printf("  --record-stats=<granularity>: granularity of compilation stats (total, file, function).\n");
     printf("  --bytecode-summary: Compute bytecode operation distribution.\n");
+    printf("  --dump-constants: Dump constant table for each function (text mode only).\n");
     printf("  --stats-file=<filename>: file in which compilation stats will be recored (default 'stats.json').\n");
     printf("  --vector-lib=<name>: name of the library providing vector type operations.\n");
     printf("  --vector-ctor=<name>: name of the function constructing a vector value.\n");
@@ -471,6 +479,7 @@ int main(int argc, char** argv)
     RecordStats recordStats = RecordStats::None;
     std::string statsFile("stats.json");
     bool bytecodeSummary = false;
+    bool dumpConstants = false;
 
     for (int i = 1; i < argc; i++)
     {
@@ -551,6 +560,10 @@ int main(int argc, char** argv)
         {
             bytecodeSummary = true;
         }
+        else if (strcmp(argv[i], "--dump-constants") == 0)
+        {
+            dumpConstants = true;
+        }
         else if (strncmp(argv[i], "--stats-file=", 13) == 0)
         {
             statsFile = argv[i] + 13;
@@ -624,7 +637,7 @@ int main(int argc, char** argv)
     {
         CompileStats fileStat = {};
         fileStat.lowerStats.functionStatsFlags = functionStats;
-        failed += !compileFile(path.c_str(), compileFormat, assemblyTarget, fileStat);
+        failed += !compileFile(path.c_str(), compileFormat, assemblyTarget, fileStat, dumpConstants);
         stats += fileStat;
         if (recordStats == RecordStats::File || recordStats == RecordStats::Function)
             fileStats.push_back(fileStat);

--- a/CodeGen/include/Luau/IrUtils.h
+++ b/CodeGen/include/Luau/IrUtils.h
@@ -5,7 +5,7 @@
 #include "Luau/Common.h"
 #include "Luau/IrData.h"
 
-LUAU_FASTFLAG(LuauCodegenMarkDeadRegisters)
+LUAU_FASTFLAG(LuauCodegenMarkDeadRegisters2)
 LUAU_FASTFLAG(LuauCodegenDseOnCondJump)
 
 namespace Luau
@@ -223,7 +223,7 @@ inline bool canInvalidateSafeEnv(IrCmd cmd)
 inline bool isPseudo(IrCmd cmd)
 {
     // Instructions that are used for internal needs and are not a part of final lowering
-    if (FFlag::LuauCodegenMarkDeadRegisters || FFlag::LuauCodegenDseOnCondJump)
+    if (FFlag::LuauCodegenMarkDeadRegisters2 || FFlag::LuauCodegenDseOnCondJump)
         return cmd == IrCmd::NOP || cmd == IrCmd::SUBSTITUTE || cmd == IrCmd::MARK_USED || cmd == IrCmd::MARK_DEAD;
     else
         return cmd == IrCmd::NOP || cmd == IrCmd::SUBSTITUTE;

--- a/CodeGen/src/IrLoweringA64.cpp
+++ b/CodeGen/src/IrLoweringA64.cpp
@@ -13,7 +13,7 @@
 #include "lgc.h"
 
 LUAU_FASTFLAG(LuauCodegenBlockSafeEnv)
-LUAU_FASTFLAG(LuauCodegenBufferRangeMerge3)
+LUAU_FASTFLAG(LuauCodegenBufferRangeMerge4)
 LUAU_FASTFLAGVARIABLE(LuauCodegenOpReadOnly)
 LUAU_FASTFLAG(LuauCodegenCounterSupport)
 LUAU_FASTFLAGVARIABLE(LuauCodegenA64ClosureOffset)
@@ -2197,7 +2197,7 @@ void IrLoweringA64::lowerInst(IrInst& inst, uint32_t index, const IrBlock& next)
     }
     case IrCmd::CHECK_BUFFER_LEN:
     {
-        if (FFlag::LuauCodegenBufferRangeMerge3)
+        if (FFlag::LuauCodegenBufferRangeMerge4)
         {
             int minOffset = intOp(OP_C(inst));
             int maxOffset = intOp(OP_D(inst));

--- a/CodeGen/src/IrLoweringX64.cpp
+++ b/CodeGen/src/IrLoweringX64.cpp
@@ -17,7 +17,7 @@
 #include "lgc.h"
 
 LUAU_FASTFLAG(LuauCodegenBlockSafeEnv)
-LUAU_FASTFLAG(LuauCodegenBufferRangeMerge3)
+LUAU_FASTFLAG(LuauCodegenBufferRangeMerge4)
 LUAU_FASTFLAG(LuauCodegenOpReadOnly)
 LUAU_FASTFLAG(LuauCodegenIsNanAndDirectCompare)
 LUAU_FASTFLAG(LuauCodegenCounterSupport)
@@ -2011,7 +2011,7 @@ void IrLoweringX64::lowerInst(IrInst& inst, uint32_t index, const IrBlock& next)
     }
     case IrCmd::CHECK_BUFFER_LEN:
     {
-        if (FFlag::LuauCodegenBufferRangeMerge3)
+        if (FFlag::LuauCodegenBufferRangeMerge4)
         {
             int minOffset = intOp(OP_C(inst));
             int maxOffset = intOp(OP_D(inst));

--- a/CodeGen/src/IrTranslateBuiltins.cpp
+++ b/CodeGen/src/IrTranslateBuiltins.cpp
@@ -8,7 +8,7 @@
 
 #include <math.h>
 
-LUAU_FASTFLAG(LuauCodegenBufferRangeMerge3)
+LUAU_FASTFLAG(LuauCodegenBufferRangeMerge4)
 LUAU_FASTFLAGVARIABLE(LuauCodegenBit32SingleArg)
 LUAU_FASTFLAG(LuauCodegenIsNanAndDirectCompare)
 
@@ -921,7 +921,7 @@ static void translateBufferArgsAndCheckBounds(
     IrOp numIndex = builtinLoadDouble(build, args);
     intIndex = build.inst(IrCmd::NUM_TO_INT, numIndex);
 
-    if (FFlag::LuauCodegenBufferRangeMerge3)
+    if (FFlag::LuauCodegenBufferRangeMerge4)
         build.inst(IrCmd::CHECK_BUFFER_LEN, buf, intIndex, build.constInt(0), build.constInt(size), build.undef(), build.vmExit(pcpos));
     else
         build.inst(IrCmd::CHECK_BUFFER_LEN, buf, intIndex, build.constInt(size), build.vmExit(pcpos));

--- a/CodeGen/src/IrTranslation.cpp
+++ b/CodeGen/src/IrTranslation.cpp
@@ -15,7 +15,7 @@
 LUAU_FASTFLAG(LuauCodegenBlockSafeEnv)
 LUAU_FASTFLAG(LuauCodegenCounterSupport)
 LUAU_FASTFLAG(LuauCodegenDseOnCondJump)
-LUAU_FASTFLAG(LuauCodegenMarkDeadRegisters)
+LUAU_FASTFLAG(LuauCodegenMarkDeadRegisters2)
 
 namespace Luau
 {
@@ -1014,7 +1014,7 @@ IrOp translateFastCallN(IrBuilder& build, const Instruction* pc, int pcpos, bool
 
         if (nresults == LUA_MULTRET)
             build.inst(IrCmd::ADJUST_STACK_TO_REG, build.vmReg(ra), build.constInt(br.actualResultCount));
-        else if (FFlag::LuauCodegenMarkDeadRegisters)
+        else if (FFlag::LuauCodegenMarkDeadRegisters2)
             build.inst(IrCmd::MARK_DEAD, build.vmReg(ra + 1), build.constInt(-1));
 
         if (br.type != BuiltinImplType::UsesFallback)

--- a/CodeGen/src/IrUtils.cpp
+++ b/CodeGen/src/IrUtils.cpp
@@ -16,7 +16,7 @@
 #include <limits.h>
 #include <math.h>
 
-LUAU_FASTFLAG(LuauCodegenBufferRangeMerge3)
+LUAU_FASTFLAG(LuauCodegenBufferRangeMerge4)
 LUAU_FASTFLAGVARIABLE(LuauCodegenTruncatedSubsts)
 
 namespace Luau
@@ -1358,7 +1358,7 @@ void foldConstants(IrBuilder& build, IrFunction& function, IrBlock& block, uint3
             substitute(function, inst, build.constInt(countrz(unsigned(function.intOp(OP_A(inst))))));
         break;
     case IrCmd::CHECK_BUFFER_LEN:
-        if (FFlag::LuauCodegenBufferRangeMerge3)
+        if (FFlag::LuauCodegenBufferRangeMerge4)
         {
             if (OP_B(inst).kind == IrOpKind::Constant && OP_E(inst).kind == IrOpKind::Constant)
             {

--- a/CodeGen/src/OptimizeConstProp.cpp
+++ b/CodeGen/src/OptimizeConstProp.cpp
@@ -26,7 +26,7 @@ LUAU_FASTFLAG(LuauCodegenDsoPairTrackFix)
 LUAU_FASTFLAGVARIABLE(DebugLuauAbortingChecks)
 LUAU_FASTFLAGVARIABLE(LuauCodegenBlockSafeEnv)
 LUAU_FASTFLAGVARIABLE(LuauCodegenSetBlockEntryState2)
-LUAU_FASTFLAGVARIABLE(LuauCodegenBufferRangeMerge3)
+LUAU_FASTFLAGVARIABLE(LuauCodegenBufferRangeMerge4)
 LUAU_FASTFLAGVARIABLE(LuauCodegenTableLoadProp2)
 LUAU_FASTFLAGVARIABLE(LuauCodegenExtraBlockers)
 LUAU_FASTFLAGVARIABLE(LuauCodegenLengthBaseInst)
@@ -842,7 +842,8 @@ struct ConstPropState
 
         if (newMinOffset != prevMinOffset)
             replace(function, OP_C(prevCheck), build.constInt(newMinOffset));
-        else if (newMaxOffset != prevMaxOffset)
+
+        if (newMaxOffset != prevMaxOffset)
             replace(function, OP_D(prevCheck), build.constInt(newMaxOffset));
 
         kill(function, currCheck);
@@ -2199,7 +2200,7 @@ static void constPropInInst(ConstPropState& state, IrBuilder& build, IrFunction&
     {
         std::optional<int> bufferOffset = function.asIntOp(OP_B(inst).kind == IrOpKind::Constant ? OP_B(inst) : state.tryGetValue(OP_B(inst)));
 
-        if (FFlag::LuauCodegenBufferRangeMerge3)
+        if (FFlag::LuauCodegenBufferRangeMerge4)
         {
             int minOffset = function.intOp(OP_C(inst));
             int maxOffset = function.intOp(OP_D(inst));
@@ -2776,7 +2777,7 @@ static void constPropInInst(ConstPropState& state, IrBuilder& build, IrFunction&
             break;
         }
 
-        if (FFlag::LuauCodegenBufferRangeMerge3 && src && src->cmd == IrCmd::ADD_NUM)
+        if (FFlag::LuauCodegenBufferRangeMerge4 && src && src->cmd == IrCmd::ADD_NUM)
         {
             if (std::optional<double> arg = function.asDoubleOp(OP_B(src)); arg && *arg == 0.0)
             {

--- a/CodeGen/src/OptimizeDeadStore.cpp
+++ b/CodeGen/src/OptimizeDeadStore.cpp
@@ -10,12 +10,12 @@
 #include "lobject.h"
 
 LUAU_FASTFLAGVARIABLE(LuauCodegenGcoDse2)
-LUAU_FASTFLAG(LuauCodegenBufferRangeMerge3)
+LUAU_FASTFLAG(LuauCodegenBufferRangeMerge4)
 LUAU_FASTFLAGVARIABLE(LuauCodegenDsoPairTrackFix)
 LUAU_FASTFLAGVARIABLE(LuauCodegenDsoTagOverlayFix)
 LUAU_FASTFLAG(LuauCodegenOpReadOnly)
 LUAU_FASTFLAG(LuauCodegenSafeEnvPreserve)
-LUAU_FASTFLAGVARIABLE(LuauCodegenMarkDeadRegisters)
+LUAU_FASTFLAGVARIABLE(LuauCodegenMarkDeadRegisters2)
 LUAU_FASTFLAGVARIABLE(LuauCodegenDseOnCondJump)
 
 // TODO: optimization can be improved by knowing which registers are live in at each VM exit
@@ -208,7 +208,7 @@ struct RemoveDeadStoreState
     {
         if (op.kind == IrOpKind::VmExit)
         {
-            if (FFlag::LuauCodegenMarkDeadRegisters)
+            if (FFlag::LuauCodegenMarkDeadRegisters2)
             {
                 for (int i = 0; i <= maxReg; i++)
                 {
@@ -284,9 +284,10 @@ struct RemoveDeadStoreState
 
     void markUnusedAtExit(int start, int count)
     {
-        CODEGEN_ASSERT(FFlag::LuauCodegenMarkDeadRegisters);
+        CODEGEN_ASSERT(FFlag::LuauCodegenMarkDeadRegisters2);
+        CODEGEN_ASSERT(count != 0);
 
-        int e = count == -1 ? maxReg : start + count;
+        int e = count == -1 ? maxReg : start + count - 1;
 
         for (int i = start; i <= e; i++)
         {
@@ -739,6 +740,9 @@ static void markDeadStoresInInst(RemoveDeadStoreState& state, IrBuilder& build, 
 
             StoreRegInfo& regInfo = state.info[reg];
 
+            if (FFlag::LuauCodegenMarkDeadRegisters2)
+                regInfo.ignoreAtExit = false;
+
             if (tryReplaceTagWithFullStore(state, build, function, block, index, OP_A(inst), OP_B(inst), regInfo))
                 break;
 
@@ -758,7 +762,20 @@ static void markDeadStoresInInst(RemoveDeadStoreState& state, IrBuilder& build, 
         // To simplify, extra field store is preserved along with all other stores made so far
         if (OP_A(inst).kind == IrOpKind::VmReg)
         {
-            state.useReg(vmRegOp(OP_A(inst)));
+            if (FFlag::LuauCodegenMarkDeadRegisters2)
+            {
+                int reg = vmRegOp(OP_A(inst));
+
+                state.useReg(reg);
+
+                StoreRegInfo& regInfo = state.info[reg];
+
+                regInfo.ignoreAtExit = false;
+            }
+            else
+            {
+                state.useReg(vmRegOp(OP_A(inst)));
+            }
         }
         break;
     case IrCmd::STORE_POINTER:
@@ -770,6 +787,9 @@ static void markDeadStoresInInst(RemoveDeadStoreState& state, IrBuilder& build, 
                 return;
 
             StoreRegInfo& regInfo = state.info[reg];
+
+            if (FFlag::LuauCodegenMarkDeadRegisters2)
+                regInfo.ignoreAtExit = false;
 
             if (tryReplaceValueWithFullStore(state, build, function, block, index, OP_A(inst), OP_B(inst), regInfo))
             {
@@ -802,6 +822,9 @@ static void markDeadStoresInInst(RemoveDeadStoreState& state, IrBuilder& build, 
 
             StoreRegInfo& regInfo = state.info[reg];
 
+            if (FFlag::LuauCodegenMarkDeadRegisters2)
+                regInfo.ignoreAtExit = false;
+
             if (tryReplaceValueWithFullStore(state, build, function, block, index, OP_A(inst), OP_B(inst), regInfo))
                 break;
 
@@ -827,6 +850,9 @@ static void markDeadStoresInInst(RemoveDeadStoreState& state, IrBuilder& build, 
 
             StoreRegInfo& regInfo = state.info[reg];
 
+            if (FFlag::LuauCodegenMarkDeadRegisters2)
+                regInfo.ignoreAtExit = false;
+
             if (tryReplaceVectorValueWithFullStore(state, build, function, block, index, regInfo))
                 break;
 
@@ -851,6 +877,9 @@ static void markDeadStoresInInst(RemoveDeadStoreState& state, IrBuilder& build, 
                 return;
 
             StoreRegInfo& regInfo = state.info[reg];
+
+            if (FFlag::LuauCodegenMarkDeadRegisters2)
+                regInfo.ignoreAtExit = false;
 
             state.killTagAndValueStorePair(regInfo);
             state.killTValueStore(regInfo);
@@ -900,6 +929,9 @@ static void markDeadStoresInInst(RemoveDeadStoreState& state, IrBuilder& build, 
                 return;
 
             StoreRegInfo& regInfo = state.info[reg];
+
+            if (FFlag::LuauCodegenMarkDeadRegisters2)
+                regInfo.ignoreAtExit = false;
 
             state.killTagAndValueStorePair(regInfo);
             state.killTValueStore(regInfo);
@@ -965,7 +997,7 @@ static void markDeadStoresInInst(RemoveDeadStoreState& state, IrBuilder& build, 
         state.checkLiveIns(OP_B(inst));
         break;
     case IrCmd::CHECK_BUFFER_LEN:
-        if (FFlag::LuauCodegenBufferRangeMerge3)
+        if (FFlag::LuauCodegenBufferRangeMerge4)
             state.checkLiveIns(OP_F(inst));
         else
             state.checkLiveIns(OP_D(inst));
@@ -1038,7 +1070,7 @@ static void markDeadStoresInInst(RemoveDeadStoreState& state, IrBuilder& build, 
         break;
 
     case IrCmd::MARK_DEAD:
-        if (FFlag::LuauCodegenMarkDeadRegisters)
+        if (FFlag::LuauCodegenMarkDeadRegisters2)
             state.markUnusedAtExit(vmRegOp(OP_A(inst)), function.intOp(OP_B(inst)));
         break;
 

--- a/Compiler/include/Luau/BytecodeBuilder.h
+++ b/Compiler/include/Luau/BytecodeBuilder.h
@@ -110,6 +110,7 @@ public:
         Dump_Locals = 1 << 3,
         Dump_Remarks = 1 << 4,
         Dump_Types = 1 << 5,
+        Dump_Constants = 1 << 6,
     };
 
     void setDumpFlags(uint32_t flags)

--- a/Compiler/src/BytecodeBuilder.cpp
+++ b/Compiler/src/BytecodeBuilder.cpp
@@ -7,7 +7,7 @@
 #include <algorithm>
 #include <string.h>
 
-LUAU_FASTFLAG(LuauCompileDuptableConstantPack)
+LUAU_FASTFLAG(LuauCompileDuptableConstantPack2)
 
 namespace Luau
 {
@@ -143,7 +143,7 @@ bool BytecodeBuilder::StringRef::operator==(const StringRef& other) const
 
 bool BytecodeBuilder::TableShape::operator==(const TableShape& other) const
 {
-    if (!FFlag::LuauCompileDuptableConstantPack)
+    if (!FFlag::LuauCompileDuptableConstantPack2)
     {
 
         return length == other.length && memcmp(keys, other.keys, length * sizeof(keys[0])) == 0;
@@ -217,7 +217,7 @@ size_t BytecodeBuilder::TableShapeHash::operator()(const TableShape& v) const
         hash ^= v.keys[i];
         hash *= 16777619;
 
-        if (FFlag::LuauCompileDuptableConstantPack && v.hasConstants)
+        if (FFlag::LuauCompileDuptableConstantPack2 && v.hasConstants)
         {
             hash ^= v.constants[i];
             hash *= 16777619;
@@ -840,7 +840,7 @@ void BytecodeBuilder::writeFunction(std::string& ss, uint32_t id, uint8_t flags)
         case Constant::Type_Table:
         {
             const TableShape& shape = tableShapes[c.valueTable];
-            if (FFlag::LuauCompileDuptableConstantPack && shape.hasConstants)
+            if (FFlag::LuauCompileDuptableConstantPack2 && shape.hasConstants)
             {
                 writeByte(ss, LBC_CONSTANT_TABLE_WITH_CONSTANTS);
                 writeVarInt(ss, uint32_t(shape.length));
@@ -1290,7 +1290,7 @@ std::string BytecodeBuilder::getError(const std::string& message)
 uint8_t BytecodeBuilder::getVersion()
 {
     // LBC_CONSTANT_TABLE_WITH_CONSTANTS requires version 7
-    if (FFlag::LuauCompileDuptableConstantPack)
+    if (FFlag::LuauCompileDuptableConstantPack2)
         return 7;
 
     return LBC_VERSION_TARGET;
@@ -2395,7 +2395,7 @@ static const char* getBaseTypeString(uint8_t type)
 
 std::string BytecodeBuilder::dumpCurrentFunction(std::vector<int>& dumpinstoffs) const
 {
-    if ((dumpFlags & Dump_Code) == 0)
+    if ((dumpFlags & (Dump_Code | Dump_Constants)) == 0)
         return std::string();
 
     int lastLine = -1;
@@ -2476,82 +2476,95 @@ std::string BytecodeBuilder::dumpCurrentFunction(std::vector<int>& dumpinstoffs)
         }
     }
 
-    std::vector<int> labels(insns.size(), -1);
-
-    // annotate valid jump targets with 0
-    for (size_t i = 0; i < insns.size();)
+    if (dumpFlags & Dump_Constants)
     {
-        int target = getJumpTarget(insns[i], uint32_t(i));
-
-        if (target >= 0)
+        for (size_t i = 0; i < constants.size(); ++i)
         {
-            LUAU_ASSERT(size_t(target) < insns.size());
-            labels[target] = 0;
+            formatAppend(result, "K%d: ", int(i));
+            dumpConstant(result, int(i));
+            formatAppend(result, "\n");
         }
-
-        i += getOpLength(LuauOpcode(LUAU_INSN_OP(insns[i])));
-        LUAU_ASSERT(i <= insns.size());
     }
 
-    int nextLabel = 0;
-
-    // compute label ids (sequential integers for all jump targets)
-    for (size_t i = 0; i < labels.size(); ++i)
-        if (labels[i] == 0)
-            labels[i] = nextLabel++;
-
-    dumpinstoffs.resize(insns.size() + 1, -1);
-
-    for (size_t i = 0; i < insns.size();)
+    if (dumpFlags & Dump_Code)
     {
-        const uint32_t* code = &insns[i];
-        uint8_t op = LUAU_INSN_OP(*code);
+        std::vector<int> labels(insns.size(), -1);
 
-        dumpinstoffs[i] = int(result.size());
-
-        if (op == LOP_PREPVARARGS)
+        // annotate valid jump targets with 0
+        for (size_t i = 0; i < insns.size();)
         {
-            // Don't emit function header in bytecode - it's used for call dispatching and doesn't contain "interesting" information
-            i++;
-            continue;
-        }
+            int target = getJumpTarget(insns[i], uint32_t(i));
 
-        if (dumpFlags & Dump_Remarks)
-        {
-            while (nextRemark < debugRemarks.size() && debugRemarks[nextRemark].first == i)
+            if (target >= 0)
             {
-                formatAppend(result, "REMARK %s\n", debugRemarkBuffer.c_str() + debugRemarks[nextRemark].second);
-                nextRemark++;
+                LUAU_ASSERT(size_t(target) < insns.size());
+                labels[target] = 0;
             }
+
+            i += getOpLength(LuauOpcode(LUAU_INSN_OP(insns[i])));
+            LUAU_ASSERT(i <= insns.size());
         }
 
-        if (dumpFlags & Dump_Source)
+        int nextLabel = 0;
+
+        // compute label ids (sequential integers for all jump targets)
+        for (size_t i = 0; i < labels.size(); ++i)
+            if (labels[i] == 0)
+                labels[i] = nextLabel++;
+
+        dumpinstoffs.resize(insns.size() + 1, -1);
+
+        for (size_t i = 0; i < insns.size();)
         {
-            int line = lines[i];
+            const uint32_t* code = &insns[i];
+            uint8_t op = LUAU_INSN_OP(*code);
 
-            if (line > 0 && line != lastLine)
+            dumpinstoffs[i] = int(result.size());
+
+            if (op == LOP_PREPVARARGS)
             {
-                LUAU_ASSERT(size_t(line - 1) < dumpSource.size());
-                formatAppend(result, "%5d: %s\n", line, dumpSource[line - 1].c_str());
-                lastLine = line;
+                // Don't emit function header in bytecode - it's used for call dispatching and doesn't contain "interesting" information
+                i++;
+                continue;
             }
+
+            if (dumpFlags & Dump_Remarks)
+            {
+                while (nextRemark < debugRemarks.size() && debugRemarks[nextRemark].first == i)
+                {
+                    formatAppend(result, "REMARK %s\n", debugRemarkBuffer.c_str() + debugRemarks[nextRemark].second);
+                    nextRemark++;
+                }
+            }
+
+            if (dumpFlags & Dump_Source)
+            {
+                int line = lines[i];
+
+                if (line > 0 && line != lastLine)
+                {
+                    LUAU_ASSERT(size_t(line - 1) < dumpSource.size());
+                    formatAppend(result, "%5d: %s\n", line, dumpSource[line - 1].c_str());
+                    lastLine = line;
+                }
+            }
+
+            if (dumpFlags & Dump_Lines)
+                formatAppend(result, "%d: ", lines[i]);
+
+            if (labels[i] != -1)
+                formatAppend(result, "L%d: ", labels[i]);
+
+            int target = getJumpTarget(*code, uint32_t(i));
+
+            dumpInstruction(code, result, target >= 0 ? labels[target] : -1);
+
+            i += getOpLength(LuauOpcode(op));
+            LUAU_ASSERT(i <= insns.size());
         }
 
-        if (dumpFlags & Dump_Lines)
-            formatAppend(result, "%d: ", lines[i]);
-
-        if (labels[i] != -1)
-            formatAppend(result, "L%d: ", labels[i]);
-
-        int target = getJumpTarget(*code, uint32_t(i));
-
-        dumpInstruction(code, result, target >= 0 ? labels[target] : -1);
-
-        i += getOpLength(LuauOpcode(op));
-        LUAU_ASSERT(i <= insns.size());
+        dumpinstoffs[insns.size()] = int(result.size());
     }
-
-    dumpinstoffs[insns.size()] = int(result.size());
 
     return result;
 }

--- a/Compiler/src/Compiler.cpp
+++ b/Compiler/src/Compiler.cpp
@@ -29,11 +29,11 @@ LUAU_FASTINTVARIABLE(LuauCompileInlineThreshold, 25)
 LUAU_FASTINTVARIABLE(LuauCompileInlineThresholdMaxBoost, 300)
 LUAU_FASTINTVARIABLE(LuauCompileInlineDepth, 5)
 
-LUAU_FASTFLAG(LuauExplicitTypeInstantiationSyntax)
-LUAU_FASTFLAGVARIABLE(LuauCompileDuptableConstantPack)
+LUAU_FASTFLAGVARIABLE(LuauCompileDuptableConstantPack2)
 LUAU_FASTFLAGVARIABLE(LuauCompileVectorReveseMul)
 LUAU_FASTFLAGVARIABLE(LuauCompileTableIndexTemp)
 LUAU_FASTFLAGVARIABLE(LuauCompileVectorConstLimit)
+LUAU_FASTFLAGVARIABLE(LuauCompileStringInterpWithZero)
 
 LUAU_FASTFLAG(DebugLuauNoInline)
 
@@ -1968,9 +1968,19 @@ struct Compiler
         int32_t formatStringIndex = -1;
 
         if (formatString.empty())
+        {
             formatStringIndex = bytecode.addConstantString({"", 0});
+        }
+        else if (FFlag::LuauCompileStringInterpWithZero)
+        {
+            AstName interned = names.getOrAdd(formatString.c_str(), formatString.size());
+            AstArray<const char> formatStringArray{interned.value, formatString.size()};
+            formatStringIndex = bytecode.addConstantString(sref(formatStringArray));
+        }
         else
+        {
             formatStringIndex = bytecode.addConstantString(sref(names.getOrAdd(formatString.c_str(), formatString.size())));
+        }
 
         if (formatStringIndex < 0)
             CompileError::raise(expr->location, "Exceeded constant limit; simplify the code to compile");
@@ -2070,7 +2080,8 @@ struct Compiler
         uint8_t reg = targetTemp ? target : allocReg(expr, 1u);
 
         // flattening operation where we only load the last element
-        // this optimizes for tables like: { data = 43, data = function() end, data = 9 }
+        // this optimizes for tables like: { data = 43, data = "true", data = 9 }
+        // this does not optimize for tables such as: { data = 43, data = function() end, data = 9}
         // in this case, we know that data = 9 should be the element, so we can just skip the rest
         InsertionOrderedMap<int32_t, int32_t> lastKeyVal;
         // Optimization: when all items are record fields, use template tables to compile expression
@@ -2078,7 +2089,7 @@ struct Compiler
         {
             BytecodeBuilder::TableShape shape;
 
-            if (FFlag::LuauCompileDuptableConstantPack)
+            if (FFlag::LuauCompileDuptableConstantPack2)
             {
                 for (size_t i = 0; i < expr->items.size; ++i)
                 {
@@ -2093,6 +2104,9 @@ struct Compiler
                         CompileError::raise(ckey->location, "Exceeded constant limit; simplify the code to compile");
 
                     int32_t valueCid = getConstantIndex(item.value);
+                    if (lastKeyVal.contains(keyCid) && lastKeyVal[keyCid] == -1)
+                        continue;
+
                     lastKeyVal[keyCid] = valueCid;
                 }
 
@@ -2145,7 +2159,7 @@ struct Compiler
             else
             {
                 // must disable duptable constant optimization here, as we're defaulting back to new table
-                if (FFlag::LuauCompileDuptableConstantPack)
+                if (FFlag::LuauCompileDuptableConstantPack2)
                 {
                     shape.hasConstants = false;
                     lastKeyVal.clear();
@@ -2191,7 +2205,7 @@ struct Compiler
             AstExpr* key = item.key;
             AstExpr* value = item.value;
 
-            if (FFlag::LuauCompileDuptableConstantPack && lastKeyVal.size() > 0 && key && key->is<AstExprConstantString>())
+            if (FFlag::LuauCompileDuptableConstantPack2 && lastKeyVal.size() > 0 && key && key->is<AstExprConstantString>())
             {
                 AstExprConstantString* ckey = item.key->as<AstExprConstantString>();
                 LUAU_ASSERT(ckey);
@@ -2598,7 +2612,6 @@ struct Compiler
         }
         else if (AstExprInstantiate* expr = node->as<AstExprInstantiate>())
         {
-            LUAU_ASSERT(FFlag::LuauExplicitTypeInstantiationSyntax);
             compileExpr(expr->expr, target, targetTemp);
         }
         else

--- a/Compiler/src/ConstantFolding.cpp
+++ b/Compiler/src/ConstantFolding.cpp
@@ -8,7 +8,6 @@
 #include <vector>
 #include <math.h>
 
-LUAU_FASTFLAG(LuauExplicitTypeInstantiationSyntax)
 LUAU_FASTFLAGVARIABLE(LuauCompileFoldStringLimit)
 
 namespace Luau
@@ -645,7 +644,6 @@ struct ConstantVisitor : AstVisitor
         }
         else if (AstExprInstantiate* expr = node->as<AstExprInstantiate>())
         {
-            LUAU_ASSERT(FFlag::LuauExplicitTypeInstantiationSyntax);
             result = analyze(expr->expr);
         }
         else

--- a/Compiler/src/CostModel.cpp
+++ b/Compiler/src/CostModel.cpp
@@ -10,8 +10,6 @@
 
 #include <limits.h>
 
-LUAU_FASTFLAG(LuauExplicitTypeInstantiationSyntax)
-
 namespace Luau
 {
 namespace Compile
@@ -220,7 +218,6 @@ struct CostVisitor : AstVisitor
         }
         else if (AstExprInstantiate* expr = node->as<AstExprInstantiate>())
         {
-            LUAU_ASSERT(FFlag::LuauExplicitTypeInstantiationSyntax);
             return model(expr->expr);
         }
         else

--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,8 @@ BYTECODE_CLI_SOURCES=CLI/src/FileUtils.cpp CLI/src/Flags.cpp CLI/src/Bytecode.cp
 BYTECODE_CLI_OBJECTS=$(BYTECODE_CLI_SOURCES:%=$(BUILD)/%.o)
 BYTECODE_CLI_TARGET=$(BUILD)/luau-bytecode
 
+MUTATOR_LIBS=build/libprotobuf-mutator/src/libfuzzer/libprotobuf-mutator-libfuzzer.a build/libprotobuf-mutator/src/libprotobuf-mutator.a
+
 FUZZ_SOURCES=$(wildcard fuzz/*.cpp) fuzz/luau.pb.cpp
 FUZZ_OBJECTS=$(FUZZ_SOURCES:%=$(BUILD)/%.o)
 
@@ -165,10 +167,14 @@ $(FUZZ_OBJECTS): CXXFLAGS+=-std=c++17 -ICommon/include -IAst/include -ICompiler/
 $(TESTS_TARGET): LDFLAGS+=-lpthread
 $(REPL_CLI_TARGET): LDFLAGS+=-lpthread
 $(ANALYZE_CLI_TARGET): LDFLAGS+=-lpthread
-fuzz-proto fuzz-prototest: LDFLAGS+=build/libprotobuf-mutator/src/libfuzzer/libprotobuf-mutator-libfuzzer.a build/libprotobuf-mutator/src/libprotobuf-mutator.a $(LPROTOBUF)
+fuzz-proto fuzz-prototest: LDFLAGS+=$(LPROTOBUF)
 
 # pseudo targets
-.PHONY: all test clean coverage format luau-size aliases
+.PHONY: all test clean coverage format luau-size aliases build-mutator-libs
+
+# Explicitly make 'all' the default goal ensuring that even if targets are added before 'all', they won't
+# implicitly become the default target built by make.
+.DEFAULT_GOAL:=all
 
 all: $(REPL_CLI_TARGET) $(ANALYZE_CLI_TARGET) $(TESTS_TARGET) aliases
 
@@ -182,6 +188,7 @@ conformance: $(TESTS_TARGET)
 
 clean:
 	rm -rf $(BUILD)
+	rm -rf build/fuzz fuzz-proto fuzz-prototest
 	rm -rf $(EXECUTABLE_ALIASES)
 
 coverage: $(TESTS_TARGET) $(COMPILE_CLI_TARGET)
@@ -207,6 +214,8 @@ coverage: $(TESTS_TARGET) $(COMPILE_CLI_TARGET)
 
 format:
 	git ls-files '*.h' '*.cpp' | xargs clang-format-11 -i
+
+FUZZ_OBJECTS: $(MUTATOR_LIBS)
 
 luau-size: luau
 	nm --print-size --demangle luau | grep ' t void luau_execute<false>' | awk -F ' ' '{sum += strtonum("0x" $$2)} END {print sum " interpreter" }'
@@ -246,8 +255,8 @@ $(TESTS_TARGET) $(REPL_CLI_TARGET) $(ANALYZE_CLI_TARGET) $(COMPILE_CLI_TARGET) $
 fuzz-%: $(BUILD)/fuzz/%.cpp.o $(ANALYSIS_TARGET) $(EQSAT_TARGET) $(COMPILER_TARGET) $(AST_TARGET) $(CONFIG_TARGET) $(CODEGEN_TARGET) $(VM_TARGET) $(COMMON_TARGET)
 	$(CXX) $^ $(LDFLAGS) -o $@
 
-fuzz-proto: $(BUILD)/fuzz/proto.cpp.o $(BUILD)/fuzz/protoprint.cpp.o $(BUILD)/fuzz/luau.pb.cpp.o $(ANALYSIS_TARGET) $(EQSAT_TARGET) $(COMPILER_TARGET) $(AST_TARGET) $(CONFIG_TARGET) $(VM_TARGET) $(COMMON_TARGET) | build/libprotobuf-mutator
-fuzz-prototest: $(BUILD)/fuzz/prototest.cpp.o $(BUILD)/fuzz/protoprint.cpp.o $(BUILD)/fuzz/luau.pb.cpp.o $(ANALYSIS_TARGET) $(EQSAT_TARGET) $(COMPILER_TARGET) $(AST_TARGET) $(CONFIG_TARGET) $(VM_TARGET) $(COMMON_TARGET) | build/libprotobuf-mutator
+fuzz-proto: $(BUILD)/fuzz/proto.cpp.o $(BUILD)/fuzz/protoprint.cpp.o $(BUILD)/fuzz/luau.pb.cpp.o $(ANALYSIS_TARGET) $(EQSAT_TARGET) $(COMPILER_TARGET) $(AST_TARGET) $(CONFIG_TARGET) $(VM_TARGET) $(COMMON_TARGET) $(MUTATOR_LIBS) | build/libprotobuf-mutator
+fuzz-prototest: $(BUILD)/fuzz/prototest.cpp.o $(BUILD)/fuzz/protoprint.cpp.o $(BUILD)/fuzz/luau.pb.cpp.o $(ANALYSIS_TARGET) $(EQSAT_TARGET) $(COMPILER_TARGET) $(AST_TARGET) $(CONFIG_TARGET) $(VM_TARGET) $(COMMON_TARGET) $(MUTATOR_LIBS) | build/libprotobuf-mutator
 
 # static library targets
 $(COMMON_TARGET): $(COMMON_OBJECTS)
@@ -274,7 +283,7 @@ $(BUILD)/%.c.o: %.c
 	$(CXX) -x c $< $(CXXFLAGS) -c -MMD -MP -o $@
 
 # protobuf fuzzer setup
-fuzz/luau.pb.cpp: fuzz/luau.proto build/libprotobuf-mutator
+fuzz/luau.pb.cpp: fuzz/luau.proto $(MUTATOR_LIBS)
 	cd fuzz && $(EPROTOC) luau.proto --cpp_out=.
 	mv fuzz/luau.pb.cc fuzz/luau.pb.cpp
 
@@ -282,11 +291,20 @@ $(BUILD)/fuzz/proto.cpp.o: fuzz/luau.pb.cpp
 $(BUILD)/fuzz/protoprint.cpp.o: fuzz/luau.pb.cpp
 $(BUILD)/fuzz/prototest.cpp.o: fuzz/luau.pb.cpp
 
+# Clone and checkout the expected version of libprotobuf-mutator
 build/libprotobuf-mutator:
 	git clone https://github.com/google/libprotobuf-mutator build/libprotobuf-mutator
 	git -C build/libprotobuf-mutator checkout 212a7be1eb08e7f9c79732d2aab9b2097085d936
+
+build/libprotobuf-mutator/Makefile: build/libprotobuf-mutator
 	$(CMAKE_PATH) -DCMAKE_CXX_COMPILER=$(CMAKE_CXX) -DCMAKE_C_COMPILER=$(CMAKE_CC) -DCMAKE_CXX_COMPILER_LAUNCHER=$(CMAKE_PROXY) -S build/libprotobuf-mutator -B build/libprotobuf-mutator $(DPROTOBUF)
+
+build-mutator-libs: build/libprotobuf-mutator/Makefile
 	$(MAKE) -C build/libprotobuf-mutator
+
+# MUTATOR_LIBS depends on a phony target because if we directly called make within this
+# target it could be invoked multiple times (once per library) and break the build.
+$(MUTATOR_LIBS): build-mutator-libs
 
 # picks up include dependencies for all object files
 -include $(OBJECTS:.o=.d)

--- a/tests/Compiler.test.cpp
+++ b/tests/Compiler.test.cpp
@@ -25,7 +25,7 @@ LUAU_FASTINT(LuauCompileInlineThresholdMaxBoost)
 LUAU_FASTINT(LuauCompileLoopUnrollThreshold)
 LUAU_FASTINT(LuauCompileLoopUnrollThresholdMaxBoost)
 LUAU_FASTINT(LuauRecursionLimit)
-LUAU_FASTFLAG(LuauCompileDuptableConstantPack)
+LUAU_FASTFLAG(LuauCompileDuptableConstantPack2)
 LUAU_FASTFLAG(LuauCompileExtraTypes)
 LUAU_FASTFLAG(LuauCompileVectorReveseMul)
 LUAU_FASTFLAG(LuauCompileFastcallsSurvivePolyfills)
@@ -667,7 +667,7 @@ RETURN R0 0
 
 TEST_CASE("TableLiterals")
 {
-    ScopedFastFlag luauCompileDuptableConstantPack{FFlag::LuauCompileDuptableConstantPack, false};
+    ScopedFastFlag LuauCompileDuptableConstantPack2{FFlag::LuauCompileDuptableConstantPack2, true};
 
     // empty table, note it's computed directly to target
     CHECK_EQ("\n" + compileFunction0("return {}"), R"(
@@ -741,13 +741,7 @@ RETURN R0 1
 
     // basic literals; note that we use DUPTABLE instead of NEWTABLE
     CHECK_EQ("\n" + compileFunction0("return {a=1,b=2,c=3}"), R"(
-DUPTABLE R0 3
-LOADN R1 1
-SETTABLEKS R1 R0 K0 ['a']
-LOADN R1 2
-SETTABLEKS R1 R0 K1 ['b']
-LOADN R1 3
-SETTABLEKS R1 R0 K2 ['c']
+DUPTABLE R0 6
 RETURN R0 1
 )");
 
@@ -777,28 +771,16 @@ RETURN R0 1
 
     // table template caching; two DUPTABLES out of three use the same slot. Note that caching is order dependent
     CHECK_EQ("\n" + compileFunction0("return {a=1,b=2},{b=3,a=4},{a=5,b=6}"), R"(
-DUPTABLE R0 2
-LOADN R1 1
-SETTABLEKS R1 R0 K0 ['a']
-LOADN R1 2
-SETTABLEKS R1 R0 K1 ['b']
-DUPTABLE R1 3
-LOADN R2 3
-SETTABLEKS R2 R1 K1 ['b']
-LOADN R2 4
-SETTABLEKS R2 R1 K0 ['a']
-DUPTABLE R2 2
-LOADN R3 5
-SETTABLEKS R3 R2 K0 ['a']
-LOADN R3 6
-SETTABLEKS R3 R2 K1 ['b']
+DUPTABLE R0 4
+DUPTABLE R1 7
+DUPTABLE R2 10
 RETURN R0 3
 )");
 }
 
 TEST_CASE("TableLiteralsConstantPackFlag")
 {
-    ScopedFastFlag luauCompileDuptableConstantPack{FFlag::LuauCompileDuptableConstantPack, true};
+    ScopedFastFlag LuauCompileDuptableConstantPack2{FFlag::LuauCompileDuptableConstantPack2, true};
 
     // basic literals becomes a single duptable
     CHECK_EQ("\n" + compileFunction0("return {a=1,b=2,c=3}"), R"(
@@ -3453,7 +3435,7 @@ until f == 0
 
 TEST_CASE("DebugLineInfoSubTable")
 {
-    ScopedFastFlag luauCompileDuptableConstantPack{FFlag::LuauCompileDuptableConstantPack, true};
+    ScopedFastFlag LuauCompileDuptableConstantPack2{FFlag::LuauCompileDuptableConstantPack2, true};
 
     Luau::BytecodeBuilder bcb;
     bcb.setDumpFlags(Luau::BytecodeBuilder::Dump_Code | Luau::BytecodeBuilder::Dump_Lines);
@@ -3562,7 +3544,7 @@ return
 
 TEST_CASE("DebugLineInfoAssignment")
 {
-    ScopedFastFlag luauCompileDuptableConstantPack{FFlag::LuauCompileDuptableConstantPack, true};
+    ScopedFastFlag LuauCompileDuptableConstantPack2{FFlag::LuauCompileDuptableConstantPack2, true};
 
     Luau::BytecodeBuilder bcb;
     bcb.setDumpFlags(Luau::BytecodeBuilder::Dump_Code | Luau::BytecodeBuilder::Dump_Lines);
@@ -5095,7 +5077,7 @@ L1: RETURN R0 0
 
 TEST_CASE("TableConstantStringIndex")
 {
-    ScopedFastFlag luauCompileDuptableConstantPack{FFlag::LuauCompileDuptableConstantPack, true};
+    ScopedFastFlag LuauCompileDuptableConstantPack2{FFlag::LuauCompileDuptableConstantPack2, true};
 
     CHECK_EQ(
         "\n" + compileFunction0(R"(
@@ -5123,9 +5105,36 @@ RETURN R0 0
     );
 }
 
+TEST_CASE("DuptableNoConstantPack")
+{
+    ScopedFastFlag LuauCompileDuptableConstantPack2{FFlag::LuauCompileDuptableConstantPack2, true};
+
+    // function has duplicate keys that are not constant fold-able
+    CHECK_EQ(
+        "\n" + compileFunction(
+                   R"(
+local t = { a = 2, a = function() end, a = 3 }
+return t['a']
+)",
+                   1
+               ),
+        R"(
+DUPTABLE R0 3
+LOADN R1 2
+SETTABLEKS R1 R0 K0 ['a']
+DUPCLOSURE R1 K4 ['a']
+SETTABLEKS R1 R0 K0 ['a']
+LOADN R1 3
+SETTABLEKS R1 R0 K0 ['a']
+GETTABLEKS R1 R0 K0 ['a']
+RETURN R1 1
+)"
+    );
+}
+
 TEST_CASE("Coverage")
 {
-    ScopedFastFlag luauCompileDuptableConstantPack{FFlag::LuauCompileDuptableConstantPack, true};
+    ScopedFastFlag LuauCompileDuptableConstantPack2{FFlag::LuauCompileDuptableConstantPack2, true};
     // basic statement coverage
     CHECK_EQ(
         "\n" + compileFunction0Coverage(

--- a/tests/Conformance.test.cpp
+++ b/tests/Conformance.test.cpp
@@ -38,13 +38,12 @@ void luaC_validate(lua_State* L);
 void luau_callhook(lua_State* L, lua_Hook hook, void* userdata);
 
 LUAU_FASTFLAG(DebugLuauAbortingChecks)
-LUAU_FASTFLAG(LuauExplicitTypeInstantiationSyntax)
 LUAU_FASTINT(CodegenHeuristicsInstructionLimit)
 LUAU_FASTFLAG(LuauStacklessPcall)
 LUAU_FASTFLAG(LuauCodegenA64ClosureOffset)
 LUAU_FASTFLAG(DebugLuauForceOldSolver)
 LUAU_FASTFLAG(LuauNewMathConstantsRuntime)
-
+LUAU_FASTFLAG(LuauCompileStringInterpWithZero)
 
 static lua_CompileOptions defaultOptions()
 {
@@ -912,6 +911,8 @@ TEST_CASE("Strings")
 
 TEST_CASE("StringInterp")
 {
+    ScopedFastFlag luauCompileStringInterpWithZero{FFlag::LuauCompileStringInterpWithZero, true};
+
     runConformance("stringinterp.luau");
 }
 
@@ -1064,7 +1065,6 @@ TEST_CASE("Pack")
 
 TEST_CASE("ExplicitTypeInstantiations")
 {
-    ScopedFastFlag sff{FFlag::LuauExplicitTypeInstantiationSyntax, true};
     runConformance("explicit_type_instantiations.luau");
 }
 

--- a/tests/IrBuilder.test.cpp
+++ b/tests/IrBuilder.test.cpp
@@ -13,11 +13,11 @@
 #include <limits.h>
 
 LUAU_FASTFLAG(DebugLuauAbortingChecks)
-LUAU_FASTFLAG(LuauCodegenMarkDeadRegisters)
+LUAU_FASTFLAG(LuauCodegenMarkDeadRegisters2)
 LUAU_FASTFLAG(LuauCodegenDseOnCondJump)
 LUAU_FASTFLAG(LuauCodegenGcoDse2)
 LUAU_FASTFLAG(LuauCodegenDsoPairTrackFix)
-LUAU_FASTFLAG(LuauCodegenBufferRangeMerge3)
+LUAU_FASTFLAG(LuauCodegenBufferRangeMerge4)
 LUAU_FASTFLAG(LuauCodegenTableLoadProp2)
 LUAU_FASTFLAG(LuauCodegenDsoTagOverlayFix)
 LUAU_FASTFLAG(LuauCodegenCounterSupport)
@@ -2788,7 +2788,7 @@ bb_fallback_1:
 
 TEST_CASE_FIXTURE(IrBuilderFixture, "DuplicateBufferLengthChecks")
 {
-    ScopedFastFlag luauCodegenBufferRangeMerge{FFlag::LuauCodegenBufferRangeMerge3, true};
+    ScopedFastFlag luauCodegenBufferRangeMerge{FFlag::LuauCodegenBufferRangeMerge4, true};
     ScopedFastFlag luauCodegenCounterSupport{FFlag::LuauCodegenCounterSupport, true};
 
     IrOp block = build.block(IrBlockKind::Internal);
@@ -2858,7 +2858,7 @@ bb_fallback_1:
 
 TEST_CASE_FIXTURE(IrBuilderFixture, "BufferLengthChecksNegativeIndex")
 {
-    ScopedFastFlag luauCodegenBufferRangeMerge{FFlag::LuauCodegenBufferRangeMerge3, true};
+    ScopedFastFlag luauCodegenBufferRangeMerge{FFlag::LuauCodegenBufferRangeMerge4, true};
     ScopedFastFlag luauCodegenCounterSupport{FFlag::LuauCodegenCounterSupport, true};
 
     IrOp block = build.block(IrBlockKind::Internal);
@@ -2894,7 +2894,7 @@ bb_fallback_1:
 
 TEST_CASE_FIXTURE(IrBuilderFixture, "BufferLengthChecksIntegerMatch")
 {
-    ScopedFastFlag luauCodegenBufferRangeMerge{FFlag::LuauCodegenBufferRangeMerge3, true};
+    ScopedFastFlag luauCodegenBufferRangeMerge{FFlag::LuauCodegenBufferRangeMerge4, true};
     ScopedFastFlag luauCodegenCounterSupport{FFlag::LuauCodegenCounterSupport, true};
 
     IrOp block = build.block(IrBlockKind::Internal);
@@ -2933,7 +2933,7 @@ bb_fallback_1:
 
 TEST_CASE_FIXTURE(IrBuilderFixture, "BufferLengthChecksIntegerMatch2")
 {
-    ScopedFastFlag luauCodegenBufferRangeMerge{FFlag::LuauCodegenBufferRangeMerge3, true};
+    ScopedFastFlag luauCodegenBufferRangeMerge{FFlag::LuauCodegenBufferRangeMerge4, true};
     ScopedFastFlag luauCodegenCounterSupport{FFlag::LuauCodegenCounterSupport, true};
 
     IrOp block = build.block(IrBlockKind::Internal);
@@ -5031,7 +5031,7 @@ bb_2:
 
 TEST_CASE_FIXTURE(IrBuilderFixture, "DoNotReturnWithPartialStores")
 {
-    ScopedFastFlag luauCodegenMarkDeadRegisters{FFlag::LuauCodegenMarkDeadRegisters, true};
+    ScopedFastFlag luauCodegenMarkDeadRegisters{FFlag::LuauCodegenMarkDeadRegisters2, true};
     ScopedFastFlag luauCodegenDseOnCondJump{FFlag::LuauCodegenDseOnCondJump, true};
 
     IrOp entry = build.block(IrBlockKind::Internal);

--- a/tests/IrLowering.test.cpp
+++ b/tests/IrLowering.test.cpp
@@ -16,13 +16,13 @@
 #include <memory>
 #include <string_view>
 
-LUAU_FASTFLAG(LuauCodegenMarkDeadRegisters)
+LUAU_FASTFLAG(LuauCodegenMarkDeadRegisters2)
 LUAU_FASTFLAG(LuauCodegenDseOnCondJump)
 LUAU_FASTFLAG(LuauCodegenBlockSafeEnv)
 LUAU_FASTFLAG(LuauCodegenSetBlockEntryState2)
 LUAU_FASTFLAG(LuauCodegenTableLoadProp2)
 LUAU_FASTFLAG(LuauCodegenGcoDse2)
-LUAU_FASTFLAG(LuauCodegenBufferRangeMerge3)
+LUAU_FASTFLAG(LuauCodegenBufferRangeMerge4)
 LUAU_FASTFLAG(LuauCodegenBit32SingleArg)
 LUAU_FASTFLAG(LuauCodegenCounterSupport)
 LUAU_FASTFLAG(LuauCodegenSafeEnvPreserve)
@@ -557,7 +557,7 @@ bb_bytecode_1:
 TEST_CASE_FIXTURE(LoweringFixture, "VectorMinMax")
 {
     ScopedFastFlag luauCodegenBlockSafeEnv{FFlag::LuauCodegenBlockSafeEnv, true};
-    ScopedFastFlag luauCodegenMarkDeadRegisters{FFlag::LuauCodegenMarkDeadRegisters, true};
+    ScopedFastFlag luauCodegenMarkDeadRegisters{FFlag::LuauCodegenMarkDeadRegisters2, true};
     ScopedFastFlag luauCodegenDseOnCondJump{FFlag::LuauCodegenDseOnCondJump, true};
 
     CHECK_EQ(
@@ -592,7 +592,7 @@ bb_bytecode_1:
 TEST_CASE_FIXTURE(LoweringFixture, "VectorFloorCeilAbs")
 {
     ScopedFastFlag luauCodegenBlockSafeEnv{FFlag::LuauCodegenBlockSafeEnv, true};
-    ScopedFastFlag luauCodegenMarkDeadRegisters{FFlag::LuauCodegenMarkDeadRegisters, true};
+    ScopedFastFlag luauCodegenMarkDeadRegisters{FFlag::LuauCodegenMarkDeadRegisters2, true};
     ScopedFastFlag luauCodegenDseOnCondJump{FFlag::LuauCodegenDseOnCondJump, true};
 
     CHECK_EQ(
@@ -629,7 +629,7 @@ bb_bytecode_1:
 TEST_CASE_FIXTURE(LoweringFixture, "ExtraMathMemoryOperands")
 {
     ScopedFastFlag luauCodegenBlockSafeEnv{FFlag::LuauCodegenBlockSafeEnv, true};
-    ScopedFastFlag luauCodegenMarkDeadRegisters{FFlag::LuauCodegenMarkDeadRegisters, true};
+    ScopedFastFlag luauCodegenMarkDeadRegisters{FFlag::LuauCodegenMarkDeadRegisters2, true};
     ScopedFastFlag luauCodegenDseOnCondJump{FFlag::LuauCodegenDseOnCondJump, true};
 
     CHECK_EQ(
@@ -992,7 +992,7 @@ TEST_CASE_FIXTURE(LoweringFixture, "TypeCompare")
 {
     ScopedFastFlag luauCodegenBlockSafeEnv{FFlag::LuauCodegenBlockSafeEnv, true};
     ScopedFastFlag luauCodegenGcoDse{FFlag::LuauCodegenGcoDse2, true};
-    ScopedFastFlag luauCodegenMarkDeadRegisters{FFlag::LuauCodegenMarkDeadRegisters, true};
+    ScopedFastFlag luauCodegenMarkDeadRegisters{FFlag::LuauCodegenMarkDeadRegisters2, true};
     ScopedFastFlag luauCodegenDseOnCondJump{FFlag::LuauCodegenDseOnCondJump, true};
 
     CHECK_EQ(
@@ -1023,7 +1023,7 @@ TEST_CASE_FIXTURE(LoweringFixture, "TypeofCompare")
 {
     ScopedFastFlag luauCodegenBlockSafeEnv{FFlag::LuauCodegenBlockSafeEnv, true};
     ScopedFastFlag luauCodegenGcoDse{FFlag::LuauCodegenGcoDse2, true};
-    ScopedFastFlag luauCodegenMarkDeadRegisters{FFlag::LuauCodegenMarkDeadRegisters, true};
+    ScopedFastFlag luauCodegenMarkDeadRegisters{FFlag::LuauCodegenMarkDeadRegisters2, true};
     ScopedFastFlag luauCodegenDseOnCondJump{FFlag::LuauCodegenDseOnCondJump, true};
 
     CHECK_EQ(
@@ -1053,7 +1053,7 @@ TEST_CASE_FIXTURE(LoweringFixture, "TypeofCompareCustom")
 {
     ScopedFastFlag luauCodegenBlockSafeEnv{FFlag::LuauCodegenBlockSafeEnv, true};
     ScopedFastFlag luauCodegenGcoDse{FFlag::LuauCodegenGcoDse2, true};
-    ScopedFastFlag luauCodegenMarkDeadRegisters{FFlag::LuauCodegenMarkDeadRegisters, true};
+    ScopedFastFlag luauCodegenMarkDeadRegisters{FFlag::LuauCodegenMarkDeadRegisters2, true};
     ScopedFastFlag luauCodegenDseOnCondJump{FFlag::LuauCodegenDseOnCondJump, true};
 
     CHECK_EQ(
@@ -1084,7 +1084,7 @@ bb_bytecode_2:
 TEST_CASE_FIXTURE(LoweringFixture, "TypeCondition")
 {
     ScopedFastFlag luauCodegenBlockSafeEnv{FFlag::LuauCodegenBlockSafeEnv, true};
-    ScopedFastFlag luauCodegenMarkDeadRegisters{FFlag::LuauCodegenMarkDeadRegisters, true};
+    ScopedFastFlag luauCodegenMarkDeadRegisters{FFlag::LuauCodegenMarkDeadRegisters2, true};
     ScopedFastFlag luauCodegenDseOnCondJump{FFlag::LuauCodegenDseOnCondJump, true};
 
     // TODO: opportunity - bb_4 already made sure %1 == R0.tag is a number, check in bb_3 can be removed
@@ -1130,7 +1130,7 @@ TEST_CASE_FIXTURE(LoweringFixture, "TypeCondition2")
     ScopedFastFlag luauCodegenBlockSafeEnv{FFlag::LuauCodegenBlockSafeEnv, true};
     ScopedFastFlag luauCodegenSafeEnvPreserve{FFlag::LuauCodegenSafeEnvPreserve, true};
     ScopedFastFlag luauCodegenCounterSupport{FFlag::LuauCodegenCounterSupport, true};
-    ScopedFastFlag luauCodegenMarkDeadRegisters{FFlag::LuauCodegenMarkDeadRegisters, true};
+    ScopedFastFlag luauCodegenMarkDeadRegisters{FFlag::LuauCodegenMarkDeadRegisters2, true};
     ScopedFastFlag luauCodegenDseOnCondJump{FFlag::LuauCodegenDseOnCondJump, true};
 
     // TODO: opportunity - bb_4 already made sure env is safe, check in bb_3 can be removed
@@ -1179,7 +1179,7 @@ bb_bytecode_1:
 TEST_CASE_FIXTURE(LoweringFixture, "AssertTypeGuard")
 {
     ScopedFastFlag luauCodegenBlockSafeEnv{FFlag::LuauCodegenBlockSafeEnv, true};
-    ScopedFastFlag luauCodegenMarkDeadRegisters{FFlag::LuauCodegenMarkDeadRegisters, true};
+    ScopedFastFlag luauCodegenMarkDeadRegisters{FFlag::LuauCodegenMarkDeadRegisters2, true};
     ScopedFastFlag luauCodegenDseOnCondJump{FFlag::LuauCodegenDseOnCondJump, true};
 
     // TODO: opportunity - CHECK_TRUTHY indirectly establishes that %1 is a number for CHECK_TAG in bb_5
@@ -1646,7 +1646,7 @@ bb_bytecode_1:
 TEST_CASE_FIXTURE(LoweringFixture, "VectorLibraryChain")
 {
     ScopedFastFlag luauCodegenBlockSafeEnv{FFlag::LuauCodegenBlockSafeEnv, true};
-    ScopedFastFlag luauCodegenMarkDeadRegisters{FFlag::LuauCodegenMarkDeadRegisters, true};
+    ScopedFastFlag luauCodegenMarkDeadRegisters{FFlag::LuauCodegenMarkDeadRegisters2, true};
     ScopedFastFlag luauCodegenDseOnCondJump{FFlag::LuauCodegenDseOnCondJump, true};
 
     CHECK_EQ(
@@ -1963,7 +1963,7 @@ TEST_CASE_FIXTURE(LoweringFixture, "EntryBlockChecksAreNotInferred")
 {
     ScopedFastFlag luauCodegenBlockSafeEnv{FFlag::LuauCodegenBlockSafeEnv, true};
     ScopedFastFlag luauCodegenSetBlockEntryState{FFlag::LuauCodegenSetBlockEntryState2, true};
-    ScopedFastFlag luauCodegenMarkDeadRegisters{FFlag::LuauCodegenMarkDeadRegisters, true};
+    ScopedFastFlag luauCodegenMarkDeadRegisters{FFlag::LuauCodegenMarkDeadRegisters2, true};
     ScopedFastFlag luauCodegenDseOnCondJump{FFlag::LuauCodegenDseOnCondJump, true};
 
     CHECK_EQ(
@@ -2820,7 +2820,7 @@ TEST_CASE_FIXTURE(LoweringFixture, "TableNodeLoadStoreProp5")
 {
     ScopedFastFlag luauCodegenSetBlockEntryState{FFlag::LuauCodegenSetBlockEntryState2, true};
     ScopedFastFlag luauCodegenGcoDse{FFlag::LuauCodegenGcoDse2, true};
-    ScopedFastFlag luauCodegenMarkDeadRegisters{FFlag::LuauCodegenMarkDeadRegisters, true};
+    ScopedFastFlag luauCodegenMarkDeadRegisters{FFlag::LuauCodegenMarkDeadRegisters2, true};
     ScopedFastFlag luauCodegenDseOnCondJump{FFlag::LuauCodegenDseOnCondJump, true};
     ScopedFastFlag luauCodegenTableLoadProp{FFlag::LuauCodegenTableLoadProp2, true};
     ScopedFastFlag luauCodegenBlockSafeEnv{FFlag::LuauCodegenBlockSafeEnv, true};
@@ -3025,7 +3025,7 @@ bb_linear_11:
 TEST_CASE_FIXTURE(LoweringFixture, "FastcallTypeInferThroughLocal")
 {
     ScopedFastFlag luauCodegenBlockSafeEnv{FFlag::LuauCodegenBlockSafeEnv, true};
-    ScopedFastFlag luauCodegenMarkDeadRegisters{FFlag::LuauCodegenMarkDeadRegisters, true};
+    ScopedFastFlag luauCodegenMarkDeadRegisters{FFlag::LuauCodegenMarkDeadRegisters2, true};
     ScopedFastFlag luauCodegenDseOnCondJump{FFlag::LuauCodegenDseOnCondJump, true};
 
     // TODO: opportunity - bb_3 has only one predecessor, but doesn't retain any info from it
@@ -3087,7 +3087,7 @@ TEST_CASE_FIXTURE(LoweringFixture, "FastcallTypeInferThroughUpvalue")
     ScopedFastFlag luauCodegenDsoPairTrackFix{FFlag::LuauCodegenDsoPairTrackFix, true};
     ScopedFastFlag luauCodegenGcoDse{FFlag::LuauCodegenGcoDse2, true};
     ScopedFastFlag luauCompileTableIndexTemp{FFlag::LuauCompileTableIndexTemp, true};
-    ScopedFastFlag luauCodegenMarkDeadRegisters{FFlag::LuauCodegenMarkDeadRegisters, true};
+    ScopedFastFlag luauCodegenMarkDeadRegisters{FFlag::LuauCodegenMarkDeadRegisters2, true};
     ScopedFastFlag luauCodegenDseOnCondJump{FFlag::LuauCodegenDseOnCondJump, true};
 
     CHECK_EQ(
@@ -3154,7 +3154,7 @@ bb_bytecode_1:
 
 TEST_CASE_FIXTURE(LoweringFixture, "LoadAndMoveTypePropagation")
 {
-    ScopedFastFlag luauCodegenMarkDeadRegisters{FFlag::LuauCodegenMarkDeadRegisters, true};
+    ScopedFastFlag luauCodegenMarkDeadRegisters{FFlag::LuauCodegenMarkDeadRegisters2, true};
     ScopedFastFlag luauCodegenDseOnCondJump{FFlag::LuauCodegenDseOnCondJump, true};
 
     CHECK_EQ(
@@ -3228,7 +3228,7 @@ bb_bytecode_4:
 TEST_CASE_FIXTURE(LoweringFixture, "ArgumentTypeRefinement")
 {
     ScopedFastFlag luauCodegenBlockSafeEnv{FFlag::LuauCodegenBlockSafeEnv, true};
-    ScopedFastFlag luauCodegenMarkDeadRegisters{FFlag::LuauCodegenMarkDeadRegisters, true};
+    ScopedFastFlag luauCodegenMarkDeadRegisters{FFlag::LuauCodegenMarkDeadRegisters2, true};
     ScopedFastFlag luauCodegenDseOnCondJump{FFlag::LuauCodegenDseOnCondJump, true};
 
     CHECK_EQ(
@@ -4380,7 +4380,7 @@ bb_bytecode_1:
 TEST_CASE_FIXTURE(LoweringFixture, "Bit32ReplaceDirect")
 {
     ScopedFastFlag luauCodegenBlockSafeEnv{FFlag::LuauCodegenBlockSafeEnv, true};
-    ScopedFastFlag luauCodegenMarkDeadRegisters{FFlag::LuauCodegenMarkDeadRegisters, true};
+    ScopedFastFlag luauCodegenMarkDeadRegisters{FFlag::LuauCodegenMarkDeadRegisters2, true};
     ScopedFastFlag luauCodegenDseOnCondJump{FFlag::LuauCodegenDseOnCondJump, true};
 
     CHECK_EQ(
@@ -4476,7 +4476,7 @@ TEST_CASE_FIXTURE(LoweringFixture, "Bit32SingleArg")
 {
     ScopedFastFlag luauCodegenBlockSafeEnv{FFlag::LuauCodegenBlockSafeEnv, true};
     ScopedFastFlag luauCodegenBit32SingleArg{FFlag::LuauCodegenBit32SingleArg, true};
-    ScopedFastFlag luauCodegenMarkDeadRegisters{FFlag::LuauCodegenMarkDeadRegisters, true};
+    ScopedFastFlag luauCodegenMarkDeadRegisters{FFlag::LuauCodegenMarkDeadRegisters2, true};
 
     CHECK_EQ(
         "\n" + getCodegenAssembly(R"(
@@ -4610,7 +4610,7 @@ bb_bytecode_1:
 TEST_CASE_FIXTURE(LoweringFixture, "VectorShuffle2")
 {
     ScopedFastFlag luauCodegenBlockSafeEnv{FFlag::LuauCodegenBlockSafeEnv, true};
-    ScopedFastFlag luauCodegenMarkDeadRegisters{FFlag::LuauCodegenMarkDeadRegisters, true};
+    ScopedFastFlag luauCodegenMarkDeadRegisters{FFlag::LuauCodegenMarkDeadRegisters2, true};
     ScopedFastFlag luauCodegenDseOnCondJump{FFlag::LuauCodegenDseOnCondJump, true};
 
     CHECK_EQ(
@@ -4815,7 +4815,7 @@ TEST_CASE_FIXTURE(LoweringFixture, "ComparisonPropagationWall")
     ScopedFastFlag luauCodegenBlockSafeEnv{FFlag::LuauCodegenBlockSafeEnv, true};
     ScopedFastFlag luauCodegenIsNanAndDirectCompare{FFlag::LuauCodegenIsNanAndDirectCompare, true};
     ScopedFastFlag luauCodegenExtraBlockers{FFlag::LuauCodegenExtraBlockers, true};
-    ScopedFastFlag luauCodegenMarkDeadRegisters{FFlag::LuauCodegenMarkDeadRegisters, true};
+    ScopedFastFlag luauCodegenMarkDeadRegisters{FFlag::LuauCodegenMarkDeadRegisters2, true};
     ScopedFastFlag luauCodegenDseOnCondJump{FFlag::LuauCodegenDseOnCondJump, true};
 
     // After CMP_ANY 'z' cannot reuse any SSA registers before
@@ -4862,7 +4862,7 @@ bb_bytecode_2:
 TEST_CASE_FIXTURE(LoweringFixture, "VectorLoadStoreOnlySamePrecision")
 {
     ScopedFastFlag luauCodegenBlockSafeEnv{FFlag::LuauCodegenBlockSafeEnv, true};
-    ScopedFastFlag luauCodegenMarkDeadRegisters{FFlag::LuauCodegenMarkDeadRegisters, true};
+    ScopedFastFlag luauCodegenMarkDeadRegisters{FFlag::LuauCodegenMarkDeadRegisters2, true};
     ScopedFastFlag luauCodegenDseOnCondJump{FFlag::LuauCodegenDseOnCondJump, true};
 
     CHECK_EQ(
@@ -4983,8 +4983,8 @@ bb_bytecode_3:
 TEST_CASE_FIXTURE(LoweringFixture, "BufferRelatedIndicesPositiveBase")
 {
     ScopedFastFlag luauCodegenBlockSafeEnv{FFlag::LuauCodegenBlockSafeEnv, true};
-    ScopedFastFlag luauCodegenBufferRangeMerge{FFlag::LuauCodegenBufferRangeMerge3, true};
-    ScopedFastFlag luauCodegenMarkDeadRegisters{FFlag::LuauCodegenMarkDeadRegisters, true};
+    ScopedFastFlag luauCodegenBufferRangeMerge{FFlag::LuauCodegenBufferRangeMerge4, true};
+    ScopedFastFlag luauCodegenMarkDeadRegisters{FFlag::LuauCodegenMarkDeadRegisters2, true};
     ScopedFastFlag luauCodegenDseOnCondJump{FFlag::LuauCodegenDseOnCondJump, true};
 
     CHECK_EQ(
@@ -5028,8 +5028,8 @@ bb_bytecode_1:
 TEST_CASE_FIXTURE(LoweringFixture, "BufferRelatedIndicesPositiveBaseInverted")
 {
     ScopedFastFlag luauCodegenBlockSafeEnv{FFlag::LuauCodegenBlockSafeEnv, true};
-    ScopedFastFlag luauCodegenBufferRangeMerge{FFlag::LuauCodegenBufferRangeMerge3, true};
-    ScopedFastFlag luauCodegenMarkDeadRegisters{FFlag::LuauCodegenMarkDeadRegisters, true};
+    ScopedFastFlag luauCodegenBufferRangeMerge{FFlag::LuauCodegenBufferRangeMerge4, true};
+    ScopedFastFlag luauCodegenMarkDeadRegisters{FFlag::LuauCodegenMarkDeadRegisters2, true};
     ScopedFastFlag luauCodegenDseOnCondJump{FFlag::LuauCodegenDseOnCondJump, true};
 
     CHECK_EQ(
@@ -5075,8 +5075,8 @@ bb_bytecode_1:
 TEST_CASE_FIXTURE(LoweringFixture, "BufferRelatedIndicesPositiveDynamicBase")
 {
     ScopedFastFlag luauCodegenBlockSafeEnv{FFlag::LuauCodegenBlockSafeEnv, true};
-    ScopedFastFlag luauCodegenBufferRangeMerge{FFlag::LuauCodegenBufferRangeMerge3, true};
-    ScopedFastFlag luauCodegenMarkDeadRegisters{FFlag::LuauCodegenMarkDeadRegisters, true};
+    ScopedFastFlag luauCodegenBufferRangeMerge{FFlag::LuauCodegenBufferRangeMerge4, true};
+    ScopedFastFlag luauCodegenMarkDeadRegisters{FFlag::LuauCodegenMarkDeadRegisters2, true};
     ScopedFastFlag luauCodegenDseOnCondJump{FFlag::LuauCodegenDseOnCondJump, true};
 
     CHECK_EQ(
@@ -5105,6 +5105,9 @@ bb_bytecode_1:
   %18 = INT_TO_NUM %17
   STORE_DOUBLE R3, %18
   STORE_TAG R3, tnumber
+  %25 = ADD_NUM %18, 0
+  STORE_DOUBLE R8, %25
+  STORE_TAG R8, tnumber
   %33 = LOAD_POINTER R1
   %35 = NUM_TO_INT %18
   CHECK_BUFFER_LEN %33, %35, 0i, 12i, %18, exit(10)
@@ -5130,8 +5133,8 @@ TEST_CASE_FIXTURE(LoweringFixture, "BufferRelatedIndicesPositiveLoopRangeBase")
 {
     ScopedFastFlag luauCodegenBlockSafeEnv{FFlag::LuauCodegenBlockSafeEnv, true};
     ScopedFastFlag luauCodegenSetBlockEntryState{FFlag::LuauCodegenSetBlockEntryState2, true};
-    ScopedFastFlag luauCodegenBufferRangeMerge{FFlag::LuauCodegenBufferRangeMerge3, true};
-    ScopedFastFlag luauCodegenMarkDeadRegisters{FFlag::LuauCodegenMarkDeadRegisters, true};
+    ScopedFastFlag luauCodegenBufferRangeMerge{FFlag::LuauCodegenBufferRangeMerge4, true};
+    ScopedFastFlag luauCodegenMarkDeadRegisters{FFlag::LuauCodegenMarkDeadRegisters2, true};
     ScopedFastFlag luauCodegenDseOnCondJump{FFlag::LuauCodegenDseOnCondJump, true};
 
     // TODO: opportunity 1 - buffer.len is not a fastcall, but under safe env we can treat it like one and read buffer len field
@@ -5220,8 +5223,8 @@ bb_bytecode_3:
 TEST_CASE_FIXTURE(LoweringFixture, "BufferRelatedIndicesPositiveAdvancingBase")
 {
     ScopedFastFlag luauCodegenBlockSafeEnv{FFlag::LuauCodegenBlockSafeEnv, true};
-    ScopedFastFlag luauCodegenBufferRangeMerge{FFlag::LuauCodegenBufferRangeMerge3, true};
-    ScopedFastFlag luauCodegenMarkDeadRegisters{FFlag::LuauCodegenMarkDeadRegisters, true};
+    ScopedFastFlag luauCodegenBufferRangeMerge{FFlag::LuauCodegenBufferRangeMerge4, true};
+    ScopedFastFlag luauCodegenMarkDeadRegisters{FFlag::LuauCodegenMarkDeadRegisters2, true};
     ScopedFastFlag luauCodegenDseOnCondJump{FFlag::LuauCodegenDseOnCondJump, true};
 
     CHECK_EQ(
@@ -5278,8 +5281,8 @@ bb_bytecode_1:
 TEST_CASE_FIXTURE(LoweringFixture, "BufferRelatedIndicesNegativeBase")
 {
     ScopedFastFlag luauCodegenBlockSafeEnv{FFlag::LuauCodegenBlockSafeEnv, true};
-    ScopedFastFlag luauCodegenBufferRangeMerge{FFlag::LuauCodegenBufferRangeMerge3, true};
-    ScopedFastFlag luauCodegenMarkDeadRegisters{FFlag::LuauCodegenMarkDeadRegisters, true};
+    ScopedFastFlag luauCodegenBufferRangeMerge{FFlag::LuauCodegenBufferRangeMerge4, true};
+    ScopedFastFlag luauCodegenMarkDeadRegisters{FFlag::LuauCodegenMarkDeadRegisters2, true};
     ScopedFastFlag luauCodegenDseOnCondJump{FFlag::LuauCodegenDseOnCondJump, true};
 
     CHECK_EQ(
@@ -5326,8 +5329,8 @@ bb_bytecode_1:
 TEST_CASE_FIXTURE(LoweringFixture, "BufferRelatedIndicesMixedBase")
 {
     ScopedFastFlag luauCodegenBlockSafeEnv{FFlag::LuauCodegenBlockSafeEnv, true};
-    ScopedFastFlag luauCodegenBufferRangeMerge{FFlag::LuauCodegenBufferRangeMerge3, true};
-    ScopedFastFlag luauCodegenMarkDeadRegisters{FFlag::LuauCodegenMarkDeadRegisters, true};
+    ScopedFastFlag luauCodegenBufferRangeMerge{FFlag::LuauCodegenBufferRangeMerge4, true};
+    ScopedFastFlag luauCodegenMarkDeadRegisters{FFlag::LuauCodegenMarkDeadRegisters2, true};
     ScopedFastFlag luauCodegenDseOnCondJump{FFlag::LuauCodegenDseOnCondJump, true};
 
     CHECK_EQ(
@@ -5371,8 +5374,8 @@ bb_bytecode_1:
 TEST_CASE_FIXTURE(LoweringFixture, "BufferSanityPositive")
 {
     ScopedFastFlag luauCodegenBlockSafeEnv{FFlag::LuauCodegenBlockSafeEnv, true};
-    ScopedFastFlag luauCodegenBufferRangeMerge{FFlag::LuauCodegenBufferRangeMerge3, true};
-    ScopedFastFlag luauCodegenMarkDeadRegisters{FFlag::LuauCodegenMarkDeadRegisters, true};
+    ScopedFastFlag luauCodegenBufferRangeMerge{FFlag::LuauCodegenBufferRangeMerge4, true};
+    ScopedFastFlag luauCodegenMarkDeadRegisters{FFlag::LuauCodegenMarkDeadRegisters2, true};
     ScopedFastFlag luauCodegenDseOnCondJump{FFlag::LuauCodegenDseOnCondJump, true};
 
     CHECK_EQ(
@@ -5413,6 +5416,8 @@ bb_bytecode_1:
   BUFFER_WRITEI8 %25, %27, %29
   %70 = BUFFER_READU8 %25, %27
   BUFFER_WRITEI8 %25, %27, %70
+  STORE_DOUBLE R5, %11
+  STORE_DOUBLE R8, %11
   %107 = LOAD_POINTER R2
   CHECK_BUFFER_LEN %107, %27, 0i, 2i, %10, exit(32)
   %111 = BUFFER_READI8 %107, %27
@@ -5437,8 +5442,8 @@ bb_bytecode_1:
 TEST_CASE_FIXTURE(LoweringFixture, "BufferSanityNegative")
 {
     ScopedFastFlag luauCodegenBlockSafeEnv{FFlag::LuauCodegenBlockSafeEnv, true};
-    ScopedFastFlag luauCodegenBufferRangeMerge{FFlag::LuauCodegenBufferRangeMerge3, true};
-    ScopedFastFlag luauCodegenMarkDeadRegisters{FFlag::LuauCodegenMarkDeadRegisters, true};
+    ScopedFastFlag luauCodegenBufferRangeMerge{FFlag::LuauCodegenBufferRangeMerge4, true};
+    ScopedFastFlag luauCodegenMarkDeadRegisters{FFlag::LuauCodegenMarkDeadRegisters2, true};
     ScopedFastFlag luauCodegenDseOnCondJump{FFlag::LuauCodegenDseOnCondJump, true};
 
     CHECK_EQ(
@@ -5479,6 +5484,8 @@ bb_bytecode_1:
   BUFFER_WRITEI8 %25, %27, %29
   %70 = BUFFER_READU8 %25, %27
   BUFFER_WRITEI8 %25, %27, %70
+  STORE_DOUBLE R5, %11
+  STORE_DOUBLE R8, %11
   %107 = LOAD_POINTER R2
   CHECK_BUFFER_LEN %107, %27, 0i, 2i, %11, exit(32)
   %111 = BUFFER_READI8 %107, %27
@@ -5503,8 +5510,8 @@ bb_bytecode_1:
 TEST_CASE_FIXTURE(LoweringFixture, "NumericConversionReplacementCheck")
 {
     ScopedFastFlag luauCodegenBlockSafeEnv{FFlag::LuauCodegenBlockSafeEnv, true};
-    ScopedFastFlag luauCodegenBufferRangeMerge{FFlag::LuauCodegenBufferRangeMerge3, true};
-    ScopedFastFlag luauCodegenMarkDeadRegisters{FFlag::LuauCodegenMarkDeadRegisters, true};
+    ScopedFastFlag luauCodegenBufferRangeMerge{FFlag::LuauCodegenBufferRangeMerge4, true};
+    ScopedFastFlag luauCodegenMarkDeadRegisters{FFlag::LuauCodegenMarkDeadRegisters2, true};
     ScopedFastFlag luauCodegenDseOnCondJump{FFlag::LuauCodegenDseOnCondJump, true};
 
     CHECK_EQ(
@@ -5549,8 +5556,8 @@ bb_bytecode_1:
 TEST_CASE_FIXTURE(LoweringFixture, "BufferRelatedIndicesPositiveMultBase")
 {
     ScopedFastFlag luauCodegenBlockSafeEnv{FFlag::LuauCodegenBlockSafeEnv, true};
-    ScopedFastFlag luauCodegenBufferRangeMerge{FFlag::LuauCodegenBufferRangeMerge3, true};
-    ScopedFastFlag luauCodegenMarkDeadRegisters{FFlag::LuauCodegenMarkDeadRegisters, true};
+    ScopedFastFlag luauCodegenBufferRangeMerge{FFlag::LuauCodegenBufferRangeMerge4, true};
+    ScopedFastFlag luauCodegenMarkDeadRegisters{FFlag::LuauCodegenMarkDeadRegisters2, true};
     ScopedFastFlag luauCodegenDseOnCondJump{FFlag::LuauCodegenDseOnCondJump, true};
 
     CHECK_EQ(
@@ -5597,8 +5604,8 @@ bb_bytecode_1:
 TEST_CASE_FIXTURE(LoweringFixture, "BufferRelatedIndicesPositiveMultBase2")
 {
     ScopedFastFlag luauCodegenBlockSafeEnv{FFlag::LuauCodegenBlockSafeEnv, true};
-    ScopedFastFlag luauCodegenBufferRangeMerge{FFlag::LuauCodegenBufferRangeMerge3, true};
-    ScopedFastFlag luauCodegenMarkDeadRegisters{FFlag::LuauCodegenMarkDeadRegisters, true};
+    ScopedFastFlag luauCodegenBufferRangeMerge{FFlag::LuauCodegenBufferRangeMerge4, true};
+    ScopedFastFlag luauCodegenMarkDeadRegisters{FFlag::LuauCodegenMarkDeadRegisters2, true};
     ScopedFastFlag luauCodegenDseOnCondJump{FFlag::LuauCodegenDseOnCondJump, true};
 
     // Different index multipliers are not merged
@@ -5630,7 +5637,11 @@ bb_bytecode_1:
   STORE_DOUBLE R3, %22
   STORE_TAG R3, tnumber
   %29 = ADD_NUM %8, 1
+  STORE_DOUBLE R7, %29
+  STORE_TAG R7, tnumber
   %35 = MUL_NUM %29, 8
+  STORE_DOUBLE R6, %35
+  STORE_TAG R6, tnumber
   %45 = NUM_TO_INT %35
   CHECK_BUFFER_LEN %17, %45, 0i, 4i, undef, exit(11)
   %47 = BUFFER_READI32 %17, %45
@@ -5647,8 +5658,8 @@ bb_bytecode_1:
 TEST_CASE_FIXTURE(LoweringFixture, "BufferRelatedIndicesPositiveMultBaseInt")
 {
     ScopedFastFlag luauCodegenBlockSafeEnv{FFlag::LuauCodegenBlockSafeEnv, true};
-    ScopedFastFlag luauCodegenBufferRangeMerge{FFlag::LuauCodegenBufferRangeMerge3, true};
-    ScopedFastFlag luauCodegenMarkDeadRegisters{FFlag::LuauCodegenMarkDeadRegisters, true};
+    ScopedFastFlag luauCodegenBufferRangeMerge{FFlag::LuauCodegenBufferRangeMerge4, true};
+    ScopedFastFlag luauCodegenMarkDeadRegisters{FFlag::LuauCodegenMarkDeadRegisters2, true};
     ScopedFastFlag luauCodegenDseOnCondJump{FFlag::LuauCodegenDseOnCondJump, true};
 
     CHECK_EQ(
@@ -5677,7 +5688,12 @@ bb_bytecode_1:
   STORE_DOUBLE R2, %13
   STORE_TAG R2, tnumber
   %27 = ADD_INT %10, 8i
+  %30 = UINT_TO_NUM %27
+  STORE_DOUBLE R3, %30
+  STORE_TAG R3, tnumber
   %44 = ADD_INT %10, 16i
+  %47 = UINT_TO_NUM %44
+  STORE_SPLIT_TVALUE R4, tnumber, %47
   %56 = LOAD_POINTER R0
   %58 = TRUNCATE_UINT %10
   CHECK_BUFFER_LEN %56, %58, 0i, 24i, undef, exit(23)
@@ -5693,10 +5709,108 @@ bb_bytecode_1:
     );
 }
 
+TEST_CASE_FIXTURE(LoweringFixture, "BufferRelatedIndicesMixedSizes")
+{
+    ScopedFastFlag luauCodegenBlockSafeEnv{FFlag::LuauCodegenBlockSafeEnv, true};
+    ScopedFastFlag luauCodegenBufferRangeMerge{FFlag::LuauCodegenBufferRangeMerge4, true};
+    ScopedFastFlag luauCodegenMarkDeadRegisters{FFlag::LuauCodegenMarkDeadRegisters2, true};
+    ScopedFastFlag luauCodegenDseOnCondJump{FFlag::LuauCodegenDseOnCondJump, true};
+
+    CHECK_EQ(
+        "\n" + getCodegenAssembly(R"(
+local function foo(buf: buffer, a: number)
+    return buffer.readi8(buf, a) + buffer.readi8(buf, a + 4) + buffer.readf64(buf, a - 1)
+end
+)"),
+        R"(
+; function foo($arg0, $arg1) line 2
+bb_0:
+  CHECK_TAG R0, tbuffer, exit(entry)
+  CHECK_TAG R1, tnumber, exit(entry)
+  JUMP bb_2
+bb_2:
+  JUMP bb_bytecode_1
+bb_bytecode_1:
+  implicit CHECK_SAFE_ENV exit(0)
+  %11 = LOAD_POINTER R0
+  %12 = LOAD_DOUBLE R1
+  %13 = NUM_TO_INT %12
+  CHECK_BUFFER_LEN %11, %13, -1i, 7i, %12, exit(2)
+  %15 = BUFFER_READI8 %11, %13
+  %16 = INT_TO_NUM %15
+  %33 = ADD_INT %13, 4i
+  %35 = BUFFER_READI8 %11, %33
+  %36 = INT_TO_NUM %35
+  %46 = ADD_NUM %16, %36
+  %62 = ADD_INT %13, -1i
+  %64 = BUFFER_READF64 %11, %62
+  %74 = ADD_NUM %46, %64
+  STORE_DOUBLE R2, %74
+  STORE_TAG R2, tnumber
+  INTERRUPT 23u
+  RETURN R2, 1i
+)"
+    );
+}
+
+TEST_CASE_FIXTURE(LoweringFixture, "BufferVmExitSync")
+{
+    ScopedFastFlag luauCodegenBlockSafeEnv{FFlag::LuauCodegenBlockSafeEnv, true};
+    ScopedFastFlag luauCodegenBufferRangeMerge{FFlag::LuauCodegenBufferRangeMerge4, true};
+    ScopedFastFlag luauCodegenMarkDeadRegisters{FFlag::LuauCodegenMarkDeadRegisters2, true};
+
+    CHECK_EQ(
+        "\n" + getCodegenAssembly(R"(
+local function foo(buf: buffer, a: number, b: number, c: number)
+    local x = buffer.readu8(buf, a * b)
+    local y = buffer.readu8(buf, a * b + c)
+    return x, y
+end
+)"),
+        R"(
+; function foo($arg0, $arg1, $arg2, $arg3) line 2
+bb_0:
+  CHECK_TAG R0, tbuffer, exit(entry)
+  CHECK_TAG R1, tnumber, exit(entry)
+  CHECK_TAG R2, tnumber, exit(entry)
+  CHECK_TAG R3, tnumber, exit(entry)
+  JUMP bb_2
+bb_2:
+  JUMP bb_bytecode_1
+bb_bytecode_1:
+  implicit CHECK_SAFE_ENV exit(0)
+  %14 = LOAD_DOUBLE R1
+  %16 = MUL_NUM %14, R2
+  STORE_DOUBLE R6, %16
+  STORE_TAG R6, tnumber
+  %24 = LOAD_POINTER R0
+  %26 = NUM_TO_INT %16
+  CHECK_BUFFER_LEN %24, %26, 0i, 1i, undef, exit(3)
+  %28 = BUFFER_READU8 %24, %26
+  %29 = INT_TO_NUM %28
+  STORE_DOUBLE R4, %29
+  STORE_TAG R4, tnumber
+  STORE_DOUBLE R8, %16
+  STORE_TAG R8, tnumber
+  %48 = ADD_NUM %16, R3
+  STORE_DOUBLE R7, %48
+  STORE_TAG R7, tnumber
+  %58 = NUM_TO_INT %48
+  CHECK_BUFFER_LEN %24, %58, 0i, 1i, undef, exit(11)
+  %60 = BUFFER_READU8 %24, %58
+  %61 = INT_TO_NUM %60
+  STORE_DOUBLE R5, %61
+  STORE_TAG R5, tnumber
+  INTERRUPT 15u
+  RETURN R4, 2i
+)"
+    );
+}
+
 TEST_CASE_FIXTURE(LoweringFixture, "Bit32NoDoubleTemporariesAdd")
 {
     ScopedFastFlag luauCodegenBlockSafeEnv{FFlag::LuauCodegenBlockSafeEnv, true};
-    ScopedFastFlag luauCodegenMarkDeadRegisters{FFlag::LuauCodegenMarkDeadRegisters, true};
+    ScopedFastFlag luauCodegenMarkDeadRegisters{FFlag::LuauCodegenMarkDeadRegisters2, true};
     ScopedFastFlag luauCodegenDseOnCondJump{FFlag::LuauCodegenDseOnCondJump, true};
 
     CHECK_EQ(
@@ -5745,7 +5859,7 @@ bb_bytecode_1:
 TEST_CASE_FIXTURE(LoweringFixture, "Bit32HasToUseDoubleTemporariesAdd")
 {
     ScopedFastFlag luauCodegenBlockSafeEnv{FFlag::LuauCodegenBlockSafeEnv, true};
-    ScopedFastFlag luauCodegenMarkDeadRegisters{FFlag::LuauCodegenMarkDeadRegisters, true};
+    ScopedFastFlag luauCodegenMarkDeadRegisters{FFlag::LuauCodegenMarkDeadRegisters2, true};
     ScopedFastFlag luauCodegenDseOnCondJump{FFlag::LuauCodegenDseOnCondJump, true};
 
     CHECK_EQ(
@@ -5797,7 +5911,7 @@ bb_bytecode_1:
 TEST_CASE_FIXTURE(LoweringFixture, "Bit32NoDoubleTemporariesSub")
 {
     ScopedFastFlag luauCodegenBlockSafeEnv{FFlag::LuauCodegenBlockSafeEnv, true};
-    ScopedFastFlag luauCodegenMarkDeadRegisters{FFlag::LuauCodegenMarkDeadRegisters, true};
+    ScopedFastFlag luauCodegenMarkDeadRegisters{FFlag::LuauCodegenMarkDeadRegisters2, true};
     ScopedFastFlag luauCodegenDseOnCondJump{FFlag::LuauCodegenDseOnCondJump, true};
 
     CHECK_EQ(
@@ -5846,7 +5960,7 @@ bb_bytecode_1:
 TEST_CASE_FIXTURE(LoweringFixture, "Bit32HasToUseDoubleTemporariesSub")
 {
     ScopedFastFlag luauCodegenBlockSafeEnv{FFlag::LuauCodegenBlockSafeEnv, true};
-    ScopedFastFlag luauCodegenMarkDeadRegisters{FFlag::LuauCodegenMarkDeadRegisters, true};
+    ScopedFastFlag luauCodegenMarkDeadRegisters{FFlag::LuauCodegenMarkDeadRegisters2, true};
     ScopedFastFlag luauCodegenDseOnCondJump{FFlag::LuauCodegenDseOnCondJump, true};
 
     CHECK_EQ(
@@ -6487,7 +6601,7 @@ TEST_CASE_FIXTURE(LoweringFixture, "UpvalueAccessLoadStore4")
     ScopedFastFlag luauCodegenBlockSafeEnv{FFlag::LuauCodegenBlockSafeEnv, true};
     ScopedFastFlag luauCodegenSetBlockEntryState{FFlag::LuauCodegenSetBlockEntryState2, true};
     ScopedFastFlag luauCodegenTableLoadProp{FFlag::LuauCodegenTableLoadProp2, true};
-    ScopedFastFlag luauCodegenMarkDeadRegisters{FFlag::LuauCodegenMarkDeadRegisters, true};
+    ScopedFastFlag luauCodegenMarkDeadRegisters{FFlag::LuauCodegenMarkDeadRegisters2, true};
     ScopedFastFlag luauCodegenDseOnCondJump{FFlag::LuauCodegenDseOnCondJump, true};
 
     CHECK_EQ(
@@ -6622,8 +6736,8 @@ bb_bytecode_3:
 TEST_CASE_FIXTURE(LoweringFixture, "BufferLoadStoreProp1")
 {
     ScopedFastFlag luauCodegenBlockSafeEnv{FFlag::LuauCodegenBlockSafeEnv, true};
-    ScopedFastFlag luauCodegenBufferRangeMerge{FFlag::LuauCodegenBufferRangeMerge3, true};
-    ScopedFastFlag luauCodegenMarkDeadRegisters{FFlag::LuauCodegenMarkDeadRegisters, true};
+    ScopedFastFlag luauCodegenBufferRangeMerge{FFlag::LuauCodegenBufferRangeMerge4, true};
+    ScopedFastFlag luauCodegenMarkDeadRegisters{FFlag::LuauCodegenMarkDeadRegisters2, true};
     ScopedFastFlag luauCodegenDseOnCondJump{FFlag::LuauCodegenDseOnCondJump, true};
 
     CHECK_EQ(
@@ -6661,7 +6775,7 @@ bb_bytecode_1:
 TEST_CASE_FIXTURE(LoweringFixture, "BufferLoadStoreProp2")
 {
     ScopedFastFlag luauCodegenBlockSafeEnv{FFlag::LuauCodegenBlockSafeEnv, true};
-    ScopedFastFlag luauCodegenBufferRangeMerge{FFlag::LuauCodegenBufferRangeMerge3, true};
+    ScopedFastFlag luauCodegenBufferRangeMerge{FFlag::LuauCodegenBufferRangeMerge4, true};
 
     CHECK_EQ(
         "\n" + getCodegenAssembly(R"(
@@ -6713,7 +6827,7 @@ bb_8:
 TEST_CASE_FIXTURE(LoweringFixture, "BufferLoadStoreProp3")
 {
     ScopedFastFlag luauCodegenBlockSafeEnv{FFlag::LuauCodegenBlockSafeEnv, true};
-    ScopedFastFlag luauCodegenBufferRangeMerge{FFlag::LuauCodegenBufferRangeMerge3, true};
+    ScopedFastFlag luauCodegenBufferRangeMerge{FFlag::LuauCodegenBufferRangeMerge4, true};
 
     CHECK_EQ(
         "\n" + getCodegenAssembly(R"(
@@ -6822,9 +6936,9 @@ bb_68:
 TEST_CASE_FIXTURE(LoweringFixture, "BufferLoadStoreProp4")
 {
     ScopedFastFlag luauCodegenBlockSafeEnv{FFlag::LuauCodegenBlockSafeEnv, true};
-    ScopedFastFlag luauCodegenBufferRangeMerge{FFlag::LuauCodegenBufferRangeMerge3, true};
+    ScopedFastFlag luauCodegenBufferRangeMerge{FFlag::LuauCodegenBufferRangeMerge4, true};
     ScopedFastFlag luauCodegenTruncatedSubsts{FFlag::LuauCodegenTruncatedSubsts, true};
-    ScopedFastFlag luauCodegenMarkDeadRegisters{FFlag::LuauCodegenMarkDeadRegisters, true};
+    ScopedFastFlag luauCodegenMarkDeadRegisters{FFlag::LuauCodegenMarkDeadRegisters2, true};
     ScopedFastFlag luauCodegenDseOnCondJump{FFlag::LuauCodegenDseOnCondJump, true};
 
     CHECK_EQ(
@@ -6938,7 +7052,7 @@ bb_bytecode_1:
 
 TEST_CASE_FIXTURE(LoweringFixture, "LoopStepDetection1")
 {
-    ScopedFastFlag luauCodegenMarkDeadRegisters{FFlag::LuauCodegenMarkDeadRegisters, true};
+    ScopedFastFlag luauCodegenMarkDeadRegisters{FFlag::LuauCodegenMarkDeadRegisters2, true};
     ScopedFastFlag luauCodegenDseOnCondJump{FFlag::LuauCodegenDseOnCondJump, true};
     assemblyOptions.includeRegFlowInfo = Luau::CodeGen::IncludeRegFlowInfo::Yes;
 
@@ -7003,7 +7117,7 @@ bb_bytecode_3:
 TEST_CASE_FIXTURE(LoweringFixture, "LoopStepDetection2")
 {
     ScopedFastFlag luauCodegenSetBlockEntryState{FFlag::LuauCodegenSetBlockEntryState2, true};
-    ScopedFastFlag luauCodegenMarkDeadRegisters{FFlag::LuauCodegenMarkDeadRegisters, true};
+    ScopedFastFlag luauCodegenMarkDeadRegisters{FFlag::LuauCodegenMarkDeadRegisters2, true};
     ScopedFastFlag luauCodegenDseOnCondJump{FFlag::LuauCodegenDseOnCondJump, true};
 
     CHECK_EQ(
@@ -7081,8 +7195,8 @@ bb_bytecode_3:
 TEST_CASE_FIXTURE(LoweringFixture, "UintSourceSanity")
 {
     ScopedFastFlag luauCodegenBlockSafeEnv{FFlag::LuauCodegenBlockSafeEnv, true};
-    ScopedFastFlag luauCodegenBufferRangeMerge{FFlag::LuauCodegenBufferRangeMerge3, true};
-    ScopedFastFlag luauCodegenMarkDeadRegisters{FFlag::LuauCodegenMarkDeadRegisters, true};
+    ScopedFastFlag luauCodegenBufferRangeMerge{FFlag::LuauCodegenBufferRangeMerge4, true};
+    ScopedFastFlag luauCodegenMarkDeadRegisters{FFlag::LuauCodegenMarkDeadRegisters2, true};
     ScopedFastFlag luauCodegenDseOnCondJump{FFlag::LuauCodegenDseOnCondJump, true};
 
     // TODO: opportunity - many conversions and stores remain because of VM exits
@@ -7132,6 +7246,9 @@ bb_bytecode_1:
   STORE_DOUBLE R5, %57
   %64 = LOAD_POINTER R2
   %65 = STRING_LEN %64
+  %66 = INT_TO_NUM %65
+  STORE_DOUBLE R8, %66
+  STORE_TAG R8, tnumber
   CHECK_BUFFER_LEN %24, %65, 0i, 4i, undef, exit(34)
   %79 = BUFFER_READI32 %24, %65
   %80 = UINT_TO_NUM %79
@@ -7146,7 +7263,7 @@ bb_bytecode_1:
 TEST_CASE_FIXTURE(LoweringFixture, "LibmIsPure")
 {
     ScopedFastFlag luauCodegenBlockSafeEnv{FFlag::LuauCodegenBlockSafeEnv, true};
-    ScopedFastFlag luauCodegenMarkDeadRegisters{FFlag::LuauCodegenMarkDeadRegisters, true};
+    ScopedFastFlag luauCodegenMarkDeadRegisters{FFlag::LuauCodegenMarkDeadRegisters2, true};
     ScopedFastFlag luauCodegenDseOnCondJump{FFlag::LuauCodegenDseOnCondJump, true};
     ScopedFastFlag luauCompileExtraTypes{FFlag::LuauCompileExtraTypes, true};
 
@@ -7200,7 +7317,7 @@ bb_bytecode_1:
 TEST_CASE_FIXTURE(LoweringFixture, "VecOpReuse")
 {
     ScopedFastFlag luauCodegenBlockSafeEnv{FFlag::LuauCodegenBlockSafeEnv, true};
-    ScopedFastFlag luauCodegenMarkDeadRegisters{FFlag::LuauCodegenMarkDeadRegisters, true};
+    ScopedFastFlag luauCodegenMarkDeadRegisters{FFlag::LuauCodegenMarkDeadRegisters2, true};
     ScopedFastFlag luauCodegenDseOnCondJump{FFlag::LuauCodegenDseOnCondJump, true};
 
     CHECK_EQ(

--- a/tests/Linter.test.cpp
+++ b/tests/Linter.test.cpp
@@ -8,8 +8,6 @@
 #include "doctest.h"
 
 LUAU_FASTFLAG(DebugLuauForceOldSolver)
-
-LUAU_FASTFLAG(LuauExplicitTypeInstantiationSyntax)
 LUAU_FASTFLAG(LuauLinterVectorPrimitive)
 
 using namespace Luau;
@@ -2561,8 +2559,6 @@ f(3)(4)
 
 TEST_CASE_FIXTURE(Fixture, "type_instantiation_lints")
 {
-    ScopedFastFlag sff{FFlag::LuauExplicitTypeInstantiationSyntax, true};
-
     LintResult result = lint(R"(
 local function a<b>(cool: b)
     print(cool)

--- a/tests/NonStrictTypeChecker.test.cpp
+++ b/tests/NonStrictTypeChecker.test.cpp
@@ -20,7 +20,6 @@ LUAU_DYNAMIC_FASTINT(LuauConstraintGeneratorRecursionLimit)
 LUAU_FASTINT(LuauNonStrictTypeCheckerRecursionLimit)
 LUAU_FASTINT(LuauCheckRecursionLimit)
 LUAU_FASTFLAG(LuauAddRecursionCounterToNonStrictTypeChecker)
-LUAU_FASTFLAG(LuauExplicitTypeInstantiationSyntax)
 LUAU_FASTFLAG(LuauExplicitTypeInstantiationSupport)
 LUAU_FASTFLAG(DebugLuauForceOldSolver)
 
@@ -463,7 +462,6 @@ end
 
 TEST_CASE_FIXTURE(NonStrictTypeCheckerFixture, "generic_type_instantiation")
 {
-    ScopedFastFlag syntax{FFlag::LuauExplicitTypeInstantiationSyntax, true};
     ScopedFastFlag semantics{FFlag::LuauExplicitTypeInstantiationSupport, true};
 
     CheckResult result = checkNonStrict(R"(

--- a/tests/Parser.test.cpp
+++ b/tests/Parser.test.cpp
@@ -17,8 +17,6 @@ LUAU_FASTINT(LuauRecursionLimit)
 LUAU_FASTINT(LuauTypeLengthLimit)
 LUAU_FASTINT(LuauParseErrorLimit)
 LUAU_DYNAMIC_FASTFLAG(DebugLuauReportReturnTypeVariadicWithTypeSuffix)
-LUAU_FASTFLAG(LuauExplicitTypeInstantiationSyntax)
-LUAU_FASTFLAG(LuauCstStatDoWithStatsStart)
 LUAU_FASTFLAG(LuauConst2)
 LUAU_FASTFLAG(DebugLuauNoInline)
 
@@ -2849,8 +2847,6 @@ TEST_CASE_FIXTURE(Fixture, "for_loop_with_single_var_has_comma_positions_of_size
 
 TEST_CASE_FIXTURE(Fixture, "explicit_type_instantiation_expression_call")
 {
-    ScopedFastFlag sff{FFlag::LuauExplicitTypeInstantiationSyntax, true};
-
     std::string source = "local x = f<<T, U>>()";
 
     ParseResult result = parseEx(source);
@@ -2875,24 +2871,18 @@ TEST_CASE_FIXTURE(Fixture, "explicit_type_instantiation_expression_call")
 
 TEST_CASE_FIXTURE(Fixture, "explicit_type_instantiation_expression")
 {
-    ScopedFastFlag sff{FFlag::LuauExplicitTypeInstantiationSyntax, true};
-
     AstStat* stat = parse("local x = f<<T, U>>");
     REQUIRE(stat != nullptr);
 }
 
 TEST_CASE_FIXTURE(Fixture, "explicit_type_instantiation_statement")
 {
-    ScopedFastFlag sff{FFlag::LuauExplicitTypeInstantiationSyntax, true};
-
     AstStat* stat = parse("f<<T, U>>()");
     REQUIRE(stat != nullptr);
 }
 
 TEST_CASE_FIXTURE(Fixture, "explicit_type_instantiation_indexing")
 {
-    ScopedFastFlag sff{FFlag::LuauExplicitTypeInstantiationSyntax, true};
-
     AstStat* stat = parse(R"(
         t.f<<T, U>>()
         t:f<<T, U>>()
@@ -2903,8 +2893,6 @@ TEST_CASE_FIXTURE(Fixture, "explicit_type_instantiation_indexing")
 
 TEST_CASE_FIXTURE(Fixture, "explicit_type_instantiation_empty_list")
 {
-    ScopedFastFlag sff{FFlag::LuauExplicitTypeInstantiationSyntax, true};
-
     AstStat* stat = parse(R"(
         f<<>>()
     )");
@@ -2929,8 +2917,6 @@ TEST_CASE_FIXTURE(Fixture, "basic_less_than_check_no_explicit_type_instantiaton"
 
 TEST_CASE_FIXTURE(Fixture, "do_end_block_with_cst")
 {
-    ScopedFastFlag sff{FFlag::LuauCstStatDoWithStatsStart, true};
-
     ParseOptions parseOptions;
     parseOptions.storeCstData = true;
 
@@ -4791,8 +4777,6 @@ TEST_CASE_FIXTURE(Fixture, "parse_type_name")
 
 TEST_CASE_FIXTURE(Fixture, "explicit_type_instantiation_errors")
 {
-    ScopedFastFlag sff{FFlag::LuauExplicitTypeInstantiationSyntax, true};
-
     matchParseError("local a = x:a<<T>>", "Expected '(', '{' or <string> when parsing function call, got <eof>");
 }
 

--- a/tests/PrettyPrinter.test.cpp
+++ b/tests/PrettyPrinter.test.cpp
@@ -10,7 +10,6 @@
 
 #include "doctest.h"
 
-LUAU_FASTFLAG(LuauExplicitTypeInstantiationSyntax)
 LUAU_FASTFLAG(DebugLuauNoInline)
 
 using namespace Luau;
@@ -2142,8 +2141,6 @@ TEST_CASE("prettyPrint_function_attributes")
 
 TEST_CASE("transpile_explicit_type_instantiations")
 {
-    ScopedFastFlag sff{FFlag::LuauExplicitTypeInstantiationSyntax, true};
-
     std::string code = "f<<A, B, C...>>() t.f<<A, B, C...>>() t:f<<A, B, C>>()";
     CHECK_EQ(code, prettyPrint(code, {}, true).code);
 

--- a/tests/RuntimeLimits.test.cpp
+++ b/tests/RuntimeLimits.test.cpp
@@ -24,7 +24,6 @@ LUAU_FASTINT(LuauTypeInferIterationLimit)
 LUAU_FASTINT(LuauTypeInferRecursionLimit)
 
 LUAU_FASTFLAG(DebugLuauForceOldSolver)
-LUAU_FASTFLAG(LuauIceLess)
 LUAU_FASTFLAG(LuauUseNativeStackGuard)
 LUAU_FASTINT(LuauGenericCounterMaxSteps)
 LUAU_FASTFLAG(LuauUnifyWithSubtyping2)

--- a/tests/TypeFunction.test.cpp
+++ b/tests/TypeFunction.test.cpp
@@ -15,7 +15,6 @@ using namespace Luau;
 LUAU_FASTFLAG(DebugLuauForceOldSolver)
 LUAU_DYNAMIC_FASTINT(LuauTypeFamilyApplicationCartesianProductLimit)
 LUAU_FASTFLAG(DebugLuauAssertOnForcedConstraint)
-LUAU_FASTFLAG(LuauExplicitTypeInstantiationSyntax)
 LUAU_FASTFLAG(LuauExplicitTypeInstantiationSupport)
 LUAU_FASTFLAG(LuauReworkInfiniteTypeFinder)
 LUAU_FASTFLAG(LuauTypeFunctionsCaptureNestedInstances)
@@ -2020,7 +2019,6 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "oss_2114_type_instantiation_on_type_function
 {
     ScopedFastFlag sffs[] = {
         {FFlag::DebugLuauForceOldSolver, false},
-        {FFlag::LuauExplicitTypeInstantiationSyntax, true},
         {FFlag::LuauExplicitTypeInstantiationSupport, true},
     };
 
@@ -2045,7 +2043,6 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "oss_2144_type_instantiation_on_type_function
 {
     ScopedFastFlag sffs[] = {
         {FFlag::DebugLuauForceOldSolver, false},
-        {FFlag::LuauExplicitTypeInstantiationSyntax, true},
         {FFlag::LuauExplicitTypeInstantiationSupport, true},
     };
 

--- a/tests/TypeInfer.builtins.test.cpp
+++ b/tests/TypeInfer.builtins.test.cpp
@@ -12,7 +12,6 @@ using namespace Luau;
 
 LUAU_FASTFLAG(DebugLuauForceOldSolver)
 LUAU_FASTFLAG(LuauPcallCallbackCanReturnZeroValues)
-LUAU_FASTFLAG(LuauExplicitTypeInstantiationSyntax)
 LUAU_FASTFLAG(LuauExplicitTypeInstantiationSupport)
 LUAU_FASTFLAG(LuauTableFreezeCheckIsSubtype)
 LUAU_FASTFLAG(LuauSilenceDynamicFormatStringErrors)
@@ -1917,7 +1916,6 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "vector_lerp_should_not_crash")
 TEST_CASE_FIXTURE(BuiltinsFixture, "instantiation_works_on_builtins")
 {
     ScopedFastFlag sffs[] = {
-        {FFlag::LuauExplicitTypeInstantiationSyntax, true},
         {FFlag::LuauExplicitTypeInstantiationSupport, true},
     };
 

--- a/tests/TypeInfer.functions.test.cpp
+++ b/tests/TypeInfer.functions.test.cpp
@@ -35,6 +35,7 @@ LUAU_FASTFLAG(LuauReplacerRespectsReboundGenerics)
 LUAU_FASTFLAG(LuauCaptureRecursiveCallsForTablesAndGlobals2)
 LUAU_FASTFLAG(LuauForwardPolarityForFunctionTypes)
 LUAU_FASTFLAG(LuauReplacerRespectsReboundGenerics)
+LUAU_FASTFLAG(LuauKeepExplicitMapForGlobalTypes)
 
 TEST_SUITE_BEGIN("TypeInferFunctions");
 
@@ -4127,6 +4128,29 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "lute_tasklib_createtask")
         "((...any) -> (unknown, ...unknown), ...any) -> { co: thread, result: unknown, success: boolean }",
         toString(requireType("createtask"))
     );
+}
+
+TEST_CASE_FIXTURE(Fixture, "global_emplacing_steals_type_from_elsewhere")
+{
+    ScopedFastFlag sffs[] = {
+        {FFlag::DebugLuauForceOldSolver, false},
+        {FFlag::LuauKeepExplicitMapForGlobalTypes, true},
+    };
+
+    CheckResult result = check(R"(
+        local function f()
+            return 42
+        end
+        local a = f()
+        b = a
+        local c = b
+        function b()
+        end
+    )");
+
+    CHECK_EQ("number", toString(requireType("a")));
+    CHECK_EQ("() -> ()", toString(requireType("b")));
+    CHECK_EQ("number", toString(requireType("c")));
 }
 
 TEST_SUITE_END();

--- a/tests/TypeInfer.generics.test.cpp
+++ b/tests/TypeInfer.generics.test.cpp
@@ -1034,7 +1034,6 @@ end
 wrapper(test2, 1, "", 3)
     )");
 
-    // What the fuck? Do we not check for function argument overflow?
     LUAU_REQUIRE_ERROR_COUNT(1, result);
     if (!FFlag::DebugLuauForceOldSolver)
     {

--- a/tests/TypeInfer.oop.test.cpp
+++ b/tests/TypeInfer.oop.test.cpp
@@ -15,7 +15,6 @@
 
 using namespace Luau;
 
-LUAU_FASTFLAG(LuauTrackFreeInteriorTypePacks)
 LUAU_FASTFLAG(DebugLuauForceOldSolver)
 
 TEST_SUITE_BEGIN("TypeInferOOP");

--- a/tests/TypeInfer.tables.test.cpp
+++ b/tests/TypeInfer.tables.test.cpp
@@ -28,6 +28,7 @@ LUAU_FASTFLAG(LuauSubtypingMissingPropertiesAsNil)
 LUAU_FASTFLAG(LuauRelateHandlesCoincidentTables)
 LUAU_FASTFLAG(LuauComparisonToNilsIsAlwaysOk2)
 LUAU_FASTFLAG(LuauGeneralizationMoreAwareOfBounds3)
+LUAU_FASTFLAG(LuauLValueCompoundAssignmentVisitLhs)
 LUAU_FASTFLAG(LuauUnifier2HandleMismatchedPacks2)
 LUAU_FASTFLAG(LuauReplacerRespectsReboundGenerics)
 LUAU_FASTFLAG(LuauOverloadGetsInstantiated)
@@ -6734,108 +6735,10 @@ TEST_CASE_FIXTURE(Fixture, "oss_1890")
     )"));
 }
 
-TEST_CASE_FIXTURE(Fixture, "cmpeq_any_with_nil_ok")
-{
-    ScopedFastFlag sff[] = {
-        {FFlag::DebugLuauForceOldSolver, false},
-        {FFlag::LuauComparisonToNilsIsAlwaysOk2, true},
-    };
-
-    CheckResult result = check(R"(
-type A = {
-    foo : { [string] : string}
-}
-
-type B = {
-	parsed: A,
-}
-
-local x : B = (nil :: any)
-local found = x.parsed.foo["any"] == nil -- errors
-)");
-
-    LUAU_REQUIRE_NO_ERRORS(result);
-}
-
-TEST_CASE_FIXTURE(Fixture, "cmpneq_any_with_nil_ok")
-{
-    ScopedFastFlag sff[] = {
-        {FFlag::DebugLuauForceOldSolver, false},
-        {FFlag::LuauComparisonToNilsIsAlwaysOk2, true},
-    };
-
-    CheckResult result = check(R"(
-type A = {
-    foo : { [string] : string}
-}
-
-type B = {
-	parsed: A,
-}
-
-local x : B = (nil :: any)
-local found = x.parsed.foo["any"] ~= nil -- errors
-)");
-
-    LUAU_REQUIRE_NO_ERRORS(result);
-}
-
-TEST_CASE_FIXTURE(Fixture, "cmpneq_any_with_nil_ok_in_if")
-{
-    ScopedFastFlag sff[] = {
-        {FFlag::DebugLuauForceOldSolver, false},
-        {FFlag::LuauComparisonToNilsIsAlwaysOk2, true},
-    };
-
-    CheckResult result = check(R"(
-type A = {
-    foo : { [string] : string}
-}
-
-type B = {
-	parsed: A,
-}
-
-local x : B = (nil :: any)
-
-if x.parsed.foo["any"] ~= nil then
-end
-
-)");
-
-    LUAU_REQUIRE_NO_ERRORS(result);
-}
-
-TEST_CASE_FIXTURE(Fixture, "cmpeq_any_with_nil_ok_in_if")
-{
-    ScopedFastFlag sff[] = {
-        {FFlag::DebugLuauForceOldSolver, false},
-        {FFlag::LuauComparisonToNilsIsAlwaysOk2, true},
-    };
-
-    CheckResult result = check(R"(
-type A = {
-    foo : { [string] : string}
-}
-
-type B = {
-	parsed: A,
-}
-
-local x : B = (nil :: any)
-
-if x.parsed.foo["any"] == nil then
-end
-
-)");
-
-    LUAU_REQUIRE_NO_ERRORS(result);
-}
-
 TEST_CASE_FIXTURE(Fixture, "compound_assignment_writes_lhs")
 {
-    if (!FFlag::LuauSolverV2)
-        return;
+    // the old solver does not support read-only properties.
+    DOES_NOT_PASS_OLD_SOLVER_GUARD();
 
     ScopedFastFlag sff{FFlag::LuauLValueCompoundAssignmentVisitLhs, true};
 
@@ -6851,5 +6754,6 @@ TEST_CASE_FIXTURE(Fixture, "compound_assignment_writes_lhs")
     LUAU_REQUIRE_ERROR_COUNT(1, result);
     REQUIRE(get<PropertyAccessViolation>(result.errors[0]));
 }
+
 
 TEST_SUITE_END();

--- a/tests/TypeInfer.test.cpp
+++ b/tests/TypeInfer.test.cpp
@@ -33,6 +33,12 @@ LUAU_FASTFLAG(LuauMissingFollowMappedGenericPacks)
 LUAU_FASTFLAG(LuauTryToOptimizeSetTypeUnification)
 LUAU_FASTFLAG(DebugLuauForbidInternalTypes)
 LUAU_FASTFLAG(LuauInstantiationUsesGenericPolarityFollow)
+LUAU_FASTFLAG(LuauFollowInExplicitInstantiation)
+LUAU_FASTFLAG(LuauKeepExplicitMapForGlobalTypes)
+LUAU_FASTFLAG(LuauFollowGenericBeforeCheckingIfMapped)
+LUAU_FASTFLAG(LuauTypeFunctionsAddFreeTypePackWithPositivePolarity)
+LUAU_FASTFLAG(LuauUnifier2HandleMismatchedPacks2)
+LUAU_FASTFLAG(LuauCaptureRecursiveCallsForTablesAndGlobals2)
 
 using namespace Luau;
 
@@ -2759,6 +2765,110 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "fuzzer_missing_follow_in_instantiation2")
 
     LUAU_REQUIRE_ERRORS(check(R"(
         _ = if {l0._,} then if _ then _ elseif rawset({[_]=_,[{_._,}]=_,}) then _ else {_._,} elseif rawset(_) then (true),""
+    )"));
+}
+
+TEST_CASE_FIXTURE(Fixture, "fuzzer_missing_follow_in_function_call")
+{
+    ScopedFastFlag _{FFlag::LuauFollowInExplicitInstantiation, true};
+
+    LUAU_REQUIRE_ERRORS(check(R"(
+        do end
+        _ = if _ then true elseif _ then if _ then _ elseif _ then 2 .. {} elseif _._ then l0 else _ elseif _ then if ... then _ elseif {} then `` elseif _ then {_G=_,}
+        type t0<),A,)...> = ({_G:any,write n0:any,write _:any<<A...>()->()>,write [any]:""""""""""""""""""""userda290013136ta:(0x000062900131369029001313690"""})|(l0.any)
+    )"));
+}
+
+TEST_CASE_FIXTURE(BuiltinsFixture, "fuzzer_avoid_emplacing_blocked_types_you_dont_own")
+{
+    ScopedFastFlag _{FFlag::LuauKeepExplicitMapForGlobalTypes, true};
+
+    LUAU_REQUIRE_ERRORS(check(R"(
+        if if _ then _ else nil then
+            local l0 = require(module0)
+            _ = l0
+        elseif _ then
+            function _(l0:true,...)
+            end
+        else
+        end
+        _ = l0
+    )"));
+
+    LUAU_REQUIRE_ERRORS(check(R"(
+        local l0 = require(module0)
+        local l10 = require(module0)
+        do end
+        for l0=_,_,true do
+        end
+        do
+        local l0 = require(module0)
+        _ = l0
+        local l10 = require(module0)
+        function _()
+        end
+        end
+        local l10 = require(module0)
+    )"));
+}
+
+TEST_CASE_FIXTURE(Fixture, "fuzzer_attach_polarity_to_ret_free_type")
+{
+    ScopedFastFlag _{FFlag::LuauTypeFunctionsAddFreeTypePackWithPositivePolarity, true};
+
+    // When we dispatch constraints in *just* the right order, we end up
+    // evaluating the type of `1 // setmetatable({}, FOO)` before we
+    // generalize the type of the lambda passed to `__idiv`. We end up
+    // with a free type who's polarity is unknown prior to this PR.
+    LUAU_REQUIRE_ERRORS(check(R"(
+        FOO =
+            {
+                [1 // setmetatable({}, FOO)] = 2,
+                __idiv = function(lhs, rhs, ...) return ... end,
+            }
+    )"));
+}
+
+TEST_CASE_FIXTURE(BuiltinsFixture, "fuzzer_missing_follow_in_checking_generic_mapping")
+{
+    ScopedFastFlag _{FFlag::LuauFollowGenericBeforeCheckingIfMapped, true};
+
+    LUAU_REQUIRE_ERRORS(check(R"(
+        function _<U...,M...>(l0,l0,l0,l0,)
+            l0(_(rshift),_()(_(if _ then _),))
+            _()(_(_(_)))
+        end
+        _()(_()(_(true,_)),)
+    )"));
+
+    LUAU_REQUIRE_ERRORS(check(R"(
+        function _<Y...,U...,M...>(l0:any,l0,l0,...)
+            _()(_,_()(_(_()),_))
+            do end
+        end
+        do end
+        _()(_(""),{})
+        do end
+        for _ in ... do
+        end
+    )"));
+}
+
+TEST_CASE_FIXTURE(BuiltinsFixture, "fuzzer_allow_failing_to_bind_generic")
+{
+    ScopedFastFlag sff[] = {
+        {FFlag::LuauUnifier2HandleMismatchedPacks2, true},
+        {FFlag::LuauCaptureRecursiveCallsForTablesAndGlobals2, true},
+    };
+
+    LUAU_REQUIRE_ERRORS(check(R"(  
+        function test(arg1, arg2)
+            local fun1 = test(test)
+            local fun2 = test(test())
+            fun1(arg2, fun2)
+        end
+
+        test()
     )"));
 }
 

--- a/tests/TypeInfer.typeInstantiations.test.cpp
+++ b/tests/TypeInfer.typeInstantiations.test.cpp
@@ -6,7 +6,6 @@
 using namespace Luau;
 
 LUAU_FASTFLAG(DebugLuauForceOldSolver)
-LUAU_FASTFLAG(LuauExplicitTypeInstantiationSyntax)
 LUAU_FASTFLAG(LuauExplicitTypeInstantiationSupport)
 LUAU_FASTFLAG(LuauMorePreciseErrorSuppression)
 LUAU_FASTFLAG(LuauReplacerRespectsReboundGenerics)
@@ -22,7 +21,6 @@ TEST_CASE_FIXTURE(Fixture, "as_expression_correct")
 {
     SUBCASE_BOTH_SOLVERS()
     {
-        ScopedFastFlag syntax{FFlag::LuauExplicitTypeInstantiationSyntax, true};
         ScopedFastFlag semantics{FFlag::LuauExplicitTypeInstantiationSupport, true};
 
         CheckResult result = check(R"(
@@ -42,7 +40,6 @@ TEST_CASE_FIXTURE(Fixture, "as_expression_incorrect")
 {
     SUBCASE_BOTH_SOLVERS()
     {
-        ScopedFastFlag syntax{FFlag::LuauExplicitTypeInstantiationSyntax, true};
         ScopedFastFlag semantics{FFlag::LuauExplicitTypeInstantiationSupport, true};
 
         CheckResult result = check(R"(
@@ -74,7 +71,6 @@ TEST_CASE_FIXTURE(Fixture, "as_stmt_correct")
 {
     SUBCASE_BOTH_SOLVERS()
     {
-        ScopedFastFlag syntax{FFlag::LuauExplicitTypeInstantiationSyntax, true};
         ScopedFastFlag semantics{FFlag::LuauExplicitTypeInstantiationSupport, true};
 
         CheckResult result = check(R"(
@@ -94,7 +90,6 @@ TEST_CASE_FIXTURE(Fixture, "as_stmt_incorrect")
 {
     SUBCASE_BOTH_SOLVERS()
     {
-        ScopedFastFlag syntax{FFlag::LuauExplicitTypeInstantiationSyntax, true};
         ScopedFastFlag semantics{FFlag::LuauExplicitTypeInstantiationSupport, true};
 
         CheckResult result = check(R"(
@@ -140,7 +135,6 @@ TEST_CASE_FIXTURE(Fixture, "multiple_calls")
 {
     SUBCASE_BOTH_SOLVERS()
     {
-        ScopedFastFlag syntax{FFlag::LuauExplicitTypeInstantiationSyntax, true};
         ScopedFastFlag semantics{FFlag::LuauExplicitTypeInstantiationSupport, true};
 
         CheckResult result = check(R"(
@@ -161,7 +155,6 @@ TEST_CASE_FIXTURE(Fixture, "anonymous_type_inferred")
 {
     SUBCASE_BOTH_SOLVERS()
     {
-        ScopedFastFlag syntax{FFlag::LuauExplicitTypeInstantiationSyntax, true};
         ScopedFastFlag semantics{FFlag::LuauExplicitTypeInstantiationSupport, true};
 
         CheckResult result = check(R"(
@@ -183,7 +176,6 @@ TEST_CASE_FIXTURE(Fixture, "anonymous_type_inferred")
 
 TEST_CASE_FIXTURE(Fixture, "type_packs")
 {
-    ScopedFastFlag syntax{FFlag::LuauExplicitTypeInstantiationSyntax, true};
     ScopedFastFlag semantics{FFlag::LuauExplicitTypeInstantiationSupport, true};
 
     // FIXME: This triggers a GenericTypePackCountMismatch error, and it's not obvious if the
@@ -202,7 +194,6 @@ TEST_CASE_FIXTURE(Fixture, "type_packs")
 
 TEST_CASE_FIXTURE(Fixture, "type_packs_method")
 {
-    ScopedFastFlag syntax{FFlag::LuauExplicitTypeInstantiationSyntax, true};
     ScopedFastFlag semantics{FFlag::LuauExplicitTypeInstantiationSupport, true};
 
     // FIXME: This triggers a GenericTypePackCountMismatch error, and it's not obvious if the
@@ -223,7 +214,6 @@ TEST_CASE_FIXTURE(Fixture, "type_packs_method")
 
 TEST_CASE_FIXTURE(Fixture, "type_packs_incorrect")
 {
-    ScopedFastFlag syntax{FFlag::LuauExplicitTypeInstantiationSyntax, true};
     ScopedFastFlag semantics{FFlag::LuauExplicitTypeInstantiationSupport, true};
 
     // FIXME: This triggers a GenericTypePackCountMismatch error, and it's not obvious if the
@@ -242,7 +232,6 @@ TEST_CASE_FIXTURE(Fixture, "type_packs_incorrect")
 
 TEST_CASE_FIXTURE(Fixture, "type_packs_incorrect_method")
 {
-    ScopedFastFlag syntax{FFlag::LuauExplicitTypeInstantiationSyntax, true};
     ScopedFastFlag semantics{FFlag::LuauExplicitTypeInstantiationSupport, true};
 
     // FIXME: This triggers a GenericTypePackCountMismatch error, and it's not obvious if the
@@ -265,7 +254,6 @@ TEST_CASE_FIXTURE(Fixture, "dot_index_call")
 {
     SUBCASE_BOTH_SOLVERS()
     {
-        ScopedFastFlag syntax{FFlag::LuauExplicitTypeInstantiationSyntax, true};
         ScopedFastFlag semantics{FFlag::LuauExplicitTypeInstantiationSupport, true};
 
         CheckResult result = check(R"(
@@ -289,7 +277,6 @@ TEST_CASE_FIXTURE(Fixture, "method_index_call")
 {
     SUBCASE_BOTH_SOLVERS()
     {
-        ScopedFastFlag syntax{FFlag::LuauExplicitTypeInstantiationSyntax, true};
         ScopedFastFlag semantics{FFlag::LuauExplicitTypeInstantiationSupport, true};
 
         CheckResult result = check(R"(
@@ -314,7 +301,6 @@ TEST_CASE_FIXTURE(Fixture, "stored_as_variable")
 {
     SUBCASE_BOTH_SOLVERS()
     {
-        ScopedFastFlag syntax{FFlag::LuauExplicitTypeInstantiationSyntax, true};
         ScopedFastFlag semantics{FFlag::LuauExplicitTypeInstantiationSupport, true};
 
         CheckResult result = check(R"(
@@ -339,7 +325,6 @@ TEST_CASE_FIXTURE(Fixture, "not_a_function")
 {
     SUBCASE_BOTH_SOLVERS()
     {
-        ScopedFastFlag syntax{FFlag::LuauExplicitTypeInstantiationSyntax, true};
         ScopedFastFlag semantics{FFlag::LuauExplicitTypeInstantiationSupport, true};
 
         CheckResult result = check(R"(
@@ -359,7 +344,6 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "metatable_call")
 {
     SUBCASE_BOTH_SOLVERS()
     {
-        ScopedFastFlag syntax{FFlag::LuauExplicitTypeInstantiationSyntax, true};
         ScopedFastFlag semantics{FFlag::LuauExplicitTypeInstantiationSupport, true};
 
         CheckResult result = check(R"(
@@ -384,7 +368,6 @@ TEST_CASE_FIXTURE(Fixture, "method_call_incomplete")
 {
     SUBCASE_BOTH_SOLVERS()
     {
-        ScopedFastFlag syntax{FFlag::LuauExplicitTypeInstantiationSyntax, true};
         ScopedFastFlag semantics{FFlag::LuauExplicitTypeInstantiationSupport, true};
 
         CheckResult result = check(R"(
@@ -409,7 +392,6 @@ TEST_CASE_FIXTURE(Fixture, "too_many_provided")
 {
     SUBCASE_BOTH_SOLVERS()
     {
-        ScopedFastFlag syntax{FFlag::LuauExplicitTypeInstantiationSyntax, true};
         ScopedFastFlag semantics{FFlag::LuauExplicitTypeInstantiationSupport, true};
 
         CheckResult result = check(R"(
@@ -443,7 +425,6 @@ TEST_CASE_FIXTURE(Fixture, "too_many_provided_type_packs")
 {
     SUBCASE_BOTH_SOLVERS()
     {
-        ScopedFastFlag syntax{FFlag::LuauExplicitTypeInstantiationSyntax, true};
         ScopedFastFlag semantics{FFlag::LuauExplicitTypeInstantiationSupport, true};
 
         CheckResult result = check(R"(
@@ -477,7 +458,6 @@ TEST_CASE_FIXTURE(Fixture, "too_many_provided_method")
 {
     SUBCASE_BOTH_SOLVERS()
     {
-        ScopedFastFlag syntax{FFlag::LuauExplicitTypeInstantiationSyntax, true};
         ScopedFastFlag semantics{FFlag::LuauExplicitTypeInstantiationSupport, true};
 
         CheckResult result = check(R"(
@@ -514,7 +494,6 @@ TEST_CASE_FIXTURE(Fixture, "too_many_type_packs_provided_method")
 {
     SUBCASE_BOTH_SOLVERS()
     {
-        ScopedFastFlag syntax{FFlag::LuauExplicitTypeInstantiationSyntax, true};
         ScopedFastFlag semantics{FFlag::LuauExplicitTypeInstantiationSupport, true};
 
         CheckResult result = check(R"(
@@ -551,7 +530,6 @@ TEST_CASE_FIXTURE(Fixture, "function_intersections")
 {
     SUBCASE_BOTH_SOLVERS()
     {
-        ScopedFastFlag syntax{FFlag::LuauExplicitTypeInstantiationSyntax, true};
         ScopedFastFlag semantics{FFlag::LuauExplicitTypeInstantiationSupport, true};
 
         CheckResult result = check(R"(
@@ -571,7 +549,6 @@ TEST_CASE_FIXTURE(Fixture, "incomplete_type_packs")
 {
     SUBCASE_BOTH_SOLVERS()
     {
-        ScopedFastFlag syntax{FFlag::LuauExplicitTypeInstantiationSyntax, true};
         ScopedFastFlag semantics{FFlag::LuauExplicitTypeInstantiationSupport, true};
 
         CheckResult result = check(R"(
@@ -591,7 +568,6 @@ TEST_CASE_FIXTURE(Fixture, "replacing_generic_with_generic")
     // This really only does the right thing in the new solver.
     ScopedFastFlag sffs[] = {
         {FFlag::DebugLuauForceOldSolver, false},
-        {FFlag::LuauExplicitTypeInstantiationSyntax, true},
         {FFlag::LuauExplicitTypeInstantiationSupport, true},
         {FFlag::LuauReplacerRespectsReboundGenerics, true},
     };

--- a/tests/conformance/stringinterp.luau
+++ b/tests/conformance/stringinterp.luau
@@ -57,5 +57,6 @@ assertEq(shadowsString(1), "Value is 1")
 assertEq(`\u{0041}\t`, "A\t")
 
 assertEq(`{"5"} + {7} = 12`, "5 + 7 = 12")
+assertEq(`\0{123}\0`, "\000123\0")
 
 return "OK"

--- a/tests/conformance/tables.luau
+++ b/tests/conformance/tables.luau
@@ -820,4 +820,18 @@ do
   end
 end
 
+do
+  -- any optimization related to constant fields must preserve side effects that may be relied upon
+  local should_change = false
+
+  function side_effect()
+    should_change = true
+  end
+
+  local t = {a = 1, a = side_effect(), a = 3}
+
+  assert(should_change == true)
+  assert(t.a == 3)
+end
+
 return "OK"

--- a/tools/lldb_formatters.lldb
+++ b/tools/lldb_formatters.lldb
@@ -26,7 +26,9 @@ type summary add -x "^TString$" -F lldb_formatters.luau_tstring_summary
 type summary add -x "^TKey$" -F lldb_formatters.luau_tkey_summary
 
 type summary add --expand -x "^TValue$" -F lldb_formatters.luau_tvalue_summary
-type synthetic add --expand -x "^TValue$" -l lldb_formatters.TValueSyntheticChildrenProvider
+type synthetic add -x "^TValue$" -l lldb_formatters.TValueSyntheticChildrenProvider
+type summary add --expand -x "^lua_TValue$" -F lldb_formatters.luau_tvalue_summary
+type synthetic add -x "^lua_TValue$" -l lldb_formatters.TValueSyntheticChildrenProvider
 
 type summary add --expand -x "^LuaTable$" -F lldb_formatters.luau_table_summary
 type synthetic add -x "^LuaTable$" -l lldb_formatters.LuauTableSyntheticChildrenProvider
@@ -36,3 +38,5 @@ type summary add --expand -x "^CallInfo$" -F lldb_formatters.luau_callinfo_summa
 type summary add -x "^Luau::TryPair<.+>$" --summary-string "(${var.first%T}, ${var.second%T})"
 type summary add -x "^LuaNode$" --summary-string "[${var.key}] = ${var.val}"
 
+type summary add --expand -x "^Proto$" -F lldb_formatters.luau_proto_summary
+type synthetic add -x "^Proto$" -l lldb_formatters.ProtoSyntheticChildrenProvider

--- a/tools/lldb_formatters.py
+++ b/tools/lldb_formatters.py
@@ -544,6 +544,17 @@ def luau_table_summary(valobj, internal_dict):
     result = f"LuaTable (size={len(array_entries) + len(hash_entries)})"
     return result
 
+def convert_ptr_size_to_array(name, ptr, num_elem):
+    """Converts a SBValue ptr into an array using the name and number of elements provided
+       num_elems may be a number of an SBValue with a numeric value. 
+    """
+    if isinstance(num_elem, lldb.SBValue):
+        if num_elem.GetType().GetTypeFlags() & lldb.eTypeIsSigned:
+            num_elem = num_elem.GetValueAsSigned()
+        else:
+            num_elem = num_elem.GetValueAsUnsigned()
+    return ptr.CreateValueFromAddress(name, int(ptr.GetValueAsAddress()), ptr.GetType().GetPointeeType().GetArrayType(num_elem))
+
 def read_from_pointer_to_array(ptr, index):
     """ Reads a single element from a pointer to an array. This function is useful because lldb only allows reading
         the 0'th element using GetChildAtIndex for a pointer type.
@@ -551,7 +562,7 @@ def read_from_pointer_to_array(ptr, index):
         ptr should be a SBValue that is a pointer
         index is the index of the array element to read (starting from 0)
     """
-    array = ptr.CreateValueFromAddress("ar", int(ptr.GetValueAsAddress()), ptr.GetType().GetPointeeType().GetArrayType(index+1))
+    array = convert_ptr_size_to_array('ar', ptr, index+1)
     return array.GetChildAtIndex(index)
 
 def remove_outer_quotes(s):
@@ -580,3 +591,77 @@ def luau_callinfo_summary(valobj, internal_dict):
         f = c.GetChildMemberWithName("f")
         debugname = c.GetChildMemberWithName("debugname")
         return f"=[C] function {remove_outer_quotes(debugname.GetSummary())} {f.GetSummary()}"
+
+def luau_proto_summary(valobj, internal_dict):
+    if valobj.GetType().IsPointerType():
+        valobj = valobj.Dereference()
+    valobj = valobj.GetNonSyntheticValue()
+    source = valobj.GetChildMemberWithName("source")
+    debugname = valobj.GetChildMemberWithName("debugname")
+    linedefined = valobj.GetChildMemberWithName("linedefined").GetValueAsUnsigned()
+    numparams = valobj.GetChildMemberWithName("numparams").GetValueAsUnsigned()
+    nups = valobj.GetChildMemberWithName("nups").GetValueAsUnsigned()
+    return f'{remove_outer_quotes(source.GetSummary())}:{linedefined} {"function " + remove_outer_quotes(debugname.GetSummary()) if debugname.GetValueAsUnsigned() != 0 else ""} [{numparams} arg, {nups} upval]'
+
+class ProtoSyntheticChildrenProvider:
+    def __init__(self, valobj, internal_dict):
+        if valobj.GetType().IsPointerType():
+           valobj = valobj.Dereference()
+        valobj = valobj.GetNonSyntheticValue()
+        
+        self.valobj = valobj
+
+    def num_children(self):
+        return len(self.children)
+
+    def has_children(self):
+        return len(self.children) > 0
+
+    def get_child_at_index(self, index):
+        if index < len(self.children):
+            return self.children[index]
+        return None
+
+    def update(self):
+        children = []
+        self.children = children
+        valobj = self.valobj
+
+        k = valobj.GetChildMemberWithName("k")
+        sizek = valobj.GetChildMemberWithName("sizek")
+        constants_array = convert_ptr_size_to_array("[constants]", k, sizek)
+        children.append(constants_array)
+
+        locvars = valobj.GetChildMemberWithName("locvars")
+        sizelocvars = valobj.GetChildMemberWithName("sizelocvars")
+        locvars_array = convert_ptr_size_to_array("[locvars]", locvars, sizelocvars)
+        children.append(locvars_array)
+
+        sizecode = valobj.GetChildMemberWithName("sizecode")
+        code = valobj.GetChildMemberWithName("code")
+        code_array = convert_ptr_size_to_array("[bytecode]", code, sizecode)
+        children.append(code_array)
+
+        sizep = valobj.GetChildMemberWithName("sizep")
+        p = valobj.GetChildMemberWithName("p")
+        p_array = convert_ptr_size_to_array("[functions]", p, sizep)
+        children.append(p_array)
+
+        sizeupvalues = valobj.GetChildMemberWithName("sizeupvalues")
+        upvalues = valobj.GetChildMemberWithName("upvalues")
+        upvalues_array = convert_ptr_size_to_array("[upvalues]", upvalues, sizeupvalues)
+        children.append(upvalues_array)
+
+        children.append(self.valobj.GetChildMemberWithName("source"))
+        return False
+
+
+# Note for future work:
+# LLDB is limited in terms of expansion. i.e. a child provider can expand to a set
+# of children, but it can't directly express how those children can be expanded further.
+# To acheive this functionality for special situations (e.g. showing callstacks in reverse
+# order) it may be necessary to create types that are only used for debugging purposes which
+# an then define how their children are expanded.
+#
+# Here's an example of how EvaluateExpression can be used to create such a type on the fly:
+# e = lldb.target.EvaluateExpression("struct DebuggerOnlyType{int a; float b;}; (DebuggerOnlyType*)0;")


### PR DESCRIPTION
Another week, another release! Happy spring! 🌷

### Analysis
- Remove an incorrect assertion triggered when we fail to bind a generic pack.
- Various miscellaneous fixes for bugs found by the fuzzer.

### Runtime
- Fix `DUPTABLE` constant packing not respecting side-effects.
- NCG: fix removal of stores that are still needed in VM exits.
- NCG: fix a bug that caused buffer access ranges to be computed incorrectly.
- Fix #2293.

### Miscellaneous
- Various `Makefile` improvements.
- Add lldb providers for `Proto`.
- Add new `--dump-constants` flag to `luau-compile`.

---

Co-authored-by: Andy Friesen <afriesen@roblox.com>
Co-authored-by: Ariel Weiss <arielweiss@roblox.com>
Co-authored-by: David Cope <dcope@roblox.com>
Co-authored-by: Hunter Goldstein <hgoldstein@roblox.com>
Co-authored-by: Sora Kanosue <skanosue@roblox.com>
Co-authored-by: Thomas Schollenberger <tschollenberger@roblox.com>
Co-authored-by: Vyacheslav Egorov <vegorov@roblox.com>