### PR TITLE
Fix string.gsub type def in BuiltinDefinitions.cpp

### DIFF
--- a/Analysis/src/BuiltinDefinitions.cpp
+++ b/Analysis/src/BuiltinDefinitions.cpp
@@ -1212,7 +1212,7 @@ TypeId makeStringMetatable(NotNull<BuiltinTypes> builtinTypes, SolverMode mode)
         UnionType{
             {stringType,
              arena->addType(TableType({}, TableIndexer(stringType, stringType), TypeLevel{}, TableState::Generic)),
-             makeFunction(*arena, std::nullopt, {}, {}, {stringType}, {}, {stringType}, /* checked */ false)}
+             arena->addType(FunctionType{stringVariadicList, oneStringPack})}
         }
     );
     const TypeId gsubFunc =


### PR DESCRIPTION
Fix string.gsub replacement function type definition to be (...string) -> (string) instead of (string) -> (string)
https://github.com/luau-lang/luau/issues/2343